### PR TITLE
Show "Discography" and "Top tracks"  for all providers

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.get
 import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.pages.assertNoItems
 import io.music_assistant.client.support.rules.createTestRuleChain
@@ -41,6 +42,18 @@ class ArtistTest {
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(album)
+    }
+
+    @Test
+    fun `can view all artist albums`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val album = ServerMediaItemFixtures.album(artist = artist)
+        serviceClient.addItems(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .clickViewAll(Res.string.artist_section_all.get())
             .assertMediaDisplayed(album)
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -16,6 +16,7 @@ import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.artist_section_all
+import musicassistantclient.composeapp.generated.resources.artist_section_in_library
 import musicassistantclient.composeapp.generated.resources.artist_section_top
 import org.junit.Rule
 import org.junit.Test
@@ -97,6 +98,19 @@ class ArtistTest {
             .assertMediaDisplayed(libraryAlbum, provider = ServerMediaItem.LIBRARY_PROVIDER)
             .assertMediaDisplayed(libraryAlbum)
             .assertMediaDisplayed(nonLibraryAlbum)
+    }
+
+    @Test
+    fun `can view all library albums`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val album = ServerMediaItemFixtures.album(artist = artist)
+        serviceClient.addItems(album)
+        serviceClient.addToLibrary(album)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .clickViewAll(Res.string.artist_section_in_library.get())
+            .assertMediaDisplayed(album, provider = ServerMediaItem.LIBRARY_PROVIDER)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
+import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import org.junit.Rule
@@ -54,7 +55,7 @@ class ArtistTest {
     }
 
     @Test
-    fun `shows albums for all providers when artists are matched across providers`() {
+    fun `can switch providers to see albums from them when artists are matched across providers`() {
         val provider1 = ServerMediaItemFixtures.provider(domain = "domain1", instance = "instance1")
         val provider2 = ServerMediaItemFixtures.provider(domain = "domain2", instance = "instance2")
         val artist1 = ServerMediaItemFixtures.artist(provider = provider1)
@@ -69,6 +70,9 @@ class ArtistTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
             .assertMediaDisplayed(album1, provider = provider1.first)
+            .assertMediaNotDisplayed(album2, provider = provider2.first)
+            .switchProvider(provider1.first, provider2.first)
+            .assertMediaNotDisplayed(album1, provider = provider1.first)
             .assertMediaDisplayed(album2, provider = provider2.first)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -30,7 +30,7 @@ class ArtistTest {
     private val serviceClient: FakeServiceClient by inject(ServiceClient::class.java)
 
     @Test
-    fun `show artist albums`() {
+    fun `shows artist albums`() {
         val artist = ServerMediaItemFixtures.artist()
         val album = ServerMediaItemFixtures.album(artist = artist)
         serviceClient.addItems(album)
@@ -38,6 +38,20 @@ class ArtistTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
             .assertMediaDisplayed(album)
+    }
+
+    @Test
+    fun `shows artist top tracks`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val track1 = ServerMediaItemFixtures.track(artists = listOf(artist))
+        val track2 = ServerMediaItemFixtures.track(artists = listOf(artist))
+        serviceClient.addItems(track1, track2)
+        serviceClient.setTopTracks(artist, track2)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(track2)
+            .assertMediaNotDisplayed(track1)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -72,6 +72,19 @@ class ArtistTest {
     }
 
     @Test
+    fun `can view all artist top tracks`() {
+        val artist = ServerMediaItemFixtures.artist()
+        val track = ServerMediaItemFixtures.track(artists = listOf(artist))
+        serviceClient.addItems(track)
+        serviceClient.setTopTracks(artist, track)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .clickViewAll(Res.string.artist_section_top.get())
+            .assertMediaDisplayed(track)
+    }
+
+    @Test
     fun `shows in library and all artist albums on provider`() {
         val artist = ServerMediaItemFixtures.artist()
         val libraryAlbum = ServerMediaItemFixtures.album(artist = artist)

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.assertMediaNotDisplayed
+import io.music_assistant.client.support.pages.assertNoItems
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import org.junit.Rule
@@ -74,5 +75,15 @@ class ArtistTest {
             .switchProvider(provider1.domain, provider2.domain)
             .assertMediaNotDisplayed(album1, provider = provider1.domain)
             .assertMediaDisplayed(album2, provider = provider2.domain)
+    }
+
+    @Test
+    fun `shows empty message when there are no items for the artist`() {
+        val artist = ServerMediaItemFixtures.artist()
+        serviceClient.addItems(artist)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertNoItems()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -54,12 +54,8 @@ class ArtistTest {
             .assertMediaDisplayed(nonLibraryAlbum)
     }
 
-    /**
-     * This is not the ideal behavior - we should show albums from all providers in someway. This
-     * will be fixed by https://github.com/music-assistant/mobile-app/issues/801.
-     */
     @Test
-    fun `shows albums for one provider when artists are matched across providers`() {
+    fun `shows albums for all providers when artists are matched across providers`() {
         val provider1 = ServerMediaItemFixtures.provider(domain = "domain1", instance = "instance1")
         val provider2 = ServerMediaItemFixtures.provider(domain = "domain2", instance = "instance2")
         val artist1 = ServerMediaItemFixtures.artist(provider = provider1)
@@ -74,6 +70,6 @@ class ArtistTest {
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
             .assertMediaDisplayed(album1, provider = provider1.first)
-            .assertMediaNotDisplayed(album2, provider = provider2.first)
+            .assertMediaDisplayed(album2, provider = provider2.first)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -7,11 +7,14 @@ import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
+import io.music_assistant.client.support.get
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.pages.assertNoItems
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.artist_section_all
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,7 +89,7 @@ class ArtistTest {
             .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
             .assertMediaDisplayed(album1, provider = provider1.domain)
             .assertMediaNotDisplayed(album2, provider = provider2.domain)
-            .switchProvider(provider1.domain, provider2.domain)
+            .switchProvider(Res.string.artist_section_all.get(), provider1.domain, provider2.domain)
             .assertMediaNotDisplayed(album1, provider = provider1.domain)
             .assertMediaDisplayed(album2, provider = provider2.domain)
     }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -11,7 +11,6 @@ import io.music_assistant.client.support.get
 import io.music_assistant.client.support.launchLoggedInApp
 import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.pages.assertMediaNotDisplayed
-import io.music_assistant.client.support.pages.assertNoItems
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
@@ -157,15 +156,5 @@ class ArtistTest {
             .switchProvider(Res.string.artist_section_top.get(), provider1.domain, provider2.domain)
             .assertMediaNotDisplayed(track1, provider = provider1.domain)
             .assertMediaDisplayed(track2, provider = provider2.domain)
-    }
-
-    @Test
-    fun `shows empty message when there are no items for the artist`() {
-        val artist = ServerMediaItemFixtures.artist()
-        serviceClient.addItems(artist)
-
-        launchLoggedInApp(composeTestRule, serviceClient)
-            .clickOnMedia(artist, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
-            .assertNoItems()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -69,10 +69,10 @@ class ArtistTest {
 
         launchLoggedInApp(composeTestRule, serviceClient)
             .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
-            .assertMediaDisplayed(album1, provider = provider1.first)
-            .assertMediaNotDisplayed(album2, provider = provider2.first)
-            .switchProvider(provider1.first, provider2.first)
-            .assertMediaNotDisplayed(album1, provider = provider1.first)
-            .assertMediaDisplayed(album2, provider = provider2.first)
+            .assertMediaDisplayed(album1, provider = provider1.domain)
+            .assertMediaNotDisplayed(album2, provider = provider2.domain)
+            .switchProvider(provider1.domain, provider2.domain)
+            .assertMediaNotDisplayed(album1, provider = provider1.domain)
+            .assertMediaDisplayed(album2, provider = provider2.domain)
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -15,6 +15,7 @@ import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.artist_section_all
+import musicassistantclient.composeapp.generated.resources.artist_section_top
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -92,6 +93,30 @@ class ArtistTest {
             .switchProvider(Res.string.artist_section_all.get(), provider1.domain, provider2.domain)
             .assertMediaNotDisplayed(album1, provider = provider1.domain)
             .assertMediaDisplayed(album2, provider = provider2.domain)
+    }
+
+    @Test
+    fun `can switch providers to see top tracks from them when artists are matched across providers`() {
+        val provider1 = ServerMediaItemFixtures.provider(domain = "domain1", instance = "instance1")
+        val provider2 = ServerMediaItemFixtures.provider(domain = "domain2", instance = "instance2")
+        val artist1 = ServerMediaItemFixtures.artist(provider = provider1)
+        val artist2 = ServerMediaItemFixtures.artist(provider = provider2)
+        val track1 = ServerMediaItemFixtures.track(artists = listOf(artist1), provider = provider1)
+        val track2 = ServerMediaItemFixtures.track(artists = listOf(artist2), provider = provider2)
+
+        serviceClient.addItems(track1, track2)
+        serviceClient.setTopTracks(artist1, track1)
+        serviceClient.setTopTracks(artist2, track2)
+        serviceClient.addToLibrary(artist1)
+        serviceClient.matchItem(artist1, artist2)
+
+        launchLoggedInApp(composeTestRule, serviceClient)
+            .clickOnMedia(artist1, withinTag = HomeScreenSemantics.rowTag("recently_added_artists"))
+            .assertMediaDisplayed(track1, provider = provider1.domain)
+            .assertMediaNotDisplayed(track2, provider = provider2.domain)
+            .switchProvider(Res.string.artist_section_top.get(), provider1.domain, provider2.domain)
+            .assertMediaNotDisplayed(track1, provider = provider1.domain)
+            .assertMediaDisplayed(track2, provider = provider2.domain)
     }
 
     @Test

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/ArtistTest.kt
@@ -8,7 +8,6 @@ import io.music_assistant.client.support.FakeServiceClient
 import io.music_assistant.client.support.Qualifiers
 import io.music_assistant.client.support.ServerMediaItemFixtures
 import io.music_assistant.client.support.launchLoggedInApp
-import io.music_assistant.client.support.pages.assertMediaNotDisplayed
 import io.music_assistant.client.support.rules.createTestRuleChain
 import io.music_assistant.client.ui.compose.home.HomeScreenSemantics
 import org.junit.Rule

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/LibraryTest.kt
@@ -12,6 +12,7 @@ import io.music_assistant.client.support.pages.ItemPage
 import io.music_assistant.client.support.pages.LibraryPage
 import io.music_assistant.client.support.pages.assertMediaDisplayed
 import io.music_assistant.client.support.pages.assertMediaNotDisplayed
+import io.music_assistant.client.support.pages.assertNoItems
 import io.music_assistant.client.support.pages.clickHome
 import io.music_assistant.client.support.pages.clickLibrary
 import io.music_assistant.client.support.pages.enableFilter

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeMediaItemStore.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeMediaItemStore.kt
@@ -9,6 +9,7 @@ internal class FakeMediaItemStore {
     private val mediaItems = mutableSetOf<ServerMediaItem>()
     private val libraryIds = mutableMapOf<Pair<String, String>, String>()
     private val playlistItems = mutableMapOf<String, List<String>>()
+    private val topTracks = mutableMapOf<Pair<String, String>, List<String>>()
 
     fun query(
         query: String? = null,
@@ -55,6 +56,13 @@ internal class FakeMediaItemStore {
         return mediaItems
             .filter { it.mediaType == MediaType.TRACK.serverValue }
             .filter { playlistItems[playlist.itemId]?.contains(it.itemId) ?: false }
+    }
+
+    fun getTracksByArtist(artist: ServerMediaItem, topOnly: Boolean = false): List<ServerMediaItem> {
+        return mediaItems
+            .filter { it.mediaType == MediaType.TRACK.serverValue }
+            .filter { it.artists?.contains(artist) ?: false }
+            .filter { !topOnly || topTracks[artist.globalId()]?.contains(it.itemId) ?: false }
     }
 
     fun addItems(vararg items: ServerMediaItem) {
@@ -110,6 +118,10 @@ internal class FakeMediaItemStore {
 
     fun setPlaylist(playlist: ServerMediaItem, vararg tracks: ServerMediaItem) {
         playlistItems[playlist.itemId] = tracks.map { it.itemId }
+    }
+
+    fun setTopTracks(artist: ServerMediaItem, vararg tracks: ServerMediaItem) {
+        topTracks[artist.globalId()] = tracks.map { it.itemId }
     }
 
     fun enrichLibraryItem(item: ServerMediaItem): ServerMediaItem {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -741,8 +741,8 @@ class FakeServiceClient : ServiceClient {
         mediaItemStore.setPlaylist(playlist, *tracks)
     }
 
-    fun setRequestErrors(reachable: Boolean) {
-        this.requestErrors = reachable
+    fun setRequestErrors(requestError: Boolean) {
+        this.requestErrors = requestError
     }
 
     fun setLegacyVersion(version: LegacyVersion) {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/FakeServiceClient.kt
@@ -472,6 +472,18 @@ class FakeServiceClient : ServiceClient {
                 Result.success(Answer(JsonObject(emptyMap())))
             }
 
+            APICommands.MUSIC_ARTISTS_TOP_TRACKS -> {
+                val artist = findItem(request)
+                val tracks = mediaItemStore.getTracksByArtist(artist, topOnly = true)
+
+                Result.success(
+                    answer(
+                        request = request,
+                        result = tracks,
+                    ),
+                )
+            }
+
             else -> {
                 Result.failure(UnsupportedOperationException())
             }
@@ -739,6 +751,10 @@ class FakeServiceClient : ServiceClient {
 
     fun setPlaylist(playlist: ServerMediaItem, vararg tracks: ServerMediaItem) {
         mediaItemStore.setPlaylist(playlist, *tracks)
+    }
+
+    fun setTopTracks(artist: ServerMediaItem, vararg tracks: ServerMediaItem) {
+        mediaItemStore.setTopTracks(artist, *tracks)
     }
 
     fun setRequestErrors(requestError: Boolean) {

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
@@ -59,6 +59,7 @@ object ServerMediaItemFixtures {
         name: String = "Track $itemId",
         album: ServerMediaItem? = album(),
         artists: List<ServerMediaItem>? = album?.artists ?: listOf(artist()),
+        provider: Provider = Provider(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
@@ -72,8 +73,8 @@ object ServerMediaItemFixtures {
             providerMappings = listOf(
                 ProviderMapping(
                     itemId = itemId,
-                    providerDomain = DEFAULT_PROVIDER_DOMAIN,
-                    providerInstance = DEFAULT_PROVIDER_INSTANCE,
+                    providerDomain = provider.domain,
+                    providerInstance = provider.instance,
                 ),
             ),
         )

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/ServerMediaItemFixtures.kt
@@ -13,11 +13,11 @@ object ServerMediaItemFixtures {
         name: String = "Album $itemId",
         artist: ServerMediaItem = artist(),
         favorite: Boolean? = null,
-        provider: Pair<String, String> = Pair(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
+        provider: Provider = Provider(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = provider.first,
+            provider = provider.domain,
             name = name,
             mediaType = MediaType.ALBUM.serverValue,
             artists = listOf(artist),
@@ -27,8 +27,8 @@ object ServerMediaItemFixtures {
             providerMappings = listOf(
                 ProviderMapping(
                     itemId = itemId,
-                    providerDomain = provider.first,
-                    providerInstance = provider.second,
+                    providerDomain = provider.domain,
+                    providerInstance = provider.instance,
                 ),
             ),
         )
@@ -37,18 +37,18 @@ object ServerMediaItemFixtures {
     fun artist(
         itemId: String = uniqueIdGenerator.nextInt().toString(),
         name: String = "Artist $itemId",
-        provider: Pair<String, String> = Pair(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
+        provider: Provider = Provider(DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
     ): ServerMediaItem {
         return ServerMediaItem(
             itemId = itemId,
-            provider = provider.first,
+            provider = provider.domain,
             name = name,
             mediaType = MediaType.ARTIST.serverValue,
             providerMappings = listOf(
                 ProviderMapping(
                     itemId = itemId,
-                    providerDomain = provider.first,
-                    providerInstance = provider.second,
+                    providerDomain = provider.domain,
+                    providerInstance = provider.instance,
                 ),
             ),
         )
@@ -182,10 +182,12 @@ object ServerMediaItemFixtures {
     fun provider(
         domain: String = DEFAULT_PROVIDER_DOMAIN,
         instance: String = DEFAULT_PROVIDER_INSTANCE,
-    ): Pair<String, String> {
-        return Pair(domain, instance)
+    ): Provider {
+        return Provider(domain, instance)
     }
 
     private const val DEFAULT_PROVIDER_DOMAIN = "test-domain"
     private const val DEFAULT_PROVIDER_INSTANCE = "test-instance"
+
+    data class Provider(val domain: String, val instance: String)
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemListPage.kt
@@ -1,0 +1,29 @@
+package io.music_assistant.client.support.pages
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import io.music_assistant.client.support.get
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.nav_home
+import musicassistantclient.composeapp.generated.resources.nav_library
+import musicassistantclient.composeapp.generated.resources.nav_search
+import musicassistantclient.composeapp.generated.resources.nav_settings
+
+open class ItemListPage(private val title: String, private val navigationItem: String, composeTestRule: ComposeTestRule) : ComposePage(
+    composeTestRule,
+) {
+    override fun assert() {
+        composeTestRule.onAllNodesWithText(title).onFirst().assertIsDisplayed()
+        assertNavBar(
+            items = listOf(
+                Res.string.nav_home.get(),
+                Res.string.nav_library.get(),
+                Res.string.nav_search.get(),
+                Res.string.nav_settings.get(),
+            ),
+            selected = navigationItem,
+        )
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -3,7 +3,10 @@ package io.music_assistant.client.support.pages
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -17,6 +20,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_go_to_artist
 import musicassistantclient.composeapp.generated.resources.action_play_now
 import musicassistantclient.composeapp.generated.resources.cd_more
+import musicassistantclient.composeapp.generated.resources.cd_provider_filter
 import musicassistantclient.composeapp.generated.resources.media_type_albums
 import musicassistantclient.composeapp.generated.resources.media_type_tracks
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -98,9 +102,11 @@ class ItemPage(
         return this
     }
 
-    fun switchProvider(current: String, new: String): ItemPage {
-        composeTestRule.onNodeWithText(current).performClick()
-        composeTestRule.onNodeWithText(new).performClick()
+    fun switchProvider(row: String, current: String, new: String): ItemPage {
+        composeTestRule
+            .onNodeWithContentDescription(Res.string.cd_provider_filter.get(row, current))
+            .performClick()
+        composeTestRule.onNode(hasAnyAncestor(isPopup()).and(hasText(new))).performClick()
         return this
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -56,13 +56,7 @@ class ItemPage(
         )
 
         when (type) {
-            MediaType.ARTIST -> {
-                composeTestRule.onNode(isTab(Res.string.media_type_albums.get()))
-                    .assertIsDisplayed()
-                composeTestRule.onNode(isTab(Res.string.media_type_tracks.get()))
-                    .assertIsDisplayed()
-            }
-
+            MediaType.ARTIST -> Unit
             MediaType.ALBUM -> {
                 composeTestRule.onNode(isTab(Res.string.media_type_tracks.get()))
                     .assertIsDisplayed()

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -21,6 +21,7 @@ import musicassistantclient.composeapp.generated.resources.action_go_to_artist
 import musicassistantclient.composeapp.generated.resources.action_play_now
 import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.cd_provider_filter
+import musicassistantclient.composeapp.generated.resources.cd_view_all
 import musicassistantclient.composeapp.generated.resources.media_type_albums
 import musicassistantclient.composeapp.generated.resources.media_type_tracks
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -116,5 +117,12 @@ class ItemPage(
             inScrollable = ItemDetailsScreenSemantics.LIST_TAG,
             provider = provider,
         )
+    }
+
+    fun clickViewAll(row: String): ItemListPage {
+        composeTestRule
+            .onNodeWithContentDescription(Res.string.cd_view_all.get(row))
+            .performClick()
+        return ItemListPage(row, navigationItem, composeTestRule).assertOnPage()
     }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/ItemPage.kt
@@ -104,6 +104,12 @@ class ItemPage(
         return this
     }
 
+    fun switchProvider(current: String, new: String): ItemPage {
+        composeTestRule.onNodeWithText(current).performClick()
+        composeTestRule.onNodeWithText(new).performClick()
+        return this
+    }
+
     fun assertMediaDisplayed(item: ServerMediaItem, provider: String? = null): ItemPage {
         return assertMediaDisplayed(
             item,

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.test.performTextInput
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.support.get
 import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.library_quick_search
 import musicassistantclient.composeapp.generated.resources.library_search_global
 import musicassistantclient.composeapp.generated.resources.nav_home
@@ -57,11 +56,6 @@ class LibraryListPage(private val type: String, composeTestRule: ComposeTestRule
     fun openSearch(): LibraryListPage {
         composeTestRule.onNodeWithContentDescription(Res.string.library_quick_search.get())
             .performClick()
-        return this
-    }
-
-    fun assertNoItems(): LibraryListPage {
-        composeTestRule.onNodeWithText(Res.string.library_empty.get()).assertIsDisplayed()
         return this
     }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/LibraryListPage.kt
@@ -2,8 +2,6 @@ package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -14,27 +12,11 @@ import io.music_assistant.client.support.get
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.library_quick_search
 import musicassistantclient.composeapp.generated.resources.library_search_global
-import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
-import musicassistantclient.composeapp.generated.resources.nav_search
-import musicassistantclient.composeapp.generated.resources.nav_settings
 import musicassistantclient.composeapp.generated.resources.search_query_label
 
-class LibraryListPage(private val type: String, composeTestRule: ComposeTestRule) :
-    ComposePage(composeTestRule) {
-    override fun assert() {
-        composeTestRule.onAllNodesWithText(type).onFirst().assertIsDisplayed()
-        assertNavBar(
-            items = listOf(
-                Res.string.nav_home.get(),
-                Res.string.nav_library.get(),
-                Res.string.nav_search.get(),
-                Res.string.nav_settings.get(),
-            ),
-            selected = Res.string.nav_library.get(),
-        )
-    }
-
+class LibraryListPage(type: String, composeTestRule: ComposeTestRule) :
+    ItemListPage(type, Res.string.nav_library.get(), composeTestRule) {
     fun clickOnMedia(item: ServerMediaItem): ItemPage {
         return clickOnMedia(
             item,

--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/SharedActions.kt
@@ -31,6 +31,7 @@ import musicassistantclient.composeapp.generated.resources.cd_current_player
 import musicassistantclient.composeapp.generated.resources.cd_filter
 import musicassistantclient.composeapp.generated.resources.cd_playing
 import musicassistantclient.composeapp.generated.resources.common_apply
+import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.nav_home
 import musicassistantclient.composeapp.generated.resources.nav_library
 import musicassistantclient.composeapp.generated.resources.nav_search
@@ -210,6 +211,11 @@ fun <T : ComposePage> T.enableFilter(action: (FilterSheetPage) -> Unit): T {
 
     composeTestRule.onNodeWithContentDescription(Res.string.cd_filter.get()).assertIsOn()
 
+    return this
+}
+
+fun <T : ComposePage> T.assertNoItems(): T {
+    composeTestRule.onNodeWithText(Res.string.library_empty.get()).assertIsDisplayed()
     return this
 }
 

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRowTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRowTest.kt
@@ -1,0 +1,92 @@
+package io.music_assistant.client.ui.compose.common.items
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Playlist
+import io.music_assistant.client.ui.compose.common.toDisplayString
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CategoryRowTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `is not visible if ItemCategory items is empty`() {
+        val itemCategory = ItemCategory<Nothing>(
+            id = "blah",
+            title = "title".toDisplayString(),
+            items = emptyList(),
+        )
+
+        composeTestRule.setContent {
+            CategoryRow(
+                itemCategory = itemCategory,
+                onNavigateClick = {},
+                onPlayClick = { _, _, _, _ -> },
+                playlistActions = StubPlaylistActions(),
+                libraryActions = StubLibraryActions(),
+                providerIconFetcher = { _, _ -> },
+            )
+        }
+
+        composeTestRule.onNodeWithText("title").assertIsNotDisplayed()
+    }
+
+    @Test
+    fun `is visible if ItemCategory items is empty and filter is not null`() {
+        val itemCategory = ItemCategory(
+            id = "blah",
+            title = "title".toDisplayString(),
+            items = emptyList(),
+            filter = ItemCategory.Filter(
+                label = "filter".toDisplayString(),
+                options = listOf("option"),
+                labelTransform = { it.toDisplayString() },
+            ),
+        )
+
+        composeTestRule.setContent {
+            CategoryRow(
+                itemCategory = itemCategory,
+                onNavigateClick = {},
+                onPlayClick = { _, _, _, _ -> },
+                playlistActions = StubPlaylistActions(),
+                libraryActions = StubLibraryActions(),
+                providerIconFetcher = { _, _ -> },
+            )
+        }
+
+        composeTestRule.onNodeWithText("title").assertIsDisplayed()
+    }
+}
+
+private class StubPlaylistActions : PlaylistActions {
+    override suspend fun getEditablePlaylists(): List<Playlist> {
+        TODO("Not yet implemented")
+    }
+
+    override fun addToPlaylist(itemUri: String?, playlist: Playlist) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun createPlaylist(name: String): Playlist? {
+        TODO("Not yet implemented")
+    }
+}
+
+private class StubLibraryActions : LibraryActions {
+    override fun onLibraryClick(item: AppMediaItem) {
+        TODO("Not yet implemented")
+    }
+
+    override fun onFavoriteClick(item: AppMediaItem) {
+        TODO("Not yet implemented")
+    }
+}

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -69,7 +69,6 @@ class ItemDetailsTest {
                     playableItemsState = DataState.NoData(),
                     // An artist's albums now live in the Library/Top/All sub-sections, not albumsState.
                     artistAlbumSections = ArtistSections(all = DataState.Data(albums)),
-                    artistTrackSections = ArtistSections(),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
                 fetchColors = NoColors,

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -67,8 +67,7 @@ class ItemDetailsTest {
                     itemState = DataState.Data(artist),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.NoData(),
-                    // An artist's albums now live in the Library/Top/All sub-sections, not albumsState.
-                    artistAlbumSections = ArtistSections(all = DataState.Data(albums)),
+                    artistAlbumSections = ArtistSections(library = DataState.Data(albums)),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
                 fetchColors = NoColors,

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -67,7 +67,7 @@ class ItemDetailsTest {
                     itemState = DataState.Data(artist),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.NoData(),
-                    artistSections = ArtistSections(library = DataState.Data(albums)),
+                    artistSections = ArtistSections(library = DataState.Data(Section(albums))),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
                 fetchColors = NoColors,

--- a/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTest.kt
@@ -67,7 +67,7 @@ class ItemDetailsTest {
                     itemState = DataState.Data(artist),
                     albumsState = DataState.NoData(),
                     playableItemsState = DataState.NoData(),
-                    artistAlbumSections = ArtistSections(library = DataState.Data(albums)),
+                    artistSections = ArtistSections(library = DataState.Data(albums)),
                 ),
                 geEditablePlaylists = suspend { emptyList() },
                 fetchColors = NoColors,

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -45,7 +45,7 @@
   <string name="all_podcasts">All podcasts</string>
   <string name="all_radio">All radio stations</string>
   <string name="all_tracks">All tracks</string>
-  <string name="artist_section_all">All</string>
+  <string name="artist_section_all">Discography</string>
   <string name="artist_section_in_library">In library</string>
   <string name="artist_section_top">Top tracks</string>
   <string name="auth_authenticating">Authenticating…</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -102,6 +102,7 @@
   <string name="cd_unmute">Unmute</string>
   <string name="cd_vinyl_record">Vinyl Record</string>
   <string name="cd_album_item">Album "%1$s" from %2$s</string>
+  <string name="cd_provider_filter">Filtering %1$s by provider %2$s</string>
   <string name="clickctx_album">Album</string>
   <string name="clickctx_artist">Artist</string>
   <string name="clickctx_browse">Browse</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -103,6 +103,7 @@
   <string name="cd_vinyl_record">Vinyl Record</string>
   <string name="cd_album_item">Album "%1$s" from %2$s</string>
   <string name="cd_provider_filter">Filtering %1$s by provider %2$s</string>
+  <string name="cd_view_all">View all %1$s</string>
   <string name="clickctx_album">Album</string>
   <string name="clickctx_artist">Artist</string>
   <string name="clickctx_browse">Browse</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -47,7 +47,7 @@
   <string name="all_tracks">All tracks</string>
   <string name="artist_section_all">All</string>
   <string name="artist_section_in_library">In library</string>
-  <string name="artist_section_top">Top</string>
+  <string name="artist_section_top">Top tracks</string>
   <string name="auth_authenticating">Authenticating…</string>
   <string name="auth_authorize_ha">Authorize with Home Assistant</string>
   <string name="auth_hide_password">Hide password</string>

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerMediaItem.kt
@@ -107,9 +107,7 @@ data class ServerMediaItemImage(
 @Serializable
 data class ProviderMapping(
     @SerialName("item_id") val itemId: String,
-    // Required by the server when a media_item is sent back (e.g. music/mark_played),
-    // so it must be retained on parse to round-trip in provider_mappings.
-    @SerialName("provider_domain") val providerDomain: String? = null,
+    @SerialName("provider_domain") val providerDomain: String,
     @SerialName("provider_instance") val providerInstance: String,
 //    @SerialName("available") val available: Boolean,
 //    @SerialName("audio_format") val audioFormat: AudioFormat? = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
 
 /**
@@ -47,6 +48,18 @@ class MediaItemRepository(
                 ?.let(factory::createList)
                 ?: error("Missing or undecodable media list payload")
         }
+
+    suspend fun fetchMediaItems(request: Request, observer: (List<AppMediaItem>) -> Unit) {
+        val result = fetchMediaItems(request)
+        val items = result.getOrNull()
+
+        if (items != null) {
+            observer(items)
+            itemChanges
+                .scan(items) { items, change -> items.replacing(change.item) }
+                .collect { observer(it) }
+        }
+    }
 
     /**
      * Issue [request] and decode its payload as a single client media item.
@@ -117,3 +130,6 @@ class MediaItemRepository(
         )
     }
 }
+
+private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
+    map { if (it.itemId == changed.itemId) changed else it }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -33,8 +33,8 @@ import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
-import io.music_assistant.client.ui.compose.library.ItemListViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
+import io.music_assistant.client.ui.compose.library.LibraryListViewModel
 import io.music_assistant.client.ui.compose.search.SearchViewModel
 import io.music_assistant.client.ui.compose.settings.CarActionsViewModel
 import io.music_assistant.client.ui.compose.settings.CarDspViewModel
@@ -104,7 +104,7 @@ fun sharedModule(
             )
         }
         factory { LibraryCategoriesViewModel(get()) }
-        factory { params -> ItemListViewModel(params[0], get(), get(), get(), get()) }
+        factory { params -> LibraryListViewModel(params[0], get(), get(), get(), get()) }
         factory { params -> BrowseViewModel(params.getOrNull<String>(), get(), get(), get()) }
         factory { params ->
             ItemDetailsViewModel(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -32,6 +32,7 @@ import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
+import io.music_assistant.client.ui.compose.item.ItemListViewModel
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
 import io.music_assistant.client.ui.compose.library.LibraryListViewModel
@@ -117,6 +118,7 @@ fun sharedModule(
                 params[2],
             )
         }
+        factory { params -> ItemListViewModel(params[0], get()) }
         factory { DspSettingsViewModel(get()) }
         factory { HomeScreenViewModel(get(), get(), get(), get()) }
         factory { SearchViewModel(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DataState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/DataState.kt
@@ -30,3 +30,6 @@ enum class StaleReason {
     RECONNECTING,          // Auto-reconnect in progress (transient)
     PERSISTENT_ERROR,      // Max attempts exhausted (manual action needed)
 }
+
+inline fun <T> DataState<T>.mapData(transform: (T) -> T): DataState<T> =
+    if (this is DataState.Data) DataState.Data(transform(data)) else this

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -1,5 +1,11 @@
 package io.music_assistant.client.ui.compose.common.items
 
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -7,13 +13,18 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -23,11 +34,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
@@ -41,28 +54,12 @@ import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.DisplayString
+import io.music_assistant.client.ui.compose.common.toDisplayString
 import io.music_assistant.client.ui.compose.item.ItemList
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_view_all
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-
-data class ItemCategory<T>(
-    val id: String,
-    val title: DisplayString,
-    val items: List<AppMediaItem>,
-    val list: ItemList? = null,
-    val filter: Filter<T>? = null,
-    val lazyListKey: String = id,
-    val tag: String? = null,
-) {
-    data class Filter<T>(
-        val label: DisplayString,
-        val options: List<T>,
-        val labelTransform: (T) -> DisplayString,
-        val contentDescription: StringResource,
-    )
-}
 
 @Composable
 fun <T, U> CategoryRow(
@@ -88,6 +85,44 @@ fun <T, U> CategoryRow(
             libraryActions = libraryActions,
             progressActions = progressActions,
             providerIconFetcher = providerIconFetcher,
+        )
+    } else if (data is DataState.Loading) {
+        val placeholderWidth = 140.dp
+        val placeholderColor by rememberInfiniteTransition().animateColor(
+            initialValue = Color.Gray.copy(alpha = 0.1f),
+            targetValue = Color.Gray.copy(alpha = 0.3f),
+            animationSpec = infiniteRepeatable(
+                animation = tween(2000),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        )
+
+        RowWithTitle(
+            title = {
+                val height = with(LocalDensity.current) {
+                    LocalTextStyle.current.fontSize.toDp()
+                }
+
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(placeholderColor)
+                        .size(width = placeholderWidth, height = height),
+                )
+            },
+            actions = {},
+            row = {
+                repeat(PLACEHOLDER_ITEMS) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(placeholderColor)
+                                .size(width = placeholderWidth, height = 152.dp),
+                        )
+                    }
+                }
+            },
         )
     }
 }
@@ -151,9 +186,136 @@ fun CategoryRow(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     rowTag: String? = null,
 ) {
-    val rowListState = rememberLazyListState()
+    if (mediaItems.isEmpty()) {
+        return
+    }
 
-    Column {
+    val modifier = if (rowTag != null) {
+        Modifier.testTag(rowTag)
+    } else {
+        Modifier
+    }
+
+    // Recommendation rows are server-curated and can repeat canonical item
+    // Key by occurrence to avoid Compose's duplicate-key crash
+    val itemKeys = remember(mediaItems) { mediaItems.lazyListOccurrenceKeys() }
+
+    RowWithTitle(
+        modifier = modifier,
+        title = {
+            Text(title)
+        },
+        actions = actions,
+    ) {
+        itemsIndexed(
+            items = mediaItems,
+            key = { index, _ -> itemKeys[index] },
+            contentType = { _, item ->
+                when (item) {
+                    is Track -> "Track"
+                    is Artist -> "Artist"
+                    is Album -> "Album"
+                    is Playlist -> "Playlist"
+                    is Audiobook -> "Audiobook"
+                    is Podcast -> "Podcast"
+                    is PodcastEpisode -> "Episode"
+                    is RadioStation -> "RadioStation"
+                    is Genre -> "Genre"
+                    else -> "Unknown"
+                }
+            },
+        ) { _, item ->
+            when (item) {
+                is Artist -> ArtistWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Album -> AlbumWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Playlist -> PlaylistWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Podcast -> PodcastWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Track -> TrackWithMenu(
+                    item = item,
+                    onPlayOption = onPlayClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is PodcastEpisode -> PodcastEpisodeWithMenu(
+                    item = item,
+                    onPlayOption = onPlayClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    progressActions = progressActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Audiobook -> AudiobookWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    progressActions = progressActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is RadioStation -> RadioWithMenu(
+                    item = item,
+                    onPlayOption = onPlayClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                is Genre -> GenreWithMenu(
+                    item = item,
+                    onNavigateClick = onNavigateClick,
+                    onPlayOption = onPlayClick,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
+
+                else -> {}
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowWithTitle(
+    modifier: Modifier = Modifier,
+    title: @Composable () -> Unit,
+    actions: @Composable () -> Unit,
+    row: LazyListScope.() -> Unit,
+) {
+    Column(modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -161,135 +323,43 @@ fun CategoryRow(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            ProvideTextStyle(
+                value = MaterialTheme.typography.titleMedium,
+            ) {
+                title()
+            }
 
             Row {
                 actions()
             }
         }
 
-        val modifier = if (rowTag != null) {
-            Modifier.testTag(rowTag)
-        } else {
-            Modifier
-        }
-
-        // Recommendation rows are server-curated and can repeat canonical item
-        // Key by occurrence to avoid Compose's duplicate-key crash
-        val itemKeys = remember(mediaItems) { mediaItems.lazyListOccurrenceKeys() }
-
+        val rowListState = rememberLazyListState()
         LazyRow(
-            modifier = modifier,
             state = rowListState,
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            itemsIndexed(
-                items = mediaItems,
-                key = { index, _ -> itemKeys[index] },
-                contentType = { _, item ->
-                    when (item) {
-                        is Track -> "Track"
-                        is Artist -> "Artist"
-                        is Album -> "Album"
-                        is Playlist -> "Playlist"
-                        is Audiobook -> "Audiobook"
-                        is Podcast -> "Podcast"
-                        is PodcastEpisode -> "Episode"
-                        is RadioStation -> "RadioStation"
-                        is Genre -> "Genre"
-                        else -> "Unknown"
-                    }
-                },
-            ) { _, item ->
-                when (item) {
-                    is Artist -> ArtistWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Album -> AlbumWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Playlist -> PlaylistWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Podcast -> PodcastWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Track -> TrackWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is PodcastEpisode -> PodcastEpisodeWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        progressActions = progressActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Audiobook -> AudiobookWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        progressActions = progressActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is RadioStation -> RadioWithMenu(
-                        item = item,
-                        onPlayOption = onPlayClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    is Genre -> GenreWithMenu(
-                        item = item,
-                        onNavigateClick = onNavigateClick,
-                        onPlayOption = onPlayClick,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-
-                    else -> {}
-                }
-            }
+            row()
         }
     }
+}
+
+data class ItemCategory<T>(
+    val id: String,
+    val title: DisplayString,
+    val items: List<AppMediaItem>,
+    val list: ItemList? = null,
+    val filter: Filter<T>? = null,
+    val lazyListKey: String = id,
+    val tag: String? = null,
+) {
+    data class Filter<T>(
+        val label: DisplayString,
+        val options: List<T>,
+        val labelTransform: (T) -> DisplayString,
+        val contentDescription: StringResource,
+    )
 }
 
 @Composable
@@ -356,4 +426,120 @@ private fun <T> FilterSelector(
             }
         }
     }
+}
+
+private const val PLACEHOLDER_ITEMS = 10
+
+@Preview
+@Composable
+fun PreviewCategoryRowEmpty() {
+    CategoryRow(
+        title = "Category",
+        onNavigateClick = {},
+        onPlayClick = { _, _, _, _ -> },
+        mediaItems = emptyList(),
+        playlistActions = object : PlaylistActions {
+            override suspend fun getEditablePlaylists(): List<Playlist> {
+                TODO("Not yet implemented")
+            }
+
+            override fun addToPlaylist(itemUri: String?, playlist: Playlist) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun createPlaylist(name: String): Playlist? {
+                TODO("Not yet implemented")
+            }
+        },
+        libraryActions = object : LibraryActions {
+            override fun onLibraryClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+
+            override fun onFavoriteClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+        },
+        providerIconFetcher = { _, _ -> },
+    )
+}
+
+@Preview
+@Composable
+fun PreviewCategoryLoading() {
+    CategoryRow(
+        data = DataState.Loading<List<AppMediaItem>>(),
+        itemCategoryProvider = {
+            ItemCategory<Nothing>(
+                id = "blah",
+                title = "blah".toDisplayString(),
+                items = it,
+            )
+        },
+        onNavigateClick = {},
+        onPlayClick = { _, _, _, _ -> },
+        playlistActions = object : PlaylistActions {
+            override suspend fun getEditablePlaylists(): List<Playlist> {
+                TODO("Not yet implemented")
+            }
+
+            override fun addToPlaylist(itemUri: String?, playlist: Playlist) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun createPlaylist(name: String): Playlist? {
+                TODO("Not yet implemented")
+            }
+        },
+        libraryActions = object : LibraryActions {
+            override fun onLibraryClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+
+            override fun onFavoriteClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+        },
+        providerIconFetcher = { _, _ -> },
+    )
+}
+
+@Preview
+@Composable
+fun PreviewCategoryNoData() {
+    CategoryRow(
+        data = DataState.NoData<List<AppMediaItem>>(),
+        itemCategoryProvider = {
+            ItemCategory<Nothing>(
+                id = "blah",
+                title = "blah".toDisplayString(),
+                items = it,
+            )
+        },
+        onNavigateClick = {},
+        onPlayClick = { _, _, _, _ -> },
+        playlistActions = object : PlaylistActions {
+            override suspend fun getEditablePlaylists(): List<Playlist> {
+                TODO("Not yet implemented")
+            }
+
+            override fun addToPlaylist(itemUri: String?, playlist: Playlist) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun createPlaylist(name: String): Playlist? {
+                TODO("Not yet implemented")
+            }
+        },
+        libraryActions = object : LibraryActions {
+            override fun onLibraryClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+
+            override fun onFavoriteClick(item: AppMediaItem) {
+                TODO("Not yet implemented")
+            }
+        },
+        providerIconFetcher = { _, _ -> },
+    )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.ui.compose.common.items
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -9,13 +10,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -30,29 +40,64 @@ import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.ui.compose.common.DisplayString
+import io.music_assistant.client.ui.compose.item.ItemList
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.cd_view_all
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
 
-data class ItemCategory(
+data class ItemCategory<T>(
     val id: String,
     val title: DisplayString,
     val items: List<AppMediaItem>,
+    val list: ItemList? = null,
+    val filter: Filter<T>? = null,
     val lazyListKey: String = id,
     val tag: String? = null,
-)
+) {
+    data class Filter<T>(
+        val selected: Int,
+        val options: List<T>,
+        val labelTransform: (T) -> DisplayString,
+        val contentDescription: StringResource,
+    )
+}
 
 @Composable
-fun CategoryRow(
-    itemCategory: ItemCategory,
-    actions: @Composable () -> Unit = {},
+fun <T> CategoryRow(
+    itemCategory: ItemCategory<T>,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
+    onOptionSelected: (T) -> Unit = {},
     onPlayClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
     progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
 ) {
+    val title = itemCategory.title.string()
     CategoryRow(
-        title = itemCategory.title.string(),
-        actions = actions,
+        title = title,
+        actions = {
+            if (itemCategory.filter != null) {
+                FilterSelector(
+                    selected = itemCategory.filter.selected,
+                    subject = title,
+                    onOptionSelected = onOptionSelected,
+                    options = itemCategory.filter.options,
+                    optionLabels = { itemCategory.filter.labelTransform(it).string() },
+                    contentDescriptionResource = itemCategory.filter.contentDescription,
+                )
+            }
+
+            if (itemCategory.list != null) {
+                ViewAllButton(
+                    rowTitle = title,
+                    onNavigateToList = onNavigateToList,
+                    itemList = itemCategory.list,
+                )
+            }
+        },
         onNavigateClick = onNavigateClick,
         onPlayClick = onPlayClick,
         mediaItems = itemCategory.items,
@@ -213,6 +258,73 @@ fun CategoryRow(
 
                     else -> {}
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ViewAllButton(
+    rowTitle: String,
+    onNavigateToList: (String, ItemList) -> Unit,
+    itemList: ItemList,
+) {
+    val viewAllContentDescription = stringResource(Res.string.cd_view_all, rowTitle)
+    TextButton(
+        modifier = Modifier.semantics {
+            contentDescription = viewAllContentDescription
+        },
+        onClick = {
+            onNavigateToList(rowTitle, itemList)
+        },
+    ) {
+        Text("View all")
+    }
+}
+
+@Composable
+private fun <T> FilterSelector(
+    selected: Int,
+    subject: String,
+    onOptionSelected: (T) -> Unit,
+    options: List<T>,
+    optionLabels: @Composable (T) -> String,
+    contentDescriptionResource: StringResource,
+) {
+    Box {
+        var expanded by remember { mutableStateOf(false) }
+
+        val selectedLabel = optionLabels(options[selected])
+        val chipContentDescription = stringResource(
+            contentDescriptionResource,
+            subject,
+            selectedLabel,
+        )
+
+        FilterChip(
+            modifier = Modifier
+                .semantics {
+                    contentDescription = chipContentDescription
+                },
+            selected = true,
+            onClick = { expanded = true },
+            label = {
+                Text(selectedLabel)
+            },
+        )
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach {
+                DropdownMenuItem(
+                    text = { Text(optionLabels(it)) },
+                    onClick = {
+                        expanded = false
+                        onOptionSelected(it)
+                    },
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -186,10 +186,6 @@ fun CategoryRow(
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
     rowTag: String? = null,
 ) {
-    if (mediaItems.isEmpty()) {
-        return
-    }
-
     val modifier = if (rowTag != null) {
         Modifier.testTag(rowTag)
     } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -39,6 +39,7 @@ import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.DisplayString
 import io.music_assistant.client.ui.compose.item.ItemList
 import musicassistantclient.composeapp.generated.resources.Res
@@ -61,6 +62,34 @@ data class ItemCategory<T>(
         val labelTransform: (T) -> DisplayString,
         val contentDescription: StringResource,
     )
+}
+
+@Composable
+fun <T, U> CategoryRow(
+    data: DataState<T>,
+    itemCategoryProvider: (T) -> ItemCategory<U>,
+    onNavigateClick: (AppMediaItem) -> Unit,
+    onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
+    onOptionSelected: (U) -> Unit = {},
+    onPlayClick: PlayHandler<AppMediaItem>,
+    playlistActions: PlaylistActions,
+    libraryActions: LibraryActions,
+    progressActions: ProgressActions? = null,
+    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
+) {
+    if (data is DataState.Data) {
+        CategoryRow(
+            itemCategory = itemCategoryProvider(data.data),
+            onNavigateClick = onNavigateClick,
+            onNavigateToList = onNavigateToList,
+            onOptionSelected = onOptionSelected,
+            onPlayClick = onPlayClick,
+            playlistActions = playlistActions,
+            libraryActions = libraryActions,
+            progressActions = progressActions,
+            providerIconFetcher = providerIconFetcher,
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -139,6 +139,10 @@ fun <T> CategoryRow(
     progressActions: ProgressActions? = null,
     providerIconFetcher: (@Composable (Modifier, String) -> Unit),
 ) {
+    if (itemCategory.items.isEmpty() && itemCategory.filter == null) {
+        return
+    }
+
     val title = itemCategory.title.string()
     CategoryRow(
         title = title,
@@ -354,7 +358,7 @@ data class ItemCategory<T>(
         val label: DisplayString,
         val options: List<T>,
         val labelTransform: (T) -> DisplayString,
-        val contentDescription: StringResource,
+        val contentDescription: StringResource? = null,
     )
 }
 
@@ -384,21 +388,27 @@ private fun <T> FilterSelector(
     onOptionSelected: (T) -> Unit,
     options: List<T>,
     optionLabels: @Composable (T) -> String,
-    contentDescriptionResource: StringResource,
+    contentDescriptionResource: StringResource? = null,
 ) {
     Box {
         var expanded by remember { mutableStateOf(false) }
 
-        val chipContentDescription = stringResource(
-            contentDescriptionResource,
-            rowTitle,
-            label,
-        )
+        val chipContentDescription = if (contentDescriptionResource != null) {
+            stringResource(
+                contentDescriptionResource,
+                rowTitle,
+                label,
+            )
+        } else {
+            null
+        }
 
         FilterChip(
             modifier = Modifier
                 .semantics {
-                    contentDescription = chipContentDescription
+                    if (chipContentDescription != null) {
+                        contentDescription = chipContentDescription
+                    }
                 },
             selected = true,
             onClick = { expanded = true },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -33,7 +33,7 @@ data class ItemCategory(
     val id: String,
     val title: DisplayString,
     val items: List<AppMediaItem>,
-    val lazyListKey: String,
+    val lazyListKey: String = id,
     val tag: String? = null,
 )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -83,7 +83,7 @@ fun CategoryRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -57,7 +57,7 @@ data class ItemCategory<T>(
     val tag: String? = null,
 ) {
     data class Filter<T>(
-        val selected: Int,
+        val label: DisplayString,
         val options: List<T>,
         val labelTransform: (T) -> DisplayString,
         val contentDescription: StringResource,
@@ -110,8 +110,8 @@ fun <T> CategoryRow(
         actions = {
             if (itemCategory.filter != null) {
                 FilterSelector(
-                    selected = itemCategory.filter.selected,
-                    subject = title,
+                    label = itemCategory.filter.label.string(),
+                    rowTitle = title,
                     onOptionSelected = onOptionSelected,
                     options = itemCategory.filter.options,
                     optionLabels = { itemCategory.filter.labelTransform(it).string() },
@@ -313,8 +313,8 @@ private fun ViewAllButton(
 
 @Composable
 private fun <T> FilterSelector(
-    selected: Int,
-    subject: String,
+    label: String,
+    rowTitle: String,
     onOptionSelected: (T) -> Unit,
     options: List<T>,
     optionLabels: @Composable (T) -> String,
@@ -323,11 +323,10 @@ private fun <T> FilterSelector(
     Box {
         var expanded by remember { mutableStateOf(false) }
 
-        val selectedLabel = optionLabels(options[selected])
         val chipContentDescription = stringResource(
             contentDescriptionResource,
-            subject,
-            selectedLabel,
+            rowTitle,
+            label,
         )
 
         FilterChip(
@@ -338,7 +337,7 @@ private fun <T> FilterSelector(
             selected = true,
             onClick = { expanded = true },
             label = {
-                Text(selectedLabel)
+                Text(label)
             },
         )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -3,6 +3,7 @@ package io.music_assistant.client.ui.compose.common.items
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
@@ -12,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +42,7 @@ data class ItemCategory(
 @Composable
 fun CategoryRow(
     itemCategory: ItemCategory,
+    actions: @Composable () -> Unit = {},
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
@@ -49,6 +52,7 @@ fun CategoryRow(
 ) {
     CategoryRow(
         title = itemCategory.title.string(),
+        actions = actions,
         onNavigateClick = onNavigateClick,
         onPlayClick = onPlayClick,
         mediaItems = itemCategory.items,
@@ -63,6 +67,7 @@ fun CategoryRow(
 @Composable
 fun CategoryRow(
     title: String,
+    actions: @Composable () -> Unit = {},
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: PlayHandler<AppMediaItem>,
     mediaItems: List<AppMediaItem>,
@@ -75,16 +80,25 @@ fun CategoryRow(
     val rowListState = rememberLazyListState()
 
     Column {
-        Text(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Row {
+                actions()
+            }
+        }
 
         val modifier = if (rowTag != null) {
             Modifier.testTag(rowTag)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -2,10 +2,13 @@ package io.music_assistant.client.ui.compose.common.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.MarkableItem
 import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.repository.MediaItemChange
@@ -157,6 +160,28 @@ class ActionsViewModel(
     }
 
     fun getProviderIcon(provider: String) = dataSource.providerIcon(provider)
+
+    fun onPlayClick(
+        item: AppMediaItem,
+        option: QueueOption,
+        radio: Boolean,
+    ) {
+        viewModelScope.launch {
+            val queueId = dataSource.selectedPlayer?.queueOrPlayerId ?: return@launch
+            item.mediaUri?.let { mediaUri ->
+                Logger.withTag("PlayDispatch")
+                    .i { "ActionsViewModel: uri=$mediaUri option=$option radio=$radio queue=$queueId" }
+                apiClient.sendRequest(
+                    Request.Library.play(
+                        media = listOf(mediaUri),
+                        queueOrPlayerId = queueId,
+                        option = option,
+                        radioMode = radio && item !is Genre,
+                    ),
+                )
+            }
+        }
+    }
 
     private companion object {
         // Upper bound for awaiting the server's "playlist added" confirmation.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfig.kt
@@ -18,16 +18,16 @@ import io.music_assistant.client.ui.compose.common.items.ItemCategory
  * - Stored ids no longer present on the server are ignored.
  */
 internal fun reconcileHomeRows(
-    categories: List<ItemCategory>,
+    categories: List<ItemCategory<*>>,
     config: List<HomeRowPref>,
     onTop: String? = null,
-): List<Pair<ItemCategory, Boolean>> {
+): List<Pair<ItemCategory<*>, Boolean>> {
     val enabledById = config.associate { it.id to it.enabled }
     val orderById = config.withIndex().associate { (index, pref) -> pref.id to index }
     val sortedCategories = categories
         .map { category -> category to (enabledById[category.id] ?: true) }
         .sortedWith(
-            compareByDescending<Pair<ItemCategory, Boolean>> { it.second }
+            compareByDescending<Pair<ItemCategory<*>, Boolean>> { it.second }
                 .thenBy { orderById[it.first.id] ?: Int.MAX_VALUE },
         )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -154,7 +154,7 @@ fun HomeScreen(
                 color = MaterialTheme.colorScheme.error,
             )
         } else {
-            val rowContent: @Composable (ItemCategory) -> Unit = {
+            val rowContent: @Composable (ItemCategory<*>) -> Unit = {
                 CategoryRow(
                     itemCategory = it,
                     onNavigateClick = onNavigateClick,
@@ -247,7 +247,7 @@ private fun getCategories(
     recommendationsState: DataState<List<RecommendationFolder>>,
     shortcutsState: DataState<List<Shortcut>>,
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
-): List<Pair<ItemCategory, Boolean>> {
+): List<Pair<ItemCategory<*>, Boolean>> {
     val baseList = if (recommendationsState is DataState.Data) {
         val recommendations = recommendationsState.data
             .filter {
@@ -265,7 +265,7 @@ private fun getCategories(
             }
             .distinctBy { it.lazyListKey() }
             .map {
-                ItemCategory(
+                ItemCategory<Nothing>(
                     id = it.itemId,
                     title = it.displayName.toDisplayString(),
                     items = it.items.orEmpty(),
@@ -276,7 +276,7 @@ private fun getCategories(
 
         if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
             val shortcuts = shortcutsState.data
-            val shortcutsCategory = ItemCategory(
+            val shortcutsCategory = ItemCategory<Nothing>(
                 id = SHORTCUTS_CATEGORY_ID,
                 title = Res.string.home_shortcuts.toDisplayString(),
                 items = shortcuts.map { it.item },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -62,6 +62,8 @@ import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
 import io.music_assistant.client.ui.compose.home.players.PlayersPager
 import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
+import io.music_assistant.client.ui.compose.item.ItemListScreen
+import io.music_assistant.client.ui.compose.item.ItemListViewModel
 import io.music_assistant.client.ui.compose.library.BrowseScreen
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
@@ -186,7 +188,7 @@ fun MainNavigationRoot(
                 multiBackStack.currentBackStack = 1
                 multiBackStack.resetCurrentBackStack()
                 // /library/<category> → push the category list onto the Library tab.
-                dest.mediaType?.let { multiBackStack.add(MainNav.ItemList(it)) }
+                dest.mediaType?.let { multiBackStack.add(MainNav.LibraryList(it)) }
             }
 
             DeepLinkDestination.Search -> {
@@ -390,13 +392,13 @@ private fun mainNavEntryProvider(
                     if (category == LibraryCategory.BROWSE) {
                         multiBackStack.add(MainNav.Browse(path = null, title = null))
                     } else {
-                        category.mediaType?.let { multiBackStack.add(MainNav.ItemList(it)) }
+                        category.mediaType?.let { multiBackStack.add(MainNav.LibraryList(it)) }
                     }
                 },
             )
         }
 
-        entry<MainNav.ItemList> {
+        entry<MainNav.LibraryList> {
             val libraryListViewModel = koinViewModel<LibraryListViewModel> {
                 parametersOf(it.mediaType)
             }
@@ -479,6 +481,40 @@ private fun mainNavEntryProvider(
             )
         }
 
+        entry<MainNav.ItemList> {
+            val itemListViewModel = koinViewModel<ItemListViewModel> {
+                parametersOf(it.itemList)
+            }
+
+            ItemListScreen(
+                title = it.title,
+                itemListViewModel = itemListViewModel,
+                actionsViewModel = actionsViewModel,
+                onNavigateClick = { item ->
+                    when (item) {
+                        is Artist,
+                        is Album,
+                        is Playlist,
+                        is Podcast,
+                        is Audiobook,
+                        is Genre,
+                            -> {
+                            multiBackStack.add(
+                                MainNav.ItemDetails(
+                                    itemId = item.itemId,
+                                    mediaType = item.mediaType,
+                                    providerId = item.provider,
+                                ),
+                            )
+                        }
+
+                        else -> Unit
+                    }
+                },
+                contentPadding = contentPadding,
+            )
+        }
+
         entry<MainNav.ItemDetails> {
             val itemDetailsViewModel = koinViewModel<ItemDetailsViewModel> {
                 parametersOf(it.itemId, it.mediaType, it.providerId)
@@ -496,6 +532,9 @@ private fun mainNavEntryProvider(
                             providerId = providerId,
                         ),
                     )
+                },
+                onNavigateToList = { title, itemList ->
+                    multiBackStack.add(MainNav.ItemList(title, itemList))
                 },
                 contentPadding = contentPadding,
             )
@@ -554,7 +593,7 @@ private sealed interface MainNav : NavKey {
     data object Library : MainNav
 
     @Serializable
-    data class ItemList(val mediaType: MediaType) : MainNav
+    data class LibraryList(val mediaType: MediaType) : MainNav
 
     /**
      * One level of the folder-style Browse tree. [path] is the server browse path (null = root);
@@ -583,6 +622,9 @@ private sealed interface MainNav : NavKey {
 
     @Serializable
     data object Search : MainNav
+
+    @Serializable
+    data class ItemList(val title: String, val itemList: io.music_assistant.client.ui.compose.item.ItemList) : MainNav
 }
 
 @Composable
@@ -594,13 +636,14 @@ private fun rememberMainNavBackStack(bottom: MainNav) = rememberNavBackStack(
                 polymorphic(NavKey::class) {
                     subclass(MainNav.Landing::class, MainNav.Landing.serializer())
                     subclass(MainNav.Library::class, MainNav.Library.serializer())
-                    subclass(MainNav.ItemList::class, MainNav.ItemList.serializer())
+                    subclass(MainNav.LibraryList::class, MainNav.LibraryList.serializer())
                     subclass(MainNav.Browse::class, MainNav.Browse.serializer())
                     subclass(
                         MainNav.ItemDetails::class,
                         MainNav.ItemDetails.serializer(),
                     )
                     subclass(MainNav.Search::class, MainNav.Search.serializer())
+                    subclass(MainNav.ItemList::class, MainNav.ItemList.serializer())
                 }
             }
         },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -511,6 +511,7 @@ private fun mainNavEntryProvider(
                         else -> Unit
                     }
                 },
+                onBack = { multiBackStack.removeLastOrNull() },
                 contentPadding = contentPadding,
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -44,6 +44,7 @@ import androidx.savedstate.serialization.SavedStateConfiguration
 import io.music_assistant.client.api.DeepLinkBus
 import io.music_assistant.client.api.DeepLinkDestination
 import io.music_assistant.client.api.ErrorMessageBus
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.Artist
@@ -513,6 +514,7 @@ private fun mainNavEntryProvider(
                 },
                 onBack = { multiBackStack.removeLastOrNull() },
                 contentPadding = contentPadding,
+                clickContext = it.clickContext,
             )
         }
 
@@ -534,8 +536,8 @@ private fun mainNavEntryProvider(
                         ),
                     )
                 },
-                onNavigateToList = { title, itemList ->
-                    multiBackStack.add(MainNav.ItemList(title, itemList))
+                onNavigateToList = { title, itemList, clickContext ->
+                    multiBackStack.add(MainNav.ItemList(title, itemList, clickContext))
                 },
                 contentPadding = contentPadding,
             )
@@ -625,7 +627,11 @@ private sealed interface MainNav : NavKey {
     data object Search : MainNav
 
     @Serializable
-    data class ItemList(val title: String, val itemList: io.music_assistant.client.ui.compose.item.ItemList) : MainNav
+    data class ItemList(
+        val title: String,
+        val itemList: io.music_assistant.client.ui.compose.item.ItemList,
+        val clickContext: ClickContext,
+    ) : MainNav
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -64,10 +64,10 @@ import io.music_assistant.client.ui.compose.item.ItemDetailsScreen
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
 import io.music_assistant.client.ui.compose.library.BrowseScreen
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
-import io.music_assistant.client.ui.compose.library.ItemListScreen
-import io.music_assistant.client.ui.compose.library.ItemListViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategory
+import io.music_assistant.client.ui.compose.library.LibraryListScreen
+import io.music_assistant.client.ui.compose.library.LibraryListViewModel
 import io.music_assistant.client.ui.compose.library.LibraryScreen
 import io.music_assistant.client.ui.compose.library.LibraryScreenState
 import io.music_assistant.client.ui.compose.nav.AdaptiveNavigationBarLayout
@@ -397,12 +397,12 @@ private fun mainNavEntryProvider(
         }
 
         entry<MainNav.ItemList> {
-            val itemListViewModel = koinViewModel<ItemListViewModel> {
+            val libraryListViewModel = koinViewModel<LibraryListViewModel> {
                 parametersOf(it.mediaType)
             }
 
-            ItemListScreen(
-                itemListViewModel = itemListViewModel,
+            LibraryListScreen(
+                libraryListViewModel = libraryListViewModel,
                 contentPadding = contentPadding,
                 actionsViewModel = actionsViewModel,
                 onBack = { multiBackStack.removeLastOrNull() },

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -1000,6 +1000,21 @@ private fun ArtistContent(
                                     providerMappings = artist.providerMappings,
                                 )
                             }
+
+                            if (topTracks.itemList != null) {
+                                val viewAllContentDescription =
+                                    stringResource(Res.string.cd_view_all, rowTitle)
+                                TextButton(
+                                    modifier = Modifier.semantics {
+                                        contentDescription = viewAllContentDescription
+                                    },
+                                    onClick = {
+                                        onNavigateToList(rowTitle, topTracks.itemList)
+                                    },
+                                ) {
+                                    Text("View all")
+                                }
+                            }
                         },
                         mediaItems = sections.topTracks.data.items,
                         onNavigateClick = onNavigateClick,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -117,6 +118,7 @@ import musicassistantclient.composeapp.generated.resources.artist_section_in_lib
 import musicassistantclient.composeapp.generated.resources.artist_section_top
 import musicassistantclient.composeapp.generated.resources.cd_provider_filter
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
+import musicassistantclient.composeapp.generated.resources.cd_view_all
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
 import musicassistantclient.composeapp.generated.resources.library_empty
@@ -132,6 +134,7 @@ fun ItemDetailsScreen(
     actionsViewModel: ActionsViewModel,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
+    onNavigateToList: (String, ItemList) -> Unit,
     contentPadding: PaddingValues,
 ) {
     val state by itemDetailsViewModel.state.collectAsStateWithLifecycle()
@@ -145,6 +148,7 @@ fun ItemDetailsScreen(
         },
         onToggleViewMode = itemDetailsViewModel::toggleViewMode,
         onNavigateToItem = onNavigateToItem,
+        onNavigateToList = onNavigateToList,
         geEditablePlaylists = actionsViewModel::getEditablePlaylists,
         createPlaylist = actionsViewModel::createPlaylist,
         addToPlaylist = actionsViewModel::addToPlaylist,
@@ -178,6 +182,7 @@ fun ItemDetails(
     viewModeProvider: @Composable (MediaType) -> ViewMode = { ViewMode.LIST },
     onToggleViewMode: (MediaType) -> Unit = {},
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
+    onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
     fetchColors: ExtractedColorsSource? = null,
     createPlaylist: suspend (String) -> Playlist? = { null },
@@ -267,6 +272,7 @@ fun ItemDetails(
                             else -> Unit
                         }
                     },
+                    onNavigateToList = onNavigateToList,
                     onPlayItemClick = onPlayClick,
                     onPlayChildClick = onChildPlayClick,
                     onChapterClick = onChapterClick,
@@ -305,6 +311,7 @@ private fun ItemContent(
     item: AppMediaItem,
     state: ItemDetailsViewModel.State,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onNavigateToList: (String, ItemList) -> Unit,
     onPlayItemClick: (QueueOption, Boolean) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     onChapterClick: (Int) -> Unit,
@@ -390,6 +397,7 @@ private fun ItemContent(
                     artist = item,
                     sections = state.artistSections,
                     onNavigateClick = onNavigateClick,
+                    onNavigateToList = onNavigateToList,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
@@ -903,6 +911,7 @@ private fun ArtistContent(
     artist: Artist,
     sections: ArtistSections,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onNavigateToList: (String, ItemList) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
@@ -920,9 +929,10 @@ private fun ArtistContent(
         if (sections.isNotEmpty()) {
             if (sections.library is DataState.Data) {
                 item {
+                    val rowTitle = stringResource(Res.string.artist_section_in_library)
                     CategoryRow(
-                        title = stringResource(Res.string.artist_section_in_library),
-                        mediaItems = sections.library.data,
+                        title = rowTitle,
+                        mediaItems = sections.library.data.items,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,
@@ -940,13 +950,28 @@ private fun ArtistContent(
                     CategoryRow(
                         title = rowTitle,
                         actions = {
-                            if (artist.providerMappings != null) {
+                            if (artist.providerMappings != null && all.providerDomain != null) {
                                 ProviderSelector(
-                                    currentProvider = all.domain,
+                                    currentProvider = all.providerDomain,
                                     subject = rowTitle,
                                     onMappingSelected = onAlbumMappingChanged,
                                     providerMappings = artist.providerMappings,
                                 )
+                            }
+
+                            if (sections.all.data.itemList != null) {
+                                val viewAllContentDescription =
+                                    stringResource(Res.string.cd_view_all, rowTitle)
+                                TextButton(
+                                    modifier = Modifier.semantics {
+                                        contentDescription = viewAllContentDescription
+                                    },
+                                    onClick = {
+                                        onNavigateToList(rowTitle, sections.all.data.itemList)
+                                    },
+                                ) {
+                                    Text("View all")
+                                }
                             }
                         },
                         mediaItems = all.items,
@@ -967,9 +992,9 @@ private fun ArtistContent(
                     CategoryRow(
                         title = rowTitle,
                         actions = {
-                            if (artist.providerMappings != null) {
+                            if (artist.providerMappings != null && topTracks.providerDomain != null) {
                                 ProviderSelector(
-                                    currentProvider = topTracks.domain,
+                                    currentProvider = topTracks.providerDomain,
                                     subject = rowTitle,
                                     onMappingSelected = onTrackMappingChanged,
                                     providerMappings = artist.providerMappings,
@@ -1009,9 +1034,10 @@ private fun ProviderSelector(
         )
 
         FilterChip(
-            modifier = Modifier.semantics {
-                contentDescription = chipContentDescription
-            },
+            modifier = Modifier
+                .semantics {
+                    contentDescription = chipContentDescription
+                },
             selected = true,
             onClick = { expanded = true },
             label = {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -929,24 +929,24 @@ private fun ArtistContent(
     ) {
         item { heroSlot() }
         if (sections.isNotEmpty()) {
-            if (sections.library is DataState.Data) {
-                item {
-                    val itemCategory = ItemCategory<Nothing>(
-                        id = "library",
-                        title = Res.string.artist_section_in_library.toDisplayString(),
-                        items = sections.library.data.items,
-                        list = sections.library.data.itemList,
-                    )
-
-                    CategoryRow(
-                        itemCategory = itemCategory,
-                        onNavigateClick = onNavigateClick,
-                        onPlayClick = onPlayChildClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-                }
+            item {
+                CategoryRow(
+                    data = sections.library,
+                    itemCategoryProvider = {
+                        ItemCategory<Nothing>(
+                            id = "library",
+                            title = Res.string.artist_section_in_library.toDisplayString(),
+                            items = it.items,
+                            list = it.itemList,
+                        )
+                    },
+                    onNavigateClick = onNavigateClick,
+                    onNavigateToList = onNavigateToList,
+                    onPlayClick = onPlayChildClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
             }
 
             if (sections.all is DataState.Data) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -169,7 +169,6 @@ fun ItemDetailsScreen(
         onPlayClick = itemDetailsViewModel::onPlayClick,
         onChapterClick = itemDetailsViewModel::onChapterClick,
         onChildPlayClick = itemDetailsViewModel::onPlayClick,
-        onAlbumsSortChanged = itemDetailsViewModel::onAlbumsSortChanged,
         onPlayableItemsSortChanged = itemDetailsViewModel::onPlayableItemsSortChanged,
         onTabSelected = itemDetailsViewModel::onTabSelected,
         onLoadSimilarArtists = itemDetailsViewModel::loadSimilarArtists,
@@ -198,7 +197,6 @@ fun ItemDetails(
     onPlayClick: (QueueOption, Boolean) -> Unit = { _, _ -> },
     onChapterClick: (Int) -> Unit = {},
     onChildPlayClick: PlayHandler<AppMediaItem> = { _, _, _, _ -> },
-    onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
     onTabSelected: (ItemDetailsTab) -> Unit = {},
     onLoadSimilarArtists: () -> Unit = {},
@@ -269,7 +267,6 @@ fun ItemDetails(
         fetchColors = fetchColors,
         onBack = onBack,
         onToggleViewMode = onToggleViewMode,
-        onAlbumsSortChanged = onAlbumsSortChanged,
         onPlayableItemsSortChanged = onPlayableItemsSortChanged,
         onTabSelected = onTabSelected,
         onLoadSimilarArtists = onLoadSimilarArtists,
@@ -301,7 +298,6 @@ private fun ItemChildren(
     fetchColors: ExtractedColorsSource?,
     onBack: () -> Unit,
     onToggleViewMode: (MediaType) -> Unit,
-    onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
     onTabSelected: (ItemDetailsTab) -> Unit,
     onLoadSimilarArtists: () -> Unit,
@@ -339,7 +335,6 @@ private fun ItemChildren(
                     fetchColors = fetchColors,
                     onBack = onBack,
                     onToggleViewMode = onToggleViewMode,
-                    onAlbumsSortChanged = onAlbumsSortChanged,
                     onPlayableItemsSortChanged = onPlayableItemsSortChanged,
                     contentPadding = contentPadding,
                     onTabSelected = onTabSelected,
@@ -376,7 +371,6 @@ private fun ItemContent(
     onBack: () -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onToggleViewMode: (MediaType) -> Unit,
-    onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
     contentPadding: PaddingValues,
     onTabSelected: (ItemDetailsTab) -> Unit,
@@ -478,7 +472,6 @@ private fun ItemContent(
                             onTabSelected = { onTabSelected(tabs[it]) },
                             albumsSortOption = state.albumsSortOption,
                             playableItemsSortOption = state.playableItemsSortOption,
-                            onAlbumsSortChanged = onAlbumsSortChanged,
                             onPlayableItemsSortChanged = onPlayableItemsSortChanged,
                             viewModeProvider = viewModeProvider,
                             onToggleViewMode = onToggleViewMode,
@@ -533,7 +526,6 @@ private fun TabsBar(
     onTabSelected: (Int) -> Unit,
     albumsSortOption: SortOption?,
     playableItemsSortOption: SortOption?,
-    onAlbumsSortChanged: (SubItemContext, SortOption) -> Unit,
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onToggleViewMode: (MediaType) -> Unit,
@@ -596,11 +588,7 @@ private fun TabsBar(
                     currentSort = currentSort,
                     availableFields = availableFields,
                     onSortChanged = { opt ->
-                        if (sortCtx == SubItemContext.ARTIST_ALBUMS) {
-                            onAlbumsSortChanged(sortCtx, opt)
-                        } else {
-                            onPlayableItemsSortChanged(sortCtx, opt)
-                        }
+                        onPlayableItemsSortChanged(sortCtx, opt)
                     },
                 )
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -86,8 +86,6 @@ import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.ExtractedColors
 import io.music_assistant.client.ui.compose.common.ExtractedColorsSource
 import io.music_assistant.client.ui.compose.common.SortChip
-import io.music_assistant.client.ui.compose.common.ToastHost
-import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.CategoryRow
@@ -105,7 +103,6 @@ import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberDynamicColorsEnabled
 import io.music_assistant.client.ui.compose.common.rememberExtractedColorsSource
-import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.fullBleed
@@ -134,14 +131,6 @@ fun ItemDetailsScreen(
     contentPadding: PaddingValues,
 ) {
     val state by itemDetailsViewModel.state.collectAsStateWithLifecycle()
-    val toastState = rememberToastState()
-
-    // Collect toasts
-    LaunchedEffect(Unit) {
-        itemDetailsViewModel.toasts.collect { toast ->
-            toastState.showToast(toast)
-        }
-    }
 
     ItemDetails(
         contentPadding = contentPadding,
@@ -151,7 +140,6 @@ fun ItemDetailsScreen(
             itemDetailsViewModel.viewMode(type).collectAsStateWithLifecycle().value
         },
         onToggleViewMode = itemDetailsViewModel::toggleViewMode,
-        toastState = toastState,
         onNavigateToItem = onNavigateToItem,
         geEditablePlaylists = actionsViewModel::getEditablePlaylists,
         createPlaylist = actionsViewModel::createPlaylist,
@@ -184,7 +172,6 @@ fun ItemDetails(
     onBack: () -> Unit = {},
     viewModeProvider: @Composable (MediaType) -> ViewMode = { ViewMode.LIST },
     onToggleViewMode: (MediaType) -> Unit = {},
-    toastState: ToastState = rememberToastState(),
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
     fetchColors: ExtractedColorsSource? = null,
@@ -242,7 +229,6 @@ fun ItemDetails(
 
     ItemChildren(
         state = state,
-        toastState = toastState,
         viewModeProvider = viewModeProvider,
         onNavigateClick = { item ->
             when (item) {
@@ -288,7 +274,6 @@ private fun ItemDetailsTab.stringResource(): StringResource? = when (this) {
 @Composable
 private fun ItemChildren(
     state: ItemDetailsViewModel.State,
-    toastState: ToastState,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayItemClick: (QueueOption, Boolean) -> Unit,
@@ -350,13 +335,6 @@ private fun ItemChildren(
 
             is DataState.NoData -> CenteredText(stringResource(Res.string.item_no_data))
         }
-
-        ToastHost(
-            toastState = toastState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = 48.dp),
-        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -932,6 +932,15 @@ private fun ArtistContent(
                     val rowTitle = stringResource(Res.string.artist_section_in_library)
                     CategoryRow(
                         title = rowTitle,
+                        actions = {
+                            if (sections.library.data.itemList != null) {
+                                ViewAllButton(
+                                    rowTitle = rowTitle,
+                                    onNavigateToList = onNavigateToList,
+                                    itemList = sections.library.data.itemList,
+                                )
+                            }
+                        },
                         mediaItems = sections.library.data.items,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
@@ -960,18 +969,11 @@ private fun ArtistContent(
                             }
 
                             if (sections.all.data.itemList != null) {
-                                val viewAllContentDescription =
-                                    stringResource(Res.string.cd_view_all, rowTitle)
-                                TextButton(
-                                    modifier = Modifier.semantics {
-                                        contentDescription = viewAllContentDescription
-                                    },
-                                    onClick = {
-                                        onNavigateToList(rowTitle, sections.all.data.itemList)
-                                    },
-                                ) {
-                                    Text("View all")
-                                }
+                                ViewAllButton(
+                                    rowTitle = rowTitle,
+                                    onNavigateToList = onNavigateToList,
+                                    itemList = sections.all.data.itemList,
+                                )
                             }
                         },
                         mediaItems = all.items,
@@ -1002,21 +1004,14 @@ private fun ArtistContent(
                             }
 
                             if (topTracks.itemList != null) {
-                                val viewAllContentDescription =
-                                    stringResource(Res.string.cd_view_all, rowTitle)
-                                TextButton(
-                                    modifier = Modifier.semantics {
-                                        contentDescription = viewAllContentDescription
-                                    },
-                                    onClick = {
-                                        onNavigateToList(rowTitle, topTracks.itemList)
-                                    },
-                                ) {
-                                    Text("View all")
-                                }
+                                ViewAllButton(
+                                    rowTitle = rowTitle,
+                                    onNavigateToList = onNavigateToList,
+                                    itemList = topTracks.itemList,
+                                )
                             }
                         },
-                        mediaItems = sections.topTracks.data.items,
+                        mediaItems = topTracks.items,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,
@@ -1028,6 +1023,25 @@ private fun ArtistContent(
         } else {
             item { CenteredText(stringResource(Res.string.library_empty)) }
         }
+    }
+}
+
+@Composable
+private fun ViewAllButton(
+    rowTitle: String,
+    onNavigateToList: (String, ItemList) -> Unit,
+    itemList: ItemList,
+) {
+    val viewAllContentDescription = stringResource(Res.string.cd_view_all, rowTitle)
+    TextButton(
+        modifier = Modifier.semantics {
+            contentDescription = viewAllContentDescription
+        },
+        onClick = {
+            onNavigateToList(rowTitle, itemList)
+        },
+    ) {
+        Text("View all")
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -925,55 +925,51 @@ private fun ArtistContent(
         contentPadding = contentPadding,
     ) {
         item { heroSlot() }
-        if (sections.isNotEmpty()) {
-            item {
-                SectionRow(
-                    artist = artist,
-                    sectionData = sections.library,
-                    id = "library",
-                    title = Res.string.artist_section_in_library.toDisplayString(),
-                    onNavigateClick = onNavigateClick,
-                    onNavigateToList = onNavigateToList,
-                    onPlayChildClick = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                )
-            }
+        item {
+            SectionRow(
+                artist = artist,
+                sectionData = sections.library,
+                id = "library",
+                title = Res.string.artist_section_in_library.toDisplayString(),
+                onNavigateClick = onNavigateClick,
+                onNavigateToList = onNavigateToList,
+                onPlayChildClick = onPlayChildClick,
+                playlistActions = playlistActions,
+                libraryActions = libraryActions,
+                providerIconFetcher = providerIconFetcher,
+            )
+        }
 
-            item {
-                SectionRow(
-                    artist = artist,
-                    sectionData = sections.all,
-                    id = "all",
-                    title = Res.string.artist_section_all.toDisplayString(),
-                    onNavigateClick = onNavigateClick,
-                    onNavigateToList = onNavigateToList,
-                    onFilterSelected = onAlbumMappingChanged,
-                    onPlayChildClick = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                )
-            }
+        item {
+            SectionRow(
+                artist = artist,
+                sectionData = sections.all,
+                id = "all",
+                title = Res.string.artist_section_all.toDisplayString(),
+                onNavigateClick = onNavigateClick,
+                onNavigateToList = onNavigateToList,
+                onFilterSelected = onAlbumMappingChanged,
+                onPlayChildClick = onPlayChildClick,
+                playlistActions = playlistActions,
+                libraryActions = libraryActions,
+                providerIconFetcher = providerIconFetcher,
+            )
+        }
 
-            item {
-                SectionRow(
-                    artist = artist,
-                    sectionData = sections.topTracks,
-                    id = "topTracks",
-                    title = stringResource(Res.string.artist_section_top).toDisplayString(),
-                    onNavigateClick = onNavigateClick,
-                    onNavigateToList = onNavigateToList,
-                    onFilterSelected = onTrackMappingChanged,
-                    onPlayChildClick = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                )
-            }
-        } else {
-            item { CenteredText(stringResource(Res.string.library_empty)) }
+        item {
+            SectionRow(
+                artist = artist,
+                sectionData = sections.topTracks,
+                id = "topTracks",
+                title = stringResource(Res.string.artist_section_top).toDisplayString(),
+                onNavigateClick = onNavigateClick,
+                onNavigateToList = onNavigateToList,
+                onFilterSelected = onTrackMappingChanged,
+                onPlayChildClick = onPlayChildClick,
+                playlistActions = playlistActions,
+                libraryActions = libraryActions,
+                providerIconFetcher = providerIconFetcher,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -26,10 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -38,13 +35,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -53,7 +48,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -86,6 +80,7 @@ import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.CenteredProgress
 import io.music_assistant.client.ui.compose.common.CenteredText
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.DisplayString
 import io.music_assistant.client.ui.compose.common.ExtractedColors
 import io.music_assistant.client.ui.compose.common.ExtractedColorsSource
 import io.music_assistant.client.ui.compose.common.SortChip
@@ -120,7 +115,6 @@ import musicassistantclient.composeapp.generated.resources.artist_section_in_lib
 import musicassistantclient.composeapp.generated.resources.artist_section_top
 import musicassistantclient.composeapp.generated.resources.cd_provider_filter
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
-import musicassistantclient.composeapp.generated.resources.cd_view_all
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
 import musicassistantclient.composeapp.generated.resources.library_empty
@@ -930,93 +924,50 @@ private fun ArtistContent(
         item { heroSlot() }
         if (sections.isNotEmpty()) {
             item {
-                CategoryRow(
-                    data = sections.library,
-                    itemCategoryProvider = {
-                        ItemCategory<Nothing>(
-                            id = "library",
-                            title = Res.string.artist_section_in_library.toDisplayString(),
-                            items = it.items,
-                            list = it.itemList,
-                        )
-                    },
+                SectionRow(
+                    artist = artist,
+                    sectionData = sections.library,
+                    id = "library",
+                    title = Res.string.artist_section_in_library.toDisplayString(),
                     onNavigateClick = onNavigateClick,
                     onNavigateToList = onNavigateToList,
-                    onPlayClick = onPlayChildClick,
+                    onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
                     providerIconFetcher = providerIconFetcher,
                 )
             }
 
-            if (sections.all is DataState.Data) {
-                val all = sections.all.data
-
-                item {
-                    val rowTitle = stringResource(Res.string.artist_section_all)
-                    CategoryRow(
-                        title = rowTitle,
-                        actions = {
-                            if (artist.providerMappings != null && all.providerDomain != null) {
-                                ProviderSelector(
-                                    currentProvider = all.providerDomain,
-                                    subject = rowTitle,
-                                    onMappingSelected = onAlbumMappingChanged,
-                                    providerMappings = artist.providerMappings,
-                                )
-                            }
-
-                            if (sections.all.data.itemList != null) {
-                                ViewAllButton(
-                                    rowTitle = rowTitle,
-                                    onNavigateToList = onNavigateToList,
-                                    itemList = sections.all.data.itemList,
-                                )
-                            }
-                        },
-                        mediaItems = all.items,
-                        onNavigateClick = onNavigateClick,
-                        onPlayClick = onPlayChildClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-                }
+            item {
+                SectionRow(
+                    artist = artist,
+                    sectionData = sections.all,
+                    id = "all",
+                    title = Res.string.artist_section_all.toDisplayString(),
+                    onNavigateClick = onNavigateClick,
+                    onNavigateToList = onNavigateToList,
+                    onFilterSelected = onAlbumMappingChanged,
+                    onPlayChildClick = onPlayChildClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
             }
 
-            if (sections.topTracks is DataState.Data) {
-                val topTracks = sections.topTracks.data
-
-                item {
-                    val rowTitle = stringResource(Res.string.artist_section_top)
-                    CategoryRow(
-                        title = rowTitle,
-                        actions = {
-                            if (artist.providerMappings != null && topTracks.providerDomain != null) {
-                                ProviderSelector(
-                                    currentProvider = topTracks.providerDomain,
-                                    subject = rowTitle,
-                                    onMappingSelected = onTrackMappingChanged,
-                                    providerMappings = artist.providerMappings,
-                                )
-                            }
-
-                            if (topTracks.itemList != null) {
-                                ViewAllButton(
-                                    rowTitle = rowTitle,
-                                    onNavigateToList = onNavigateToList,
-                                    itemList = topTracks.itemList,
-                                )
-                            }
-                        },
-                        mediaItems = topTracks.items,
-                        onNavigateClick = onNavigateClick,
-                        onPlayClick = onPlayChildClick,
-                        playlistActions = playlistActions,
-                        libraryActions = libraryActions,
-                        providerIconFetcher = providerIconFetcher,
-                    )
-                }
+            item {
+                SectionRow(
+                    artist = artist,
+                    sectionData = sections.topTracks,
+                    id = "topTracks",
+                    title = stringResource(Res.string.artist_section_top).toDisplayString(),
+                    onNavigateClick = onNavigateClick,
+                    onNavigateToList = onNavigateToList,
+                    onFilterSelected = onTrackMappingChanged,
+                    onPlayChildClick = onPlayChildClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                )
             }
         } else {
             item { CenteredText(stringResource(Res.string.library_empty)) }
@@ -1025,68 +976,47 @@ private fun ArtistContent(
 }
 
 @Composable
-private fun ViewAllButton(
-    rowTitle: String,
+private fun <T : AppMediaItem> SectionRow(
+    artist: Artist,
+    sectionData: DataState<Section<T>>,
+    id: String,
+    title: DisplayString,
+    onNavigateClick: (AppMediaItem) -> Unit,
     onNavigateToList: (String, ItemList) -> Unit,
-    itemList: ItemList,
+    onFilterSelected: (ProviderMapping) -> Unit = {},
+    onPlayChildClick: PlayHandler<AppMediaItem>,
+    playlistActions: PlaylistActions,
+    libraryActions: LibraryActions,
+    providerIconFetcher: @Composable ((Modifier, String) -> Unit),
 ) {
-    val viewAllContentDescription = stringResource(Res.string.cd_view_all, rowTitle)
-    TextButton(
-        modifier = Modifier.semantics {
-            contentDescription = viewAllContentDescription
-        },
-        onClick = {
-            onNavigateToList(rowTitle, itemList)
-        },
-    ) {
-        Text("View all")
-    }
-}
-
-@Composable
-private fun ProviderSelector(
-    currentProvider: String,
-    subject: String,
-    onMappingSelected: (ProviderMapping) -> Unit,
-    providerMappings: List<ProviderMapping>,
-) {
-    Box {
-        var expanded by remember { mutableStateOf(false) }
-
-        val provider = currentProvider
-        val chipContentDescription = stringResource(
-            Res.string.cd_provider_filter,
-            subject,
-            provider,
-        )
-
-        FilterChip(
-            modifier = Modifier
-                .semantics {
-                    contentDescription = chipContentDescription
+    CategoryRow(
+        data = sectionData,
+        itemCategoryProvider = { section ->
+            ItemCategory(
+                id = id,
+                title = title,
+                items = section.items,
+                list = section.itemList,
+                filter = if (section.providerDomain != null && artist.providerMappings != null) {
+                    ItemCategory.Filter(
+                        label = section.providerDomain.toDisplayString(),
+                        options = artist.providerMappings,
+                        labelTransform = { it.providerDomain.toDisplayString() },
+                        contentDescription = Res.string.cd_provider_filter,
+                    )
+                } else {
+                    null
                 },
-            selected = true,
-            onClick = { expanded = true },
-            label = {
-                Text(provider)
-            },
-        )
-
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-        ) {
-            providerMappings.forEach {
-                DropdownMenuItem(
-                    text = { Text(it.providerDomain) },
-                    onClick = {
-                        expanded = false
-                        onMappingSelected(it)
-                    },
-                )
-            }
-        }
-    }
+            )
+        },
+        onNavigateClick = onNavigateClick,
+        onNavigateToList = onNavigateToList,
+        onOptionSelected = onFilterSelected,
+        onPlayClick = onPlayChildClick,
+        playlistActions = playlistActions,
+        libraryActions = libraryActions,
+        providerIconFetcher = providerIconFetcher,
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -438,10 +438,24 @@ private fun ItemContent(
             // selectedTab is null exactly while sub-lists load (for an item that has tabs), so it
             // doubles as the loading gate: show the hero + a single spinner, tabs hidden.
             val currentTab = state.selectedTab
-            if (tabs.isEmpty()) {
+
+            val gridState = rememberLazyGridState()
+            if (item is Artist) {
+                ArtistContent(
+                    sections = state.artistAlbumSections ?: ArtistSections.loading(),
+                    viewModeProvider = viewModeProvider,
+                    onNavigateClick = onNavigateClick,
+                    onPlayChildClick = onPlayChildClick,
+                    playlistActions = playlistActions,
+                    libraryActions = libraryActions,
+                    providerIconFetcher = providerIconFetcher,
+                    contentPadding = contentPadding,
+                    heroSlot = heroSlot,
+                    gridState = gridState,
+                )
+            } else if (tabs.isEmpty()) {
                 heroSlot()
             } else {
-                val gridState = rememberLazyGridState()
                 if (currentTab == null) {
                     Box(modifier = Modifier.weight(1f)) {
                         DetailGrid(
@@ -625,33 +639,6 @@ private fun TabContent(
     gridState: LazyGridState,
 ) {
     when (tab) {
-        ItemDetailsTab.ARTIST_ALBUMS -> ArtistAlbumsTabContent(
-            sections = state.artistAlbumSections ?: ArtistSections.loading(),
-            viewModeProvider = viewModeProvider,
-            onNavigateClick = onNavigateClick,
-            onPlayChildClick = onPlayChildClick,
-            playlistActions = playlistActions,
-            libraryActions = libraryActions,
-            providerIconFetcher = providerIconFetcher,
-            contentPadding = contentPadding,
-            heroSlot = heroSlot,
-            tabsSlot = tabsSlot,
-            gridState = gridState,
-        )
-
-        ItemDetailsTab.ARTIST_TRACKS -> ArtistTracksTabContent(
-            sections = state.artistTrackSections ?: ArtistSections.loading(),
-            viewModeProvider = viewModeProvider,
-            onPlayChildClick = onPlayChildClick,
-            playlistActions = playlistActions,
-            libraryActions = libraryActions,
-            providerIconFetcher = providerIconFetcher,
-            contentPadding = contentPadding,
-            heroSlot = heroSlot,
-            tabsSlot = tabsSlot,
-            gridState = gridState,
-        )
-
         ItemDetailsTab.GENRE_ALBUMS -> AlbumsTabContent(
             albumsState = state.albumsState,
             viewModeProvider = viewModeProvider,
@@ -1022,7 +1009,7 @@ private inline fun <T> LazyGridScope.artistSectionsBody(
 }
 
 @Composable
-private fun ArtistAlbumsTabContent(
+private fun ArtistContent(
     sections: ArtistSections<Album>,
     viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -1032,11 +1019,10 @@ private fun ArtistAlbumsTabContent(
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
-    tabsSlot: @Composable () -> Unit,
     gridState: LazyGridState,
 ) {
     val viewMode = viewModeProvider(MediaType.ALBUM)
-    DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
+    DetailGrid(contentPadding, heroSlot, null, gridState) {
         artistSectionsBody(sections) { section, albums ->
             val albumKeys = albums.lazyListOccurrenceKeys()
             itemsIndexed(
@@ -1054,46 +1040,6 @@ private fun ArtistAlbumsTabContent(
                     onNavigateClick = onNavigateClick,
                     onPlayOption = onPlayChildClick,
                     playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ArtistTracksTabContent(
-    sections: ArtistSections<Track>,
-    viewModeProvider: @Composable (MediaType) -> ViewMode,
-    onPlayChildClick: PlayHandler<AppMediaItem>,
-    playlistActions: PlaylistActions,
-    libraryActions: LibraryActions,
-    providerIconFetcher: @Composable (Modifier, String) -> Unit,
-    contentPadding: PaddingValues,
-    heroSlot: @Composable () -> Unit,
-    tabsSlot: @Composable () -> Unit,
-    gridState: LazyGridState,
-) {
-    val viewMode = viewModeProvider(MediaType.TRACK)
-    DetailGrid(contentPadding, heroSlot, tabsSlot, gridState) {
-        artistSectionsBody(sections) { section, tracks ->
-            val trackKeys = tracks.playableLazyListOccurrenceKeys()
-            itemsIndexed(
-                items = tracks,
-                key = { index, _ -> "track-${section.name}-${trackKeys[index]}" },
-                span = when (viewMode) {
-                    ViewMode.LIST -> { _, _ -> GridItemSpan(maxLineSpan) }
-                    ViewMode.GRID -> null
-                },
-            ) { _, track ->
-                TrackWithMenu(
-                    item = track,
-                    viewMode = viewMode,
-                    showTrackNumber = false,
-                    onPlayOption = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    onRemoveFromPlaylist = null,
                     libraryActions = libraryActions,
                     providerIconFetcher = providerIconFetcher,
                 )

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -112,6 +112,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.album_disc_header
 import musicassistantclient.composeapp.generated.resources.artist_section_all
 import musicassistantclient.composeapp.generated.resources.artist_section_in_library
+import musicassistantclient.composeapp.generated.resources.artist_section_top
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
@@ -425,7 +426,7 @@ private fun ItemContent(
             if (item is Artist) {
                 ArtistContent(
                     artist = item,
-                    sections = state.artistAlbumSections ?: ArtistSections.loading(),
+                    sections = state.artistSections ?: ArtistSections.loading(),
                     onNavigateClick = onNavigateClick,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
@@ -937,7 +938,7 @@ private fun DiscHeader(disc: Int) {
 @Composable
 private fun ArtistContent(
     artist: Artist,
-    sections: ArtistSections<Album>,
+    sections: ArtistSections,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
@@ -1003,6 +1004,20 @@ private fun ArtistContent(
                             }
                         },
                         mediaItems = all.items,
+                        onNavigateClick = onNavigateClick,
+                        onPlayClick = onPlayChildClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+                }
+            }
+
+            if (sections.topTracks is DataState.Data) {
+                item {
+                    CategoryRow(
+                        title = stringResource(Res.string.artist_section_top),
+                        mediaItems = sections.topTracks.data,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -233,74 +233,6 @@ fun ItemDetails(
         }
     }
 
-    ItemChildren(
-        state = state,
-        viewModeProvider = viewModeProvider,
-        onNavigateClick = { item ->
-            when (item) {
-                is Artist,
-                is Album,
-                is Playlist,
-                is Podcast,
-                is Audiobook,
-                is Genre,
-                    -> {
-                    onNavigateToItem(item.itemId, item.mediaType, item.provider)
-                }
-
-                else -> Unit
-            }
-        },
-        onPlayItemClick = onPlayClick,
-        onPlayChildClick = onChildPlayClick,
-        onChapterClick = onChapterClick,
-        playlistActions = playlistActions,
-        progressActions = progressActions,
-        onRemoveFromPlaylist = onRemoveFromPlaylist,
-        libraryActions = libraryActions,
-        providerIconFetcher = providerIconFetcher,
-        fetchColors = fetchColors,
-        onBack = onBack,
-        onToggleViewMode = onToggleViewMode,
-        onPlayableItemsSortChanged = onPlayableItemsSortChanged,
-        onTabSelected = onTabSelected,
-        onLoadSimilarArtists = onLoadSimilarArtists,
-        contentPadding = contentPadding,
-        onAlbumMappingChanged = onAlbumMappingChanged,
-        onTrackMappingChanged = onTrackMappingChanged,
-    )
-}
-
-/** Tab label. Chapters have a dedicated string; every other tab borrows its media-type label. */
-private fun ItemDetailsTab.stringResource(): StringResource? = when (this) {
-    ItemDetailsTab.AUDIOBOOK_CHAPTERS -> Res.string.media_type_chapters
-    ItemDetailsTab.PODCAST_EPISODES -> Res.string.media_type_episodes
-    else -> viewMediaType?.stringResource()
-}
-
-@Composable
-private fun ItemChildren(
-    state: ItemDetailsViewModel.State,
-    viewModeProvider: @Composable (MediaType) -> ViewMode,
-    onNavigateClick: (AppMediaItem) -> Unit,
-    onPlayItemClick: (QueueOption, Boolean) -> Unit,
-    onPlayChildClick: PlayHandler<AppMediaItem>,
-    onChapterClick: (Int) -> Unit,
-    playlistActions: PlaylistActions,
-    progressActions: ProgressActions? = null,
-    onRemoveFromPlaylist: (String, Int) -> Unit,
-    libraryActions: LibraryActions,
-    providerIconFetcher: (@Composable (Modifier, String) -> Unit),
-    fetchColors: ExtractedColorsSource?,
-    onBack: () -> Unit,
-    onToggleViewMode: (MediaType) -> Unit,
-    onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit,
-    onTabSelected: (ItemDetailsTab) -> Unit,
-    onLoadSimilarArtists: () -> Unit,
-    contentPadding: PaddingValues,
-    onAlbumMappingChanged: (ProviderMapping) -> Unit,
-    onTrackMappingChanged: (ProviderMapping) -> Unit,
-) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
             is DataState.Loading -> CenteredProgress()
@@ -320,9 +252,23 @@ private fun ItemChildren(
                 ItemContent(
                     item = item,
                     state = state,
-                    onNavigateClick = onNavigateClick,
-                    onPlayItemClick = onPlayItemClick,
-                    onPlayChildClick = onPlayChildClick,
+                    onNavigateClick = { item: AppMediaItem ->
+                        when (item) {
+                            is Artist,
+                            is Album,
+                            is Playlist,
+                            is Podcast,
+                            is Audiobook,
+                            is Genre,
+                                -> {
+                                onNavigateToItem(item.itemId, item.mediaType, item.provider)
+                            }
+
+                            else -> Unit
+                        }
+                    },
+                    onPlayItemClick = onPlayClick,
+                    onPlayChildClick = onChildPlayClick,
                     onChapterClick = onChapterClick,
                     playlistActions = playlistActions,
                     progressActions = progressActions,
@@ -345,6 +291,13 @@ private fun ItemChildren(
             is DataState.NoData -> CenteredText(stringResource(Res.string.item_no_data))
         }
     }
+}
+
+/** Tab label. Chapters have a dedicated string; every other tab borrows its media-type label. */
+private fun ItemDetailsTab.stringResource(): StringResource? = when (this) {
+    ItemDetailsTab.AUDIOBOOK_CHAPTERS -> Res.string.media_type_chapters
+    ItemDetailsTab.PODCAST_EPISODES -> Res.string.media_type_episodes
+    else -> viewMediaType?.stringResource()
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -130,7 +129,7 @@ fun ItemDetailsScreen(
     actionsViewModel: ActionsViewModel,
     onBack: () -> Unit,
     onNavigateToItem: (String, MediaType, String) -> Unit,
-    onNavigateToList: (String, ItemList) -> Unit,
+    onNavigateToList: (String, ItemList, ClickContext) -> Unit,
     contentPadding: PaddingValues,
 ) {
     val state by itemDetailsViewModel.state.collectAsStateWithLifecycle()
@@ -178,7 +177,7 @@ fun ItemDetails(
     viewModeProvider: @Composable (MediaType) -> ViewMode = { ViewMode.LIST },
     onToggleViewMode: (MediaType) -> Unit = {},
     onNavigateToItem: (String, MediaType, String) -> Unit = { _, _, _ -> },
-    onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
+    onNavigateToList: (String, ItemList, ClickContext) -> Unit = { _, _, _ -> },
     geEditablePlaylists: suspend () -> List<Playlist> = suspend { emptyList() },
     fetchColors: ExtractedColorsSource? = null,
     createPlaylist: suspend (String) -> Playlist? = { null },
@@ -307,7 +306,7 @@ private fun ItemContent(
     item: AppMediaItem,
     state: ItemDetailsViewModel.State,
     onNavigateClick: (AppMediaItem) -> Unit,
-    onNavigateToList: (String, ItemList) -> Unit,
+    onNavigateToList: (String, ItemList, ClickContext) -> Unit,
     onPlayItemClick: (QueueOption, Boolean) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     onChapterClick: (Int) -> Unit,
@@ -389,20 +388,24 @@ private fun ItemContent(
 
             val gridState = rememberLazyGridState()
             if (item is Artist) {
-                ArtistContent(
-                    artist = item,
-                    sections = state.artistSections,
-                    onNavigateClick = onNavigateClick,
-                    onNavigateToList = onNavigateToList,
-                    onPlayChildClick = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                    contentPadding = contentPadding,
-                    heroSlot = heroSlot,
-                    onAlbumMappingChanged = onAlbumMappingChanged,
-                    onTrackMappingChanged = onTrackMappingChanged,
-                )
+                ProvideClickActions(ClickContext.ARTIST) {
+                    ArtistContent(
+                        artist = item,
+                        sections = state.artistSections,
+                        onNavigateClick = onNavigateClick,
+                        onNavigateToList = { title, itemList ->
+                            onNavigateToList(title, itemList, ClickContext.ARTIST)
+                        },
+                        onPlayChildClick = onPlayChildClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                        contentPadding = contentPadding,
+                        heroSlot = heroSlot,
+                        onAlbumMappingChanged = onAlbumMappingChanged,
+                        onTrackMappingChanged = onTrackMappingChanged,
+                    )
+                }
             } else if (tabs.isEmpty()) {
                 heroSlot()
             } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -111,7 +111,6 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.album_disc_header
 import musicassistantclient.composeapp.generated.resources.artist_section_all
 import musicassistantclient.composeapp.generated.resources.artist_section_in_library
-import musicassistantclient.composeapp.generated.resources.artist_section_top
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
@@ -978,7 +977,6 @@ private fun ArtistSectionHeader(section: ArtistSection) {
         text = stringResource(
             when (section) {
                 ArtistSection.LIBRARY -> Res.string.artist_section_in_library
-                ArtistSection.TOP -> Res.string.artist_section_top
                 ArtistSection.ALL -> Res.string.artist_section_all
             },
         ),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -78,6 +78,7 @@ import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.stringResource
 import io.music_assistant.client.data.model.client.toClickContext
+import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.CenteredProgress
 import io.music_assistant.client.ui.compose.common.CenteredText
@@ -172,6 +173,7 @@ fun ItemDetailsScreen(
         onPlayableItemsSortChanged = itemDetailsViewModel::onPlayableItemsSortChanged,
         onTabSelected = itemDetailsViewModel::onTabSelected,
         onLoadSimilarArtists = itemDetailsViewModel::loadSimilarArtists,
+        onMappingSelected = itemDetailsViewModel::loadAlbumsForProvider,
     )
 }
 
@@ -200,6 +202,7 @@ fun ItemDetails(
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
     onTabSelected: (ItemDetailsTab) -> Unit = {},
     onLoadSimilarArtists: () -> Unit = {},
+    onMappingSelected: (ProviderMapping) -> Unit = { },
 ) {
     val playlistActions = object : PlaylistActions {
         override suspend fun getEditablePlaylists(): List<Playlist> {
@@ -271,6 +274,7 @@ fun ItemDetails(
         onTabSelected = onTabSelected,
         onLoadSimilarArtists = onLoadSimilarArtists,
         contentPadding = contentPadding,
+        onMappingSelected = onMappingSelected,
     )
 }
 
@@ -302,6 +306,7 @@ private fun ItemChildren(
     onTabSelected: (ItemDetailsTab) -> Unit,
     onLoadSimilarArtists: () -> Unit,
     contentPadding: PaddingValues,
+    onMappingSelected: (ProviderMapping) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
@@ -322,7 +327,6 @@ private fun ItemChildren(
                 ItemContent(
                     item = item,
                     state = state,
-                    viewModeProvider = viewModeProvider,
                     onNavigateClick = onNavigateClick,
                     onPlayItemClick = onPlayItemClick,
                     onPlayChildClick = onPlayChildClick,
@@ -334,11 +338,13 @@ private fun ItemChildren(
                     providerIconFetcher = providerIconFetcher,
                     fetchColors = fetchColors,
                     onBack = onBack,
+                    viewModeProvider = viewModeProvider,
                     onToggleViewMode = onToggleViewMode,
                     onPlayableItemsSortChanged = onPlayableItemsSortChanged,
                     contentPadding = contentPadding,
                     onTabSelected = onTabSelected,
                     onLoadSimilarArtists = onLoadSimilarArtists,
+                    onMappingSelected = onMappingSelected,
                 )
             }
 
@@ -375,6 +381,7 @@ private fun ItemContent(
     contentPadding: PaddingValues,
     onTabSelected: (ItemDetailsTab) -> Unit,
     onLoadSimilarArtists: () -> Unit,
+    onMappingSelected: (ProviderMapping) -> Unit,
 ) {
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
@@ -439,6 +446,7 @@ private fun ItemContent(
             val gridState = rememberLazyGridState()
             if (item is Artist) {
                 ArtistContent(
+                    artist = item,
                     sections = state.artistAlbumSections ?: ArtistSections.loading(),
                     onNavigateClick = onNavigateClick,
                     onPlayChildClick = onPlayChildClick,
@@ -447,6 +455,7 @@ private fun ItemContent(
                     providerIconFetcher = providerIconFetcher,
                     contentPadding = contentPadding,
                     heroSlot = heroSlot,
+                    onMappingSelected = onMappingSelected,
                 )
             } else if (tabs.isEmpty()) {
                 heroSlot()
@@ -910,9 +919,9 @@ private fun PlayablesTabContent(
             // any other sort intentionally mixes discs, so headers would lie. Requiring every
             // track to carry a disc number avoids a bogus "Disc null" header on partial tags.
             val sectionByDisc = parentItem is Album &&
-                playableItemsSortOption?.field == SortField.ORIGINAL &&
-                tracks.all { it is Track && it.discNumber != null } &&
-                tracks.mapNotNull { (it as? Track)?.discNumber }.distinct().size > 1
+                    playableItemsSortOption?.field == SortField.ORIGINAL &&
+                    tracks.all { it is Track && it.discNumber != null } &&
+                    tracks.mapNotNull { (it as? Track)?.discNumber }.distinct().size > 1
             if (sectionByDisc) {
                 tracks.forEachIndexed { index, track ->
                     // Gate guarantees a non-null disc; Original sort keeps discs contiguous.
@@ -949,6 +958,7 @@ private fun DiscHeader(disc: Int) {
 
 @Composable
 private fun ArtistContent(
+    artist: Artist,
     sections: ArtistSections<Album>,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
@@ -957,6 +967,7 @@ private fun ArtistContent(
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
+    onMappingSelected: (ProviderMapping) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.testTag(ItemDetailsScreenSemantics.LIST_TAG),
@@ -984,31 +995,36 @@ private fun ArtistContent(
                     CategoryRow(
                         title = stringResource(Res.string.artist_section_all),
                         actions = {
-                            Box {
-                                var expanded by remember { mutableStateOf(false) }
+                            if (artist.providerMappings != null) {
+                                Box {
+                                    var expanded by remember { mutableStateOf(false) }
 
-                                FilterChip(
-                                    selected = true,
-                                    onClick = { expanded = true },
-                                    label = {
-                                        Text(all.selectedDomain)
-                                    },
-                                )
+                                    FilterChip(
+                                        selected = true,
+                                        onClick = { expanded = true },
+                                        label = {
+                                            Text(all.domain)
+                                        },
+                                    )
 
-                                DropdownMenu(
-                                    expanded = expanded,
-                                    onDismissRequest = { expanded = false },
-                                ) {
-                                    all.options.forEach {
-                                        DropdownMenuItem(
-                                            text = { Text(it) },
-                                            onClick = {},
-                                        )
+                                    DropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = { expanded = false },
+                                    ) {
+                                        artist.providerMappings.forEach {
+                                            DropdownMenuItem(
+                                                text = { Text(it.providerDomain) },
+                                                onClick = {
+                                                    expanded = false
+                                                    onMappingSelected(it)
+                                                },
+                                            )
+                                        }
                                     }
                                 }
                             }
                         },
-                        mediaItems = sections.all.data.items,
+                        mediaItems = all.items,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -426,7 +426,7 @@ private fun ItemContent(
             if (item is Artist) {
                 ArtistContent(
                     artist = item,
-                    sections = state.artistSections ?: ArtistSections.loading(),
+                    sections = state.artistSections,
                     onNavigateClick = onNavigateClick,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -3,7 +3,6 @@
 package io.music_assistant.client.ui.compose.item
 
 import androidx.compose.foundation.LocalOverscrollFactory
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.plus
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridItemSpanScope
@@ -22,7 +22,7 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
@@ -45,7 +45,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
@@ -87,6 +86,8 @@ import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
+import io.music_assistant.client.ui.compose.common.items.CategoryRow
+import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlayHandler
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
@@ -102,6 +103,7 @@ import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberDynamicColorsEnabled
 import io.music_assistant.client.ui.compose.common.rememberExtractedColorsSource
 import io.music_assistant.client.ui.compose.common.rememberToastState
+import io.music_assistant.client.ui.compose.common.toDisplayString
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.fullBleed
@@ -443,7 +445,6 @@ private fun ItemContent(
             if (item is Artist) {
                 ArtistContent(
                     sections = state.artistAlbumSections ?: ArtistSections.loading(),
-                    viewModeProvider = viewModeProvider,
                     onNavigateClick = onNavigateClick,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
@@ -451,7 +452,6 @@ private fun ItemContent(
                     providerIconFetcher = providerIconFetcher,
                     contentPadding = contentPadding,
                     heroSlot = heroSlot,
-                    gridState = gridState,
                 )
             } else if (tabs.isEmpty()) {
                 heroSlot()
@@ -959,59 +959,8 @@ private fun DiscHeader(disc: Int) {
 }
 
 @Composable
-private fun ArtistSectionHeader(section: ArtistSection) {
-    Text(
-        text = stringResource(
-            when (section) {
-                ArtistSection.LIBRARY -> Res.string.artist_section_in_library
-                ArtistSection.ALL -> Res.string.artist_section_all
-            },
-        ),
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 4.dp, end = 4.dp, top = 12.dp, bottom = 4.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-    )
-}
-
-/**
- * Emits the artist tab's Library/Top/All sub-sections: each non-empty section gets a header row
- * then its [items]. If none has data, shows a single error/empty message (mirroring [tabListBody]).
- */
-private inline fun <T> LazyGridScope.artistSectionsBody(
-    sections: ArtistSections<T>,
-    crossinline items: LazyGridScope.(ArtistSection, List<T>) -> Unit,
-) {
-    val visible = sections.ordered().mapNotNull { (section, state) ->
-        (state.dataOrNull?.takeIf { it.isNotEmpty() })?.let { section to it }
-    }
-    if (visible.isEmpty()) {
-        if (sections.ordered().any { it.second is DataState.Error }) {
-            fullSpanItem(DETAIL_ERROR_KEY) {
-                CenteredText(
-                    text = stringResource(Res.string.library_error),
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        } else {
-            fullSpanItem(DETAIL_EMPTY_KEY) { CenteredText(stringResource(Res.string.library_empty)) }
-        }
-        return
-    }
-    visible.forEach { (section, data) ->
-        fullSpanItem("section-header-${section.name}") { ArtistSectionHeader(section) }
-        items(section, data)
-    }
-}
-
-@Composable
 private fun ArtistContent(
     sections: ArtistSections<Album>,
-    viewModeProvider: @Composable (MediaType) -> ViewMode,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayChildClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
@@ -1019,31 +968,47 @@ private fun ArtistContent(
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
-    gridState: LazyGridState,
 ) {
-    val viewMode = viewModeProvider(MediaType.ALBUM)
-    DetailGrid(contentPadding, heroSlot, null, gridState) {
-        artistSectionsBody(sections) { section, albums ->
-            val albumKeys = albums.lazyListOccurrenceKeys()
-            itemsIndexed(
-                items = albums,
-                // Prefix by section: the same album can appear in more than one section.
-                key = { index, _ -> "album-${section.name}-${albumKeys[index]}" },
-                span = when (viewMode) {
-                    ViewMode.LIST -> { _, _ -> GridItemSpan(maxLineSpan) }
-                    ViewMode.GRID -> null
-                },
-            ) { _, album ->
-                AlbumWithMenu(
-                    item = album,
-                    viewMode = viewMode,
+    val categories = buildList {
+        if (sections.library is DataState.Data && sections.library.data.isNotEmpty()) {
+            add(
+                ItemCategory(
+                    id = "library",
+                    title = Res.string.artist_section_in_library.toDisplayString(),
+                    items = sections.library.data,
+                ),
+            )
+        }
+
+        if (sections.all is DataState.Data && sections.all.data.isNotEmpty()) {
+            add(
+                ItemCategory(
+                    id = "library",
+                    title = Res.string.artist_section_all.toDisplayString(),
+                    items = sections.all.data,
+                ),
+            )
+        }
+    }
+
+    LazyColumn(
+        modifier = Modifier.testTag(ItemDetailsScreenSemantics.LIST_TAG),
+        contentPadding = contentPadding,
+    ) {
+        item { heroSlot() }
+        if (!categories.isEmpty()) {
+            items(categories) {
+                CategoryRow(
+                    itemCategory = it,
                     onNavigateClick = onNavigateClick,
-                    onPlayOption = onPlayChildClick,
+                    onPlayClick = onPlayChildClick,
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
                     providerIconFetcher = providerIconFetcher,
                 )
             }
+        } else {
+            item { CenteredText(stringResource(Res.string.library_empty)) }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -22,11 +22,12 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -42,6 +43,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -88,7 +90,6 @@ import io.music_assistant.client.ui.compose.common.ToastState
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.CategoryRow
-import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlayHandler
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
@@ -104,7 +105,6 @@ import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberDynamicColorsEnabled
 import io.music_assistant.client.ui.compose.common.rememberExtractedColorsSource
 import io.music_assistant.client.ui.compose.common.rememberToastState
-import io.music_assistant.client.ui.compose.common.toDisplayString
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.fullBleed
@@ -958,52 +958,64 @@ private fun ArtistContent(
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
 ) {
-    val categories = buildList {
-        if (sections.library is DataState.Data && sections.library.data.isNotEmpty()) {
-            add(
-                ItemCategory(
-                    id = "library",
-                    title = Res.string.artist_section_in_library.toDisplayString(),
-                    items = sections.library.data,
-                ),
-            )
-        }
-
-        if (sections.all is DataState.Data && sections.all.data.isNotEmpty()) {
-            add(
-                ItemCategory(
-                    id = "library",
-                    title = Res.string.artist_section_all.toDisplayString(),
-                    items = sections.all.data,
-                ),
-            )
-        }
-    }
-
     LazyColumn(
         modifier = Modifier.testTag(ItemDetailsScreenSemantics.LIST_TAG),
         contentPadding = contentPadding,
     ) {
         item { heroSlot() }
-        if (!categories.isEmpty()) {
-            items(categories) {
-                CategoryRow(
-                    itemCategory = it,
-                    actions = {
-                        FilterChip(
-                            selected = true,
-                            onClick = {},
-                            label = {
-                                Text(it.items.first().provider)
-                            },
-                        )
-                    },
-                    onNavigateClick = onNavigateClick,
-                    onPlayClick = onPlayChildClick,
-                    playlistActions = playlistActions,
-                    libraryActions = libraryActions,
-                    providerIconFetcher = providerIconFetcher,
-                )
+        if (sections.isNotEmpty()) {
+            if (sections.library is DataState.Data) {
+                item {
+                    CategoryRow(
+                        title = stringResource(Res.string.artist_section_in_library),
+                        mediaItems = sections.library.data,
+                        onNavigateClick = onNavigateClick,
+                        onPlayClick = onPlayChildClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+                }
+            }
+
+            if (sections.all is DataState.Data) {
+                val all = sections.all.data
+                item {
+                    CategoryRow(
+                        title = stringResource(Res.string.artist_section_all),
+                        actions = {
+                            Box {
+                                var expanded by remember { mutableStateOf(false) }
+
+                                FilterChip(
+                                    selected = true,
+                                    onClick = { expanded = true },
+                                    label = {
+                                        Text(all.selectedDomain)
+                                    },
+                                )
+
+                                DropdownMenu(
+                                    expanded = expanded,
+                                    onDismissRequest = { expanded = false },
+                                ) {
+                                    all.options.forEach {
+                                        DropdownMenuItem(
+                                            text = { Text(it) },
+                                            onClick = {},
+                                        )
+                                    }
+                                }
+                            }
+                        },
+                        mediaItems = sections.all.data.items,
+                        onNavigateClick = onNavigateClick,
+                        onPlayClick = onPlayChildClick,
+                        playlistActions = playlistActions,
+                        libraryActions = libraryActions,
+                        providerIconFetcher = providerIconFetcher,
+                    )
+                }
             }
         } else {
             item { CenteredText(stringResource(Res.string.library_empty)) }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -1000,6 +1001,15 @@ private fun ArtistContent(
             items(categories) {
                 CategoryRow(
                     itemCategory = it,
+                    actions = {
+                        FilterChip(
+                            selected = true,
+                            onClick = {},
+                            label = {
+                                Text(it.items.first().provider)
+                            },
+                        )
+                    },
                     onNavigateClick = onNavigateClick,
                     onPlayClick = onPlayChildClick,
                     playlistActions = playlistActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -113,6 +115,7 @@ import musicassistantclient.composeapp.generated.resources.album_disc_header
 import musicassistantclient.composeapp.generated.resources.artist_section_all
 import musicassistantclient.composeapp.generated.resources.artist_section_in_library
 import musicassistantclient.composeapp.generated.resources.artist_section_top
+import musicassistantclient.composeapp.generated.resources.cd_provider_filter
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.item_error
 import musicassistantclient.composeapp.generated.resources.item_no_data
@@ -971,18 +974,29 @@ private fun ArtistContent(
             if (sections.all is DataState.Data) {
                 val all = sections.all.data
                 item {
+                    val rowTitle = stringResource(Res.string.artist_section_all)
                     CategoryRow(
-                        title = stringResource(Res.string.artist_section_all),
+                        title = rowTitle,
                         actions = {
                             if (artist.providerMappings != null) {
                                 Box {
                                     var expanded by remember { mutableStateOf(false) }
 
+                                    val provider = all.domain
+                                    val chipContentDescription = stringResource(
+                                        Res.string.cd_provider_filter,
+                                        rowTitle,
+                                        provider,
+                                    )
+
                                     FilterChip(
+                                        modifier = Modifier.semantics {
+                                            contentDescription = chipContentDescription
+                                        },
                                         selected = true,
                                         onClick = { expanded = true },
                                         label = {
-                                            Text(all.domain)
+                                            Text(provider)
                                         },
                                     )
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -165,7 +165,8 @@ fun ItemDetailsScreen(
         onPlayableItemsSortChanged = itemDetailsViewModel::onPlayableItemsSortChanged,
         onTabSelected = itemDetailsViewModel::onTabSelected,
         onLoadSimilarArtists = itemDetailsViewModel::loadSimilarArtists,
-        onMappingSelected = itemDetailsViewModel::loadAlbumsForProvider,
+        onAlbumMappingChanged = itemDetailsViewModel::loadAlbumsForProvider,
+        onTrackMappingChanged = itemDetailsViewModel::loadTopTracksForProvider,
     )
 }
 
@@ -193,7 +194,8 @@ fun ItemDetails(
     onPlayableItemsSortChanged: (SubItemContext, SortOption) -> Unit = { _, _ -> },
     onTabSelected: (ItemDetailsTab) -> Unit = {},
     onLoadSimilarArtists: () -> Unit = {},
-    onMappingSelected: (ProviderMapping) -> Unit = { },
+    onAlbumMappingChanged: (ProviderMapping) -> Unit = { },
+    onTrackMappingChanged: (ProviderMapping) -> Unit = { },
 ) {
     val playlistActions = object : PlaylistActions {
         override suspend fun getEditablePlaylists(): List<Playlist> {
@@ -264,7 +266,8 @@ fun ItemDetails(
         onTabSelected = onTabSelected,
         onLoadSimilarArtists = onLoadSimilarArtists,
         contentPadding = contentPadding,
-        onMappingSelected = onMappingSelected,
+        onAlbumMappingChanged = onAlbumMappingChanged,
+        onTrackMappingChanged = onTrackMappingChanged,
     )
 }
 
@@ -295,7 +298,8 @@ private fun ItemChildren(
     onTabSelected: (ItemDetailsTab) -> Unit,
     onLoadSimilarArtists: () -> Unit,
     contentPadding: PaddingValues,
-    onMappingSelected: (ProviderMapping) -> Unit,
+    onAlbumMappingChanged: (ProviderMapping) -> Unit,
+    onTrackMappingChanged: (ProviderMapping) -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         when (val itemState = state.itemState) {
@@ -333,7 +337,8 @@ private fun ItemChildren(
                     contentPadding = contentPadding,
                     onTabSelected = onTabSelected,
                     onLoadSimilarArtists = onLoadSimilarArtists,
-                    onMappingSelected = onMappingSelected,
+                    onAlbumMappingChanged = onAlbumMappingChanged,
+                    onTrackMappingChanged = onTrackMappingChanged,
                 )
             }
 
@@ -363,7 +368,8 @@ private fun ItemContent(
     contentPadding: PaddingValues,
     onTabSelected: (ItemDetailsTab) -> Unit,
     onLoadSimilarArtists: () -> Unit,
-    onMappingSelected: (ProviderMapping) -> Unit,
+    onAlbumMappingChanged: (ProviderMapping) -> Unit,
+    onTrackMappingChanged: (ProviderMapping) -> Unit,
 ) {
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
@@ -437,7 +443,8 @@ private fun ItemContent(
                     providerIconFetcher = providerIconFetcher,
                     contentPadding = contentPadding,
                     heroSlot = heroSlot,
-                    onMappingSelected = onMappingSelected,
+                    onAlbumMappingChanged = onAlbumMappingChanged,
+                    onTrackMappingChanged = onTrackMappingChanged,
                 )
             } else if (tabs.isEmpty()) {
                 heroSlot()
@@ -949,7 +956,8 @@ private fun ArtistContent(
     providerIconFetcher: @Composable (Modifier, String) -> Unit,
     contentPadding: PaddingValues,
     heroSlot: @Composable () -> Unit,
-    onMappingSelected: (ProviderMapping) -> Unit,
+    onAlbumMappingChanged: (ProviderMapping) -> Unit,
+    onTrackMappingChanged: (ProviderMapping) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.testTag(ItemDetailsScreenSemantics.LIST_TAG),
@@ -973,48 +981,19 @@ private fun ArtistContent(
 
             if (sections.all is DataState.Data) {
                 val all = sections.all.data
+
                 item {
                     val rowTitle = stringResource(Res.string.artist_section_all)
                     CategoryRow(
                         title = rowTitle,
                         actions = {
                             if (artist.providerMappings != null) {
-                                Box {
-                                    var expanded by remember { mutableStateOf(false) }
-
-                                    val provider = all.domain
-                                    val chipContentDescription = stringResource(
-                                        Res.string.cd_provider_filter,
-                                        rowTitle,
-                                        provider,
-                                    )
-
-                                    FilterChip(
-                                        modifier = Modifier.semantics {
-                                            contentDescription = chipContentDescription
-                                        },
-                                        selected = true,
-                                        onClick = { expanded = true },
-                                        label = {
-                                            Text(provider)
-                                        },
-                                    )
-
-                                    DropdownMenu(
-                                        expanded = expanded,
-                                        onDismissRequest = { expanded = false },
-                                    ) {
-                                        artist.providerMappings.forEach {
-                                            DropdownMenuItem(
-                                                text = { Text(it.providerDomain) },
-                                                onClick = {
-                                                    expanded = false
-                                                    onMappingSelected(it)
-                                                },
-                                            )
-                                        }
-                                    }
-                                }
+                                ProviderSelector(
+                                    currentProvider = all.domain,
+                                    subject = rowTitle,
+                                    onMappingSelected = onAlbumMappingChanged,
+                                    providerMappings = artist.providerMappings,
+                                )
                             }
                         },
                         mediaItems = all.items,
@@ -1028,10 +1007,23 @@ private fun ArtistContent(
             }
 
             if (sections.topTracks is DataState.Data) {
+                val topTracks = sections.topTracks.data
+
                 item {
+                    val rowTitle = stringResource(Res.string.artist_section_top)
                     CategoryRow(
-                        title = stringResource(Res.string.artist_section_top),
-                        mediaItems = sections.topTracks.data,
+                        title = rowTitle,
+                        actions = {
+                            if (artist.providerMappings != null) {
+                                ProviderSelector(
+                                    currentProvider = topTracks.domain,
+                                    subject = rowTitle,
+                                    onMappingSelected = onTrackMappingChanged,
+                                    providerMappings = artist.providerMappings,
+                                )
+                            }
+                        },
+                        mediaItems = sections.topTracks.data.items,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,
@@ -1042,6 +1034,51 @@ private fun ArtistContent(
             }
         } else {
             item { CenteredText(stringResource(Res.string.library_empty)) }
+        }
+    }
+}
+
+@Composable
+private fun ProviderSelector(
+    currentProvider: String,
+    subject: String,
+    onMappingSelected: (ProviderMapping) -> Unit,
+    providerMappings: List<ProviderMapping>,
+) {
+    Box {
+        var expanded by remember { mutableStateOf(false) }
+
+        val provider = currentProvider
+        val chipContentDescription = stringResource(
+            Res.string.cd_provider_filter,
+            subject,
+            provider,
+        )
+
+        FilterChip(
+            modifier = Modifier.semantics {
+                contentDescription = chipContentDescription
+            },
+            selected = true,
+            onClick = { expanded = true },
+            label = {
+                Text(provider)
+            },
+        )
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            providerMappings.forEach {
+                DropdownMenuItem(
+                    text = { Text(it.providerDomain) },
+                    onClick = {
+                        expanded = false
+                        onMappingSelected(it)
+                    },
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -92,6 +92,7 @@ import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.items.AlbumWithMenu
 import io.music_assistant.client.ui.compose.common.items.ArtistWithMenu
 import io.music_assistant.client.ui.compose.common.items.CategoryRow
+import io.music_assistant.client.ui.compose.common.items.ItemCategory
 import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlayHandler
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
@@ -106,6 +107,7 @@ import io.music_assistant.client.ui.compose.common.providers.ProviderIcon
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberDynamicColorsEnabled
 import io.music_assistant.client.ui.compose.common.rememberExtractedColorsSource
+import io.music_assistant.client.ui.compose.common.toDisplayString
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.fullBleed
@@ -929,19 +931,15 @@ private fun ArtistContent(
         if (sections.isNotEmpty()) {
             if (sections.library is DataState.Data) {
                 item {
-                    val rowTitle = stringResource(Res.string.artist_section_in_library)
+                    val itemCategory = ItemCategory<Nothing>(
+                        id = "library",
+                        title = Res.string.artist_section_in_library.toDisplayString(),
+                        items = sections.library.data.items,
+                        list = sections.library.data.itemList,
+                    )
+
                     CategoryRow(
-                        title = rowTitle,
-                        actions = {
-                            if (sections.library.data.itemList != null) {
-                                ViewAllButton(
-                                    rowTitle = rowTitle,
-                                    onNavigateToList = onNavigateToList,
-                                    itemList = sections.library.data.itemList,
-                                )
-                            }
-                        },
-                        mediaItems = sections.library.data.items,
+                        itemCategory = itemCategory,
                         onNavigateClick = onNavigateClick,
                         onPlayClick = onPlayChildClick,
                         playlistActions = playlistActions,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTab.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsTab.kt
@@ -4,7 +4,6 @@ import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.SubItemContext
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
-import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.Playlist
@@ -19,8 +18,6 @@ enum class ItemDetailsTab(
     val sortContext: SubItemContext?,
     val viewMediaType: MediaType?,
 ) {
-    ARTIST_ALBUMS(SubItemContext.ARTIST_ALBUMS, MediaType.ALBUM),
-    ARTIST_TRACKS(SubItemContext.ARTIST_TRACKS, MediaType.TRACK),
     ALBUM_TRACKS(SubItemContext.ALBUM_TRACKS, MediaType.TRACK),
     PLAYLIST_ITEMS(SubItemContext.PLAYLIST_ITEMS, MediaType.TRACK),
     PODCAST_EPISODES(SubItemContext.PODCAST_EPISODES, MediaType.TRACK),
@@ -30,7 +27,6 @@ enum class ItemDetailsTab(
 }
 
 fun tabsFor(item: AppMediaItem): List<ItemDetailsTab> = when (item) {
-    is Artist -> listOf(ItemDetailsTab.ARTIST_ALBUMS, ItemDetailsTab.ARTIST_TRACKS)
     is Album -> listOf(ItemDetailsTab.ALBUM_TRACKS)
     is Playlist -> listOf(ItemDetailsTab.PLAYLIST_ITEMS)
     is Podcast -> listOf(ItemDetailsTab.PODCAST_EPISODES)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -701,12 +701,6 @@ data class ArtistSections(
     val all: DataState<Section<Album>> = DataState.Loading(),
     val topTracks: DataState<Section<Track>> = DataState.Loading(),
 ) {
-    fun isNotEmpty(): Boolean {
-        return (library is DataState.Data && library.data.items.isNotEmpty()) ||
-                (all is DataState.Data && all.data.items.isNotEmpty()) ||
-                (topTracks is DataState.Data && topTracks.data.items.isNotEmpty())
-    }
-
     companion object {
         fun loading() =
             ArtistSections(DataState.Loading(), DataState.Loading(), DataState.Loading())

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -52,7 +52,7 @@ class ItemDetailsViewModel(
          * these back the ARTIST_ALBUMS / ARTIST_TRACKS tabs instead of [albumsState] /
          * [playableItemsState]. Null for non-artist items.
          */
-        val artistSections: ArtistSections? = null,
+        val artistSections: ArtistSections = ArtistSections(),
         /** Lazily loaded on demand from the artist overflow menu; NoData until then. */
         val similarArtistsState: DataState<List<Artist>> = DataState.NoData(),
         val albumsSortOption: SortOption? = null,
@@ -261,7 +261,7 @@ class ItemDetailsViewModel(
 
                 _state.update {
                     it.copy(
-                        artistSections = (it.artistSections ?: ArtistSections()).copy(
+                        artistSections = it.artistSections.copy(
                             library = DataState.Data(library),
                         ),
                     )
@@ -289,7 +289,7 @@ class ItemDetailsViewModel(
 
             _state.update {
                 it.copy(
-                    artistSections = (it.artistSections ?: ArtistSections()).copy(
+                    artistSections = it.artistSections.copy(
                         all = DataState.Data(ProviderList(mapping.providerDomain, albums)),
                     ),
                 )
@@ -308,7 +308,7 @@ class ItemDetailsViewModel(
 
             _state.update {
                 it.copy(
-                    artistSections = (it.artistSections ?: ArtistSections()).copy(
+                    artistSections = it.artistSections.copy(
                         topTracks = DataState.Data(tracks),
                     ),
                 )
@@ -586,7 +586,7 @@ class ItemDetailsViewModel(
             }
 
             is Album -> {
-                _state.value.artistSections?.let { sections ->
+                _state.value.artistSections.let { sections ->
                     _state.update { s ->
                         s.copy(
                             artistSections = sections.copy(
@@ -597,8 +597,8 @@ class ItemDetailsViewModel(
                             ),
                         )
                     }
-                    return
                 }
+
                 val albumsData = (_state.value.albumsState as? DataState.Data)?.data ?: return
                 val updated = albumsData.map { if (it.itemId == changed.itemId) changed else it }
                 rawAlbums = rawAlbums.map { if (it.itemId == changed.itemId) changed else it }
@@ -606,6 +606,18 @@ class ItemDetailsViewModel(
             }
 
             is PlayableItem -> {
+                if (changed is Track) {
+                    _state.value.artistSections.let { sections ->
+                        _state.update { s ->
+                            s.copy(
+                                artistSections = sections.copy(
+                                    topTracks = sections.topTracks.mapData { it.replacing(changed) },
+                                ),
+                            )
+                        }
+                    }
+                }
+
                 val tracksData =
                     (_state.value.playableItemsState as? DataState.Data)?.data ?: return
                 val updated = tracksData.map { existing ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -53,7 +53,6 @@ class ItemDetailsViewModel(
          * [playableItemsState]. Null for non-artist items.
          */
         val artistAlbumSections: ArtistSections<Album>? = null,
-        val artistTrackSections: ArtistSections<Track>? = null,
         /** Lazily loaded on demand from the artist overflow menu; NoData until then. */
         val similarArtistsState: DataState<List<Artist>> = DataState.NoData(),
         val albumsSortOption: SortOption? = null,
@@ -82,10 +81,6 @@ class ItemDetailsViewModel(
 
     private var rawAlbums: List<Album> = emptyList()
     private var rawPlayableItems: List<PlayableItem> = emptyList()
-
-    // Unsorted per-section caches for the artist tabs, so a sort change re-sorts without refetching
-    // (Top intentionally keeps server order, so it's never re-sorted). Mirror [rawAlbums].
-    private val rawArtistTracks = RawSections<Track>()
 
     private val _toasts = MutableSharedFlow<String>()
     val toasts = _toasts.asSharedFlow()
@@ -174,13 +169,11 @@ class ItemDetailsViewModel(
                         albumsState = DataState.NoData(),
                         playableItemsState = DataState.NoData(),
                         artistAlbumSections = ArtistSections.loading(),
-                        artistTrackSections = ArtistSections.loading(),
                         albumsSortOption = settingsRepository.getSortOption(SubItemContext.ARTIST_ALBUMS),
                         playableItemsSortOption = settingsRepository.getSortOption(SubItemContext.ARTIST_TRACKS),
                     )
                 }
                 loadArtistAlbumSections(item)
-                loadArtistTrackSections(item)
                 // Prefetch similar artists in the background so the sheet opens warm: the server's
                 // first per-artist lookup (lastfm + matching) is the slow part, so we pay it while
                 // the user browses albums/tracks rather than on the menu tap.
@@ -268,17 +261,6 @@ class ItemDetailsViewModel(
             listOf(itemId to provider)
         }
 
-    /** First source (in order) whose [fetch] returns items, paired with those items; else null + []. */
-    private suspend fun <T> List<Pair<String, String>>.firstNonEmpty(
-        fetch: suspend (String, String) -> List<T>,
-    ): Pair<Pair<String, String>?, List<T>> {
-        for (src in this) {
-            val items = fetch(src.first, src.second)
-            if (items.isNotEmpty()) return src to items
-        }
-        return null to emptyList()
-    }
-
     private suspend fun fetchArtistItems(request: Request): List<AppMediaItem> =
         mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
 
@@ -311,53 +293,6 @@ class ItemDetailsViewModel(
             } catch (e: Exception) {
                 Logger.e("Failed to load artist album sections", e)
                 _state.update { it.copy(artistAlbumSections = ArtistSections.error()) }
-            }
-        }
-    }
-
-    private fun loadArtistTrackSections(artist: Artist) {
-        viewModelScope.launch {
-            try {
-                val sort = _state.value.playableItemsSortOption
-                    ?: SortConfig.defaultFor(SubItemContext.ARTIST_TRACKS)
-                val library = if (artist.isInLibrary) {
-                    fetchArtistItems(Request.Artist.getTracks(artist.itemId, artist.provider))
-                        .filterIsInstance<Track>()
-                } else {
-                    emptyList()
-                }
-                val sources = artist.subItemSources()
-                val (_, all) = sources.firstNonEmpty { id, prov ->
-                    fetchArtistItems(Request.Artist.getTracks(id, prov)).filterIsInstance<Track>()
-                }
-                val (_, top) = sources.firstNonEmpty { id, prov ->
-                    fetchArtistItems(
-                        Request.Artist.getTopTracks(
-                            id,
-                            prov,
-                        ),
-                    ).filterIsInstance<Track>()
-                }
-
-                rawArtistTracks.set(library, top)
-                _state.update {
-                    it.copy(
-                        artistTrackSections = ArtistSections(
-                            library = library.sectionState(artist.isInLibrary) {
-                                clientSorted(sort, SubItemContext.ARTIST_TRACKS)
-                            },
-                            all = DataState.Data(
-                                all.clientSorted(
-                                    sort,
-                                    SubItemContext.ARTIST_TRACKS,
-                                ),
-                            ),
-                        ),
-                    )
-                }
-            } catch (e: Exception) {
-                Logger.e("Failed to load artist track sections", e)
-                _state.update { it.copy(artistTrackSections = ArtistSections.error()) }
             }
         }
     }
@@ -605,36 +540,15 @@ class ItemDetailsViewModel(
     fun onPlayableItemsSortChanged(context: SubItemContext, sortOption: SortOption) {
         settingsRepository.setSortOption(context, sortOption)
         _state.update { st ->
-            val sections = st.artistTrackSections
-            if (sections != null) {
-                st.copy(
-                    playableItemsSortOption = sortOption,
-                    artistTrackSections = sections.copy(
-                        library = sections.library.reSorted(
-                            rawArtistTracks.library.clientSorted(
-                                sortOption,
-                                context,
-                            ),
-                        ),
-                        all = sections.all.reSorted(
-                            rawArtistTracks.all.clientSorted(
-                                sortOption,
-                                context,
-                            ),
-                        ),
+            st.copy(
+                playableItemsSortOption = sortOption,
+                playableItemsState = DataState.Data(
+                    rawPlayableItems.clientSorted(
+                        sortOption,
+                        context,
                     ),
-                )
-            } else {
-                st.copy(
-                    playableItemsSortOption = sortOption,
-                    playableItemsState = DataState.Data(
-                        rawPlayableItems.clientSorted(
-                            sortOption,
-                            context,
-                        ),
-                    ),
-                )
-            }
+                ),
+            )
         }
     }
 
@@ -666,15 +580,6 @@ class ItemDetailsViewModel(
             }
 
             is PlayableItem -> {
-                (changed as? Track)?.let { track ->
-                    _state.value.artistTrackSections?.let { sections ->
-                        rawArtistTracks.replace(track)
-                        _state.update { s ->
-                            s.copy(artistTrackSections = sections.mapData { it.replacing(track) })
-                        }
-                        return
-                    }
-                }
                 val tracksData =
                     (_state.value.playableItemsState as? DataState.Data)?.data ?: return
                 val updated = tracksData.map { existing ->
@@ -738,32 +643,6 @@ data class ArtistSections<T>(
         fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
     }
 }
-
-/** Mutable unsorted caches for an artist tab's three subsections; see [ItemDetailsViewModel.rawArtistAlbums]. */
-private class RawSections<T : AppMediaItem> {
-    var library: List<T> = emptyList()
-    var all: List<T> = emptyList()
-
-    fun set(library: List<T>, all: List<T>) {
-        this.library = library
-        this.all = all
-    }
-
-    fun replace(changed: T) {
-        library = library.replacing(changed)
-        all = all.replacing(changed)
-    }
-}
-
-/** NoData when [inLibrary] is false; otherwise Data of the [transform]ed (sorted) list. */
-private inline fun <T> List<T>.sectionState(
-    inLibrary: Boolean,
-    transform: List<T>.() -> List<T>,
-): DataState<List<T>> = if (inLibrary) DataState.Data(transform()) else DataState.NoData()
-
-/** Replace a Data section's contents with [sorted]; leave non-Data (NoData/Error) untouched. */
-private fun <T> DataState<List<T>>.reSorted(sorted: List<T>): DataState<List<T>> =
-    if (this is DataState.Data) DataState.Data(sorted) else this
 
 private inline fun <T> DataState<List<T>>.mapData(transform: (List<T>) -> List<T>): DataState<List<T>> =
     if (this is DataState.Data) DataState.Data(transform(data)) else this

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -28,9 +28,7 @@ import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.mapData
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -83,9 +81,6 @@ class ItemDetailsViewModel(
 
     private var rawAlbums: List<Album> = emptyList()
     private var rawPlayableItems: List<PlayableItem> = emptyList()
-
-    private val _toasts = MutableSharedFlow<String>()
-    val toasts = _toasts.asSharedFlow()
 
     fun viewMode(mediaType: MediaType) = settingsRepository.viewMode(mediaType)
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -277,33 +277,29 @@ class ItemDetailsViewModel(
             }
         }
 
-        val mappings = artist.providerMappings ?: emptyList()
         viewModelScope.launch {
-            val results = mappings.map {
-                val itemId = it.itemId
-                val providerInstance = it.providerInstance
+            val list = ItemUseCases.fetchArtistItemsAcrossProviders<Album>(
+                mediaItemRepository,
+                artist,
+            ) { itemId, providerInstance ->
+                Request.Artist.getAlbums(
+                    itemId,
+                    providerInstance,
+                )
+            }
 
-                val albums = fetchArtistItems(
-                    Request.Artist.getAlbums(
-                        itemId,
-                        providerInstance,
-                    ),
-                ).filterIsInstance<Album>()
-
-                it to albums
-            }.filter { it.second.isNotEmpty() }
-
-            if (results.isNotEmpty()) {
-                val (mapping, albums) = results.first()
-
+            if (list != null) {
                 _state.update {
                     it.copy(
                         artistSections = it.artistSections.copy(
                             all = DataState.Data(
                                 Section(
-                                    albums.take(ARTIST_SECTION_LIMIT),
-                                    providerDomain = mapping.providerDomain,
-                                    itemList = ItemList.ArtistAlbums(mapping.providerInstance, itemId),
+                                    list.items.take(ARTIST_SECTION_LIMIT),
+                                    providerDomain = list.mapping.providerDomain,
+                                    itemList = ItemList.ArtistAlbums(
+                                        list.mapping.providerInstance,
+                                        itemId,
+                                    ),
                                 ),
                             ),
                         ),
@@ -313,32 +309,29 @@ class ItemDetailsViewModel(
         }
 
         viewModelScope.launch {
-            val results = mappings.map {
-                val itemId = it.itemId
-                val providerInstance = it.providerInstance
+            val list = ItemUseCases.fetchArtistItemsAcrossProviders<Track>(
+                mediaItemRepository,
+                artist,
+            ) { itemId, providerInstance ->
+                Request.Artist.getTopTracks(
+                    itemId,
+                    providerInstance,
+                )
+            }
 
-                val tracks = fetchArtistItems(
-                    Request.Artist.getTopTracks(
-                        itemId,
-                        providerInstance,
-                    ),
-                ).filterIsInstance<Track>()
-
-                it to tracks
-            }.filter { it.second.isNotEmpty() }
-
-            if (results.isNotEmpty()) {
-                val (mapping, tracks) = results.first()
-
+            if (list != null) {
                 _state.update {
                     it.copy(
                         artistSections = it.artistSections.copy(
                             topTracks = DataState.Data(
                                 Section(
-                                    tracks.take(ARTIST_SECTION_LIMIT),
-                                    providerDomain = mapping.providerDomain,
+                                    list.items.take(ARTIST_SECTION_LIMIT),
+                                    providerDomain = list.mapping.providerDomain,
                                     itemList =
-                                        ItemList.ArtistTopTracks(mapping.providerInstance, itemId),
+                                        ItemList.ArtistTopTracks(
+                                            list.mapping.providerInstance,
+                                            itemId,
+                                        ),
                                 ),
                             ),
                         ),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -296,11 +296,14 @@ class ItemDetailsViewModel(
                 }
 
                 val sources = artist.subItemSources()
-                val all = sources.flatMap { (id, prov) ->
-                    fetchArtistItems(Request.Artist.getAlbums(id, prov)).filterIsInstance<Album>()
+                val albumsByProvider = sources.associate { (instance, domain) ->
+                    domain to fetchArtistItems(Request.Artist.getAlbums(instance, domain))
+                        .filterIsInstance<Album>()
                 }
 
+                val all = albumsByProvider[sources.first().second]!!
                 rawArtistAlbums.set(library, all)
+
                 _state.update {
                     it.copy(
                         artistAlbumSections = ArtistSections(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -250,18 +250,6 @@ class ItemDetailsViewModel(
         }
     }
 
-    /**
-     * Ordered candidate `(itemId, provider)` sources for an artist's All sub-lists. A library
-     * artist fans out over its provider mappings (its own "library" identity would only return the
-     * owned subset); a non-library artist is already its own source.
-     */
-    private fun Artist.subItemSources(): List<Pair<String, String>> =
-        if (isInLibrary) {
-            providerMappings?.map { it.itemId to it.providerInstance } ?: emptyList()
-        } else {
-            listOf(itemId to provider)
-        }
-
     private suspend fun fetchArtistItems(request: Request): List<AppMediaItem> =
         mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
 
@@ -275,13 +263,18 @@ class ItemDetailsViewModel(
                     emptyList()
                 }
 
-                val sources = artist.subItemSources()
-                val albumsByProvider = sources.associate { (instance, domain) ->
-                    domain to fetchArtistItems(Request.Artist.getAlbums(instance, domain))
+                val sources = artist.providerMappings ?: emptyList()
+                val albumsByProvider = sources.associate { (itemId, domain, instance) ->
+                    domain to fetchArtistItems(Request.Artist.getAlbums(itemId, instance))
                         .filterIsInstance<Album>()
                 }
 
-                val all = albumsByProvider[sources.first().second]!!
+                val firstProvider = albumsByProvider.entries.first()
+                val all = ProviderList(
+                    selectedDomain = firstProvider.key,
+                    items = firstProvider.value,
+                    options = albumsByProvider.keys.toList(),
+                )
 
                 _state.update {
                     it.copy(
@@ -628,22 +621,35 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
     else -> false
 }
 
-data class ArtistSections<T>(
+data class ArtistSections<T : AppMediaItem>(
     val library: DataState<List<T>> = DataState.NoData(),
-    val all: DataState<List<T>> = DataState.NoData(),
+    val all: DataState<ProviderList<T>> = DataState.NoData(),
 ) {
     fun mapData(transform: (List<T>) -> List<T>): ArtistSections<T> = copy(
         library = library.mapData(transform),
-        all = all.mapData(transform),
+        all = all.mapData {
+            it.copy(items = transform(it.items))
+        },
     )
 
+    fun isNotEmpty(): Boolean {
+        return (library is DataState.Data && library.data.isNotEmpty()) ||
+                (all is DataState.Data && all.data.items.isNotEmpty())
+    }
+
     companion object {
-        fun <T> loading() =
+        fun <T : AppMediaItem> loading() =
             ArtistSections<T>(DataState.Loading(), DataState.Loading())
 
-        fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
+        fun <T : AppMediaItem> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
     }
 }
+
+data class ProviderList<T : AppMediaItem>(
+    val selectedDomain: String,
+    val items: List<T>,
+    val options: List<String>,
+)
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
     map { if (it.itemId == changed.itemId) changed else it }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -733,8 +733,6 @@ private fun ItemDetailsViewModel.State.itemOrNull(): AppMediaItem? = when (itemS
 private fun ItemDetailsTab.subState(
     state: ItemDetailsViewModel.State,
 ): DataState<out List<Any>> = when (this) {
-    ItemDetailsTab.ARTIST_ALBUMS -> state.artistAlbumSections?.aggregate() ?: DataState.NoData()
-    ItemDetailsTab.ARTIST_TRACKS -> state.artistTrackSections?.aggregate() ?: DataState.NoData()
     ItemDetailsTab.GENRE_ALBUMS -> state.albumsState
     ItemDetailsTab.ALBUM_TRACKS,
     ItemDetailsTab.PLAYLIST_ITEMS,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -85,7 +85,6 @@ class ItemDetailsViewModel(
 
     // Unsorted per-section caches for the artist tabs, so a sort change re-sorts without refetching
     // (Top intentionally keeps server order, so it's never re-sorted). Mirror [rawAlbums].
-    private val rawArtistAlbums = RawSections<Album>()
     private val rawArtistTracks = RawSections<Track>()
 
     private val _toasts = MutableSharedFlow<String>()
@@ -286,8 +285,6 @@ class ItemDetailsViewModel(
     private fun loadArtistAlbumSections(artist: Artist) {
         viewModelScope.launch {
             try {
-                val sort = _state.value.albumsSortOption
-                    ?: SortConfig.defaultFor(SubItemContext.ARTIST_ALBUMS)
                 val library = if (artist.isInLibrary) {
                     fetchArtistItems(Request.Artist.getAlbums(artist.itemId, artist.provider))
                         .filterIsInstance<Album>()
@@ -302,13 +299,12 @@ class ItemDetailsViewModel(
                 }
 
                 val all = albumsByProvider[sources.first().second]!!
-                rawArtistAlbums.set(library, all)
 
                 _state.update {
                     it.copy(
                         artistAlbumSections = ArtistSections(
-                            library = library.sectionState(artist.isInLibrary) { clientSorted(sort) },
-                            all = DataState.Data(all.clientSorted(sort)),
+                            library = DataState.Data(library),
+                            all = DataState.Data(all),
                         ),
                     )
                 }
@@ -606,32 +602,6 @@ class ItemDetailsViewModel(
         }
     }
 
-    fun onAlbumsSortChanged(context: SubItemContext, sortOption: SortOption) {
-        settingsRepository.setSortOption(context, sortOption)
-        _state.update { st ->
-            // Artist tabs re-sort Library + All in place
-            val sections = st.artistAlbumSections
-            if (sections != null) {
-                st.copy(
-                    albumsSortOption = sortOption,
-                    artistAlbumSections = sections.copy(
-                        library = sections.library.reSorted(
-                            rawArtistAlbums.library.clientSorted(
-                                sortOption,
-                            ),
-                        ),
-                        all = sections.all.reSorted(rawArtistAlbums.all.clientSorted(sortOption)),
-                    ),
-                )
-            } else {
-                st.copy(
-                    albumsSortOption = sortOption,
-                    albumsState = DataState.Data(rawAlbums.clientSorted(sortOption)),
-                )
-            }
-        }
-    }
-
     fun onPlayableItemsSortChanged(context: SubItemContext, sortOption: SortOption) {
         settingsRepository.setSortOption(context, sortOption)
         _state.update { st ->
@@ -684,7 +654,6 @@ class ItemDetailsViewModel(
 
             is Album -> {
                 _state.value.artistAlbumSections?.let { sections ->
-                    rawArtistAlbums.replace(changed)
                     _state.update { s ->
                         s.copy(artistAlbumSections = sections.mapData { it.replacing(changed) })
                     }
@@ -757,20 +726,6 @@ data class ArtistSections<T>(
     val library: DataState<List<T>> = DataState.NoData(),
     val all: DataState<List<T>> = DataState.NoData(),
 ) {
-    /** Loading while any section is; otherwise the concatenation, for tab loading/selection checks. */
-    fun aggregate(): DataState<List<T>> = when {
-        library is DataState.Loading  || all is DataState.Loading ->
-            DataState.Loading()
-
-        else -> DataState.Data(
-            (library.dataOrNull ?: emptyList()) + (all.dataOrNull ?: emptyList()),
-        )
-    }
-
-    /** Ordered (label-bearing) sections for rendering; callers skip the empty ones. */
-    fun ordered(): List<Pair<ArtistSection, DataState<List<T>>>> =
-        listOf(ArtistSection.LIBRARY to library, ArtistSection.ALL to all)
-
     fun mapData(transform: (List<T>) -> List<T>): ArtistSections<T> = copy(
         library = library.mapData(transform),
         all = all.mapData(transform),
@@ -783,8 +738,6 @@ data class ArtistSections<T>(
         fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
     }
 }
-
-enum class ArtistSection { LIBRARY, ALL }
 
 /** Mutable unsorted caches for an artist tab's three subsections; see [ItemDetailsViewModel.rawArtistAlbums]. */
 private class RawSections<T : AppMediaItem> {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -262,7 +262,7 @@ class ItemDetailsViewModel(
                 _state.update {
                     it.copy(
                         artistSections = it.artistSections.copy(
-                            library = DataState.Data(library),
+                            library = DataState.Data(Section(library)),
                         ),
                     )
                 }
@@ -280,17 +280,26 @@ class ItemDetailsViewModel(
 
     fun loadAlbumsForProvider(mapping: ProviderMapping) {
         viewModelScope.launch {
+            val itemId = mapping.itemId
+            val providerInstance = mapping.providerInstance
+
             val albums = fetchArtistItems(
                 Request.Artist.getAlbums(
-                    mapping.itemId,
-                    mapping.providerInstance,
+                    itemId,
+                    providerInstance,
                 ),
             ).filterIsInstance<Album>()
 
             _state.update {
                 it.copy(
                     artistSections = it.artistSections.copy(
-                        all = DataState.Data(ProviderList(mapping.providerDomain, albums)),
+                        all = DataState.Data(
+                            Section(
+                                albums,
+                                providerDomain = mapping.providerDomain,
+                                itemList = ItemList.ArtistAlbums(providerInstance, itemId),
+                            ),
+                        ),
                     ),
                 )
             }
@@ -309,7 +318,7 @@ class ItemDetailsViewModel(
             _state.update {
                 it.copy(
                     artistSections = it.artistSections.copy(
-                        topTracks = DataState.Data(ProviderList(mapping.providerDomain, tracks)),
+                        topTracks = DataState.Data(Section(tracks, providerDomain = mapping.providerDomain)),
                     ),
                 )
             }
@@ -590,7 +599,9 @@ class ItemDetailsViewModel(
                     _state.update { s ->
                         s.copy(
                             artistSections = sections.copy(
-                                library = sections.library.mapData { it.replacing(changed) },
+                                library = sections.library.mapData {
+                                    it.copy(items = it.items.replacing(changed))
+                                },
                                 all = sections.all.mapData {
                                     it.copy(items = it.items.replacing(changed))
                                 },
@@ -668,25 +679,28 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
 }
 
 data class ArtistSections(
-    val library: DataState<List<Album>> = DataState.NoData(),
-    val all: DataState<ProviderList<Album>> = DataState.NoData(),
-    val topTracks: DataState<ProviderList<Track>> = DataState.NoData(),
+    val library: DataState<Section<Album>> = DataState.NoData(),
+    val all: DataState<Section<Album>> = DataState.NoData(),
+    val topTracks: DataState<Section<Track>> = DataState.NoData(),
 ) {
     fun isNotEmpty(): Boolean {
-        return (library is DataState.Data && library.data.isNotEmpty()) ||
+        return (library is DataState.Data && library.data.items.isNotEmpty()) ||
                 (all is DataState.Data && all.data.items.isNotEmpty()) ||
                 (topTracks is DataState.Data && topTracks.data.items.isNotEmpty())
     }
 
     companion object {
-        fun loading() = ArtistSections(DataState.Loading(), DataState.Loading(), DataState.Loading())
+        fun loading() =
+            ArtistSections(DataState.Loading(), DataState.Loading(), DataState.Loading())
+
         fun error() = ArtistSections(DataState.Error(), DataState.Error(), DataState.Error())
     }
 }
 
-data class ProviderList<T : AppMediaItem>(
-    val domain: String,
+data class Section<T : AppMediaItem>(
     val items: List<T>,
+    val itemList: ItemList? = null,
+    val providerDomain: String? = null,
 )
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -278,9 +278,74 @@ class ItemDetailsViewModel(
         }
 
         val mappings = artist.providerMappings ?: emptyList()
-        val firstMapping = mappings.first()
-        loadAlbumsForProvider(firstMapping)
-        loadTopTracksForProvider(firstMapping)
+        viewModelScope.launch {
+            val results = mappings.map {
+                val itemId = it.itemId
+                val providerInstance = it.providerInstance
+
+                val albums = fetchArtistItems(
+                    Request.Artist.getAlbums(
+                        itemId,
+                        providerInstance,
+                    ),
+                ).filterIsInstance<Album>()
+
+                it to albums
+            }.filter { it.second.isNotEmpty() }
+
+            if (results.isNotEmpty()) {
+                val (mapping, albums) = results.first()
+
+                _state.update {
+                    it.copy(
+                        artistSections = it.artistSections.copy(
+                            all = DataState.Data(
+                                Section(
+                                    albums.take(ARTIST_SECTION_LIMIT),
+                                    providerDomain = mapping.providerDomain,
+                                    itemList = ItemList.ArtistAlbums(mapping.providerInstance, itemId),
+                                ),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            val results = mappings.map {
+                val itemId = it.itemId
+                val providerInstance = it.providerInstance
+
+                val tracks = fetchArtistItems(
+                    Request.Artist.getTopTracks(
+                        itemId,
+                        providerInstance,
+                    ),
+                ).filterIsInstance<Track>()
+
+                it to tracks
+            }.filter { it.second.isNotEmpty() }
+
+            if (results.isNotEmpty()) {
+                val (mapping, tracks) = results.first()
+
+                _state.update {
+                    it.copy(
+                        artistSections = it.artistSections.copy(
+                            topTracks = DataState.Data(
+                                Section(
+                                    tracks.take(ARTIST_SECTION_LIMIT),
+                                    providerDomain = mapping.providerDomain,
+                                    itemList =
+                                        ItemList.ArtistTopTracks(mapping.providerInstance, itemId),
+                                ),
+                            ),
+                        ),
+                    )
+                }
+            }
+        }
     }
 
     fun loadAlbumsForProvider(mapping: ProviderMapping) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -273,7 +273,13 @@ class ItemDetailsViewModel(
                 }
             } catch (e: Exception) {
                 Logger.e("Failed to load artist album sections", e)
-                _state.update { it.copy(artistSections = ArtistSections.error()) }
+                _state.update {
+                    it.copy(
+                        artistSections = it.artistSections.copy(
+                            library = DataState.Error(),
+                        ),
+                    )
+                }
             }
         }
 
@@ -298,10 +304,18 @@ class ItemDetailsViewModel(
                                     providerDomain = list.mapping.providerDomain,
                                     itemList = ItemList.ArtistAlbums(
                                         list.mapping.providerInstance,
-                                        itemId,
+                                        list.mapping.itemId,
                                     ),
                                 ),
                             ),
+                        ),
+                    )
+                }
+            } else {
+                _state.update {
+                    it.copy(
+                        artistSections = it.artistSections.copy(
+                            all = DataState.Error(),
                         ),
                     )
                 }
@@ -327,13 +341,20 @@ class ItemDetailsViewModel(
                                 Section(
                                     list.items.take(ARTIST_SECTION_LIMIT),
                                     providerDomain = list.mapping.providerDomain,
-                                    itemList =
-                                        ItemList.ArtistTopTracks(
-                                            list.mapping.providerInstance,
-                                            itemId,
-                                        ),
+                                    itemList = ItemList.ArtistTopTracks(
+                                        list.mapping.providerInstance,
+                                        list.mapping.itemId,
+                                    ),
                                 ),
                             ),
+                        ),
+                    )
+                }
+            } else {
+                _state.update {
+                    it.copy(
+                        artistSections = it.artistSections.copy(
+                            topTracks = DataState.Error(),
                         ),
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -48,7 +48,7 @@ class ItemDetailsViewModel(
         val playableItemsState: DataState<List<PlayableItem>>,
         val artistsState: DataState<List<Artist>> = DataState.Loading(),
         /**
-         * An artist's Albums / Tracks tabs are split into Library / Top / All sub-sections;
+         * An artist's Albums / Tracks tabs are split into Library / All sub-sections;
          * these back the ARTIST_ALBUMS / ARTIST_TRACKS tabs instead of [albumsState] /
          * [playableItemsState]. Null for non-artist items.
          */
@@ -258,7 +258,7 @@ class ItemDetailsViewModel(
     }
 
     /**
-     * Ordered candidate `(itemId, provider)` sources for an artist's Top/All sub-lists. A library
+     * Ordered candidate `(itemId, provider)` sources for an artist's All sub-lists. A library
      * artist fans out over its provider mappings (its own "library" identity would only return the
      * owned subset); a non-library artist is already its own source.
      */
@@ -294,28 +294,17 @@ class ItemDetailsViewModel(
                 } else {
                     emptyList()
                 }
-                // All and Top are resolved independently: each takes the first source provider that
-                // returns items for that query. A provider can expose All albums but no Top (or vice
-                // versa), so coupling them to one provider would hide a section that actually exists.
+
                 val sources = artist.subItemSources()
                 val (_, all) = sources.firstNonEmpty { id, prov ->
                     fetchArtistItems(Request.Artist.getAlbums(id, prov)).filterIsInstance<Album>()
                 }
-                val (_, top) = sources.firstNonEmpty { id, prov ->
-                    fetchArtistItems(
-                        Request.Artist.getTopAlbums(
-                            id,
-                            prov,
-                        ),
-                    ).filterIsInstance<Album>()
-                }
 
-                rawArtistAlbums.set(library, top, all)
+                rawArtistAlbums.set(library, all)
                 _state.update {
                     it.copy(
                         artistAlbumSections = ArtistSections(
                             library = library.sectionState(artist.isInLibrary) { clientSorted(sort) },
-                            top = DataState.Data(top),
                             all = DataState.Data(all.clientSorted(sort)),
                         ),
                     )
@@ -351,14 +340,13 @@ class ItemDetailsViewModel(
                     ).filterIsInstance<Track>()
                 }
 
-                rawArtistTracks.set(library, top, all)
+                rawArtistTracks.set(library, top)
                 _state.update {
                     it.copy(
                         artistTrackSections = ArtistSections(
                             library = library.sectionState(artist.isInLibrary) {
                                 clientSorted(sort, SubItemContext.ARTIST_TRACKS)
                             },
-                            top = DataState.Data(top),
                             all = DataState.Data(
                                 all.clientSorted(
                                     sort,
@@ -618,7 +606,7 @@ class ItemDetailsViewModel(
     fun onAlbumsSortChanged(context: SubItemContext, sortOption: SortOption) {
         settingsRepository.setSortOption(context, sortOption)
         _state.update { st ->
-            // Artist tabs re-sort Library + All in place; Top stays in server order.
+            // Artist tabs re-sort Library + All in place
             val sections = st.artistAlbumSections
             if (sections != null) {
                 st.copy(
@@ -739,7 +727,7 @@ private fun ItemDetailsViewModel.State.itemOrNull(): AppMediaItem? = when (itemS
 
 /**
  * The [DataState] driving this tab's loading/selection. For the artist tabs it's the aggregate of
- * the Library/Top/All sub-sections; for the others, the single backing list. Chapters are carried
+ * the Library/All sub-sections; for the others, the single backing list. Chapters are carried
  * by the item itself.
  */
 private fun ItemDetailsTab.subState(
@@ -764,62 +752,51 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
     else -> false
 }
 
-/**
- * An artist tab's three sub-sections. Order of display is Library → Top → All; each is hidden when
- * it has no items. [library] is [DataState.NoData] for non-library artists.
- */
 data class ArtistSections<T>(
     val library: DataState<List<T>> = DataState.NoData(),
-    val top: DataState<List<T>> = DataState.NoData(),
     val all: DataState<List<T>> = DataState.NoData(),
 ) {
     /** Loading while any section is; otherwise the concatenation, for tab loading/selection checks. */
     fun aggregate(): DataState<List<T>> = when {
-        library is DataState.Loading || top is DataState.Loading || all is DataState.Loading ->
+        library is DataState.Loading  || all is DataState.Loading ->
             DataState.Loading()
 
         else -> DataState.Data(
-            (library.dataOrNull ?: emptyList()) +
-                    (top.dataOrNull ?: emptyList()) +
-                    (all.dataOrNull ?: emptyList()),
+            (library.dataOrNull ?: emptyList()) + (all.dataOrNull ?: emptyList()),
         )
     }
 
     /** Ordered (label-bearing) sections for rendering; callers skip the empty ones. */
     fun ordered(): List<Pair<ArtistSection, DataState<List<T>>>> =
-        listOf(ArtistSection.LIBRARY to library, ArtistSection.TOP to top, ArtistSection.ALL to all)
+        listOf(ArtistSection.LIBRARY to library, ArtistSection.ALL to all)
 
     fun mapData(transform: (List<T>) -> List<T>): ArtistSections<T> = copy(
         library = library.mapData(transform),
-        top = top.mapData(transform),
         all = all.mapData(transform),
     )
 
     companion object {
         fun <T> loading() =
-            ArtistSections<T>(DataState.Loading(), DataState.Loading(), DataState.Loading())
+            ArtistSections<T>(DataState.Loading(), DataState.Loading())
 
-        fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error(), DataState.Error())
+        fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
     }
 }
 
-enum class ArtistSection { LIBRARY, TOP, ALL }
+enum class ArtistSection { LIBRARY, ALL }
 
 /** Mutable unsorted caches for an artist tab's three subsections; see [ItemDetailsViewModel.rawArtistAlbums]. */
 private class RawSections<T : AppMediaItem> {
     var library: List<T> = emptyList()
-    var top: List<T> = emptyList()
     var all: List<T> = emptyList()
 
-    fun set(library: List<T>, top: List<T>, all: List<T>) {
+    fun set(library: List<T>, all: List<T>) {
         this.library = library
-        this.top = top
         this.all = all
     }
 
     fun replace(changed: T) {
         library = library.replacing(changed)
-        top = top.replacing(changed)
         all = all.replacing(changed)
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -262,7 +262,12 @@ class ItemDetailsViewModel(
                 _state.update {
                     it.copy(
                         artistSections = it.artistSections.copy(
-                            library = DataState.Data(Section(library)),
+                            library = DataState.Data(
+                                Section(
+                                    items = library,
+                                    itemList = ItemList.ArtistLibrary(artist.itemId),
+                                ),
+                            ),
                         ),
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -26,6 +26,7 @@ import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.mapData
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -643,9 +644,6 @@ data class ArtistSections<T>(
         fun <T> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
     }
 }
-
-private inline fun <T> DataState<List<T>>.mapData(transform: (List<T>) -> List<T>): DataState<List<T>> =
-    if (this is DataState.Data) DataState.Data(transform(data)) else this
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =
     map { if (it.itemId == changed.itemId) changed else it }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -264,7 +264,7 @@ class ItemDetailsViewModel(
                         artistSections = it.artistSections.copy(
                             library = DataState.Data(
                                 Section(
-                                    items = library,
+                                    items = library.take(ARTIST_SECTION_LIMIT),
                                     itemList = ItemList.ArtistLibrary(artist.itemId),
                                 ),
                             ),
@@ -300,7 +300,7 @@ class ItemDetailsViewModel(
                     artistSections = it.artistSections.copy(
                         all = DataState.Data(
                             Section(
-                                albums,
+                                albums.take(ARTIST_SECTION_LIMIT),
                                 providerDomain = mapping.providerDomain,
                                 itemList = ItemList.ArtistAlbums(providerInstance, itemId),
                             ),
@@ -328,7 +328,7 @@ class ItemDetailsViewModel(
                     artistSections = it.artistSections.copy(
                         topTracks = DataState.Data(
                             Section(
-                                tracks,
+                                tracks.take(ARTIST_SECTION_LIMIT),
                                 providerDomain = mapping.providerDomain,
                                 itemList = ItemList.ArtistTopTracks(providerInstance, itemId),
                             ),
@@ -658,6 +658,10 @@ class ItemDetailsViewModel(
 
             else -> Unit
         }
+    }
+
+    companion object {
+        const val ARTIST_SECTION_LIMIT = 10
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -309,7 +309,7 @@ class ItemDetailsViewModel(
             _state.update {
                 it.copy(
                     artistSections = it.artistSections.copy(
-                        topTracks = DataState.Data(tracks),
+                        topTracks = DataState.Data(ProviderList(mapping.providerDomain, tracks)),
                     ),
                 )
             }
@@ -611,7 +611,9 @@ class ItemDetailsViewModel(
                         _state.update { s ->
                             s.copy(
                                 artistSections = sections.copy(
-                                    topTracks = sections.topTracks.mapData { it.replacing(changed) },
+                                    topTracks = sections.topTracks.mapData {
+                                        it.copy(items = it.items.replacing(changed))
+                                    },
                                 ),
                             )
                         }
@@ -668,17 +670,17 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
 data class ArtistSections(
     val library: DataState<List<Album>> = DataState.NoData(),
     val all: DataState<ProviderList<Album>> = DataState.NoData(),
-    val topTracks: DataState<List<Track>> = DataState.NoData(),
+    val topTracks: DataState<ProviderList<Track>> = DataState.NoData(),
 ) {
     fun isNotEmpty(): Boolean {
         return (library is DataState.Data && library.data.isNotEmpty()) ||
                 (all is DataState.Data && all.data.items.isNotEmpty()) ||
-                (topTracks is DataState.Data && topTracks.data.isNotEmpty())
+                (topTracks is DataState.Data && topTracks.data.items.isNotEmpty())
     }
 
     companion object {
-        fun loading() = ArtistSections(DataState.Loading(), DataState.Loading())
-        fun error() = ArtistSections(DataState.Error(), DataState.Error())
+        fun loading() = ArtistSections(DataState.Loading(), DataState.Loading(), DataState.Loading())
+        fun error() = ArtistSections(DataState.Error(), DataState.Error(), DataState.Error())
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -296,7 +296,7 @@ class ItemDetailsViewModel(
                 }
 
                 val sources = artist.subItemSources()
-                val (_, all) = sources.firstNonEmpty { id, prov ->
+                val all = sources.flatMap { (id, prov) ->
                     fetchArtistItems(Request.Artist.getAlbums(id, prov)).filterIsInstance<Album>()
                 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -308,17 +308,26 @@ class ItemDetailsViewModel(
 
     fun loadTopTracksForProvider(mapping: ProviderMapping) {
         viewModelScope.launch {
+            val itemId = mapping.itemId
+            val providerInstance = mapping.providerInstance
+
             val tracks = fetchArtistItems(
                 Request.Artist.getTopTracks(
-                    mapping.itemId,
-                    mapping.providerInstance,
+                    itemId,
+                    providerInstance,
                 ),
             ).filterIsInstance<Track>()
 
             _state.update {
                 it.copy(
                     artistSections = it.artistSections.copy(
-                        topTracks = DataState.Data(Section(tracks, providerDomain = mapping.providerDomain)),
+                        topTracks = DataState.Data(
+                            Section(
+                                tracks,
+                                providerDomain = mapping.providerDomain,
+                                itemList = ItemList.ArtistTopTracks(providerInstance, itemId),
+                            ),
+                        ),
                     ),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -697,9 +697,9 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
 }
 
 data class ArtistSections(
-    val library: DataState<Section<Album>> = DataState.NoData(),
-    val all: DataState<Section<Album>> = DataState.NoData(),
-    val topTracks: DataState<Section<Track>> = DataState.NoData(),
+    val library: DataState<Section<Album>> = DataState.Loading(),
+    val all: DataState<Section<Album>> = DataState.Loading(),
+    val topTracks: DataState<Section<Track>> = DataState.Loading(),
 ) {
     fun isNotEmpty(): Boolean {
         return (library is DataState.Data && library.data.items.isNotEmpty()) ||

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -52,7 +52,7 @@ class ItemDetailsViewModel(
          * these back the ARTIST_ALBUMS / ARTIST_TRACKS tabs instead of [albumsState] /
          * [playableItemsState]. Null for non-artist items.
          */
-        val artistAlbumSections: ArtistSections<Album>? = null,
+        val artistSections: ArtistSections? = null,
         /** Lazily loaded on demand from the artist overflow menu; NoData until then. */
         val similarArtistsState: DataState<List<Artist>> = DataState.NoData(),
         val albumsSortOption: SortOption? = null,
@@ -165,7 +165,7 @@ class ItemDetailsViewModel(
                     it.copy(
                         albumsState = DataState.NoData(),
                         playableItemsState = DataState.NoData(),
-                        artistAlbumSections = ArtistSections.loading(),
+                        artistSections = ArtistSections.loading(),
                         albumsSortOption = settingsRepository.getSortOption(SubItemContext.ARTIST_ALBUMS),
                         playableItemsSortOption = settingsRepository.getSortOption(SubItemContext.ARTIST_TRACKS),
                     )
@@ -250,9 +250,6 @@ class ItemDetailsViewModel(
         mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
 
     private fun loadArtistAlbumSections(artist: Artist) {
-        val mappings = artist.providerMappings ?: emptyList()
-        loadAlbumsForProvider(mappings.first())
-
         viewModelScope.launch {
             try {
                 val library = if (artist.isInLibrary) {
@@ -264,16 +261,21 @@ class ItemDetailsViewModel(
 
                 _state.update {
                     it.copy(
-                        artistAlbumSections = (it.artistAlbumSections ?: ArtistSections()).copy(
+                        artistSections = (it.artistSections ?: ArtistSections()).copy(
                             library = DataState.Data(library),
                         ),
                     )
                 }
             } catch (e: Exception) {
                 Logger.e("Failed to load artist album sections", e)
-                _state.update { it.copy(artistAlbumSections = ArtistSections.error()) }
+                _state.update { it.copy(artistSections = ArtistSections.error()) }
             }
         }
+
+        val mappings = artist.providerMappings ?: emptyList()
+        val firstMapping = mappings.first()
+        loadAlbumsForProvider(firstMapping)
+        loadTopTracksForProvider(firstMapping)
     }
 
     fun loadAlbumsForProvider(mapping: ProviderMapping) {
@@ -287,8 +289,27 @@ class ItemDetailsViewModel(
 
             _state.update {
                 it.copy(
-                    artistAlbumSections = (it.artistAlbumSections ?: ArtistSections()).copy(
+                    artistSections = (it.artistSections ?: ArtistSections()).copy(
                         all = DataState.Data(ProviderList(mapping.providerDomain, albums)),
+                    ),
+                )
+            }
+        }
+    }
+
+    fun loadTopTracksForProvider(mapping: ProviderMapping) {
+        viewModelScope.launch {
+            val tracks = fetchArtistItems(
+                Request.Artist.getTopTracks(
+                    mapping.itemId,
+                    mapping.providerInstance,
+                ),
+            ).filterIsInstance<Track>()
+
+            _state.update {
+                it.copy(
+                    artistSections = (it.artistSections ?: ArtistSections()).copy(
+                        topTracks = DataState.Data(tracks),
                     ),
                 )
             }
@@ -565,9 +586,16 @@ class ItemDetailsViewModel(
             }
 
             is Album -> {
-                _state.value.artistAlbumSections?.let { sections ->
+                _state.value.artistSections?.let { sections ->
                     _state.update { s ->
-                        s.copy(artistAlbumSections = sections.mapData { it.replacing(changed) })
+                        s.copy(
+                            artistSections = sections.copy(
+                                library = sections.library.mapData { it.replacing(changed) },
+                                all = sections.all.mapData {
+                                    it.copy(items = it.items.replacing(changed))
+                                },
+                            ),
+                        )
                     }
                     return
                 }
@@ -625,27 +653,20 @@ private fun DataState<out List<*>>.hasItems(): Boolean = when (this) {
     else -> false
 }
 
-data class ArtistSections<T : AppMediaItem>(
-    val library: DataState<List<T>> = DataState.NoData(),
-    val all: DataState<ProviderList<T>> = DataState.NoData(),
+data class ArtistSections(
+    val library: DataState<List<Album>> = DataState.NoData(),
+    val all: DataState<ProviderList<Album>> = DataState.NoData(),
+    val topTracks: DataState<List<Track>> = DataState.NoData(),
 ) {
-    fun mapData(transform: (List<T>) -> List<T>): ArtistSections<T> = copy(
-        library = library.mapData(transform),
-        all = all.mapData {
-            it.copy(items = transform(it.items))
-        },
-    )
-
     fun isNotEmpty(): Boolean {
         return (library is DataState.Data && library.data.isNotEmpty()) ||
-                (all is DataState.Data && all.data.items.isNotEmpty())
+                (all is DataState.Data && all.data.items.isNotEmpty()) ||
+                (topTracks is DataState.Data && topTracks.data.isNotEmpty())
     }
 
     companion object {
-        fun <T : AppMediaItem> loading() =
-            ArtistSections<T>(DataState.Loading(), DataState.Loading())
-
-        fun <T : AppMediaItem> error() = ArtistSections<T>(DataState.Error(), DataState.Error())
+        fun loading() = ArtistSections(DataState.Loading(), DataState.Loading())
+        fun error() = ArtistSections(DataState.Error(), DataState.Error())
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -23,6 +23,7 @@ import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
@@ -254,6 +255,9 @@ class ItemDetailsViewModel(
         mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
 
     private fun loadArtistAlbumSections(artist: Artist) {
+        val mappings = artist.providerMappings ?: emptyList()
+        loadAlbumsForProvider(mappings.first())
+
         viewModelScope.launch {
             try {
                 val library = if (artist.isInLibrary) {
@@ -263,30 +267,35 @@ class ItemDetailsViewModel(
                     emptyList()
                 }
 
-                val sources = artist.providerMappings ?: emptyList()
-                val albumsByProvider = sources.associate { (itemId, domain, instance) ->
-                    domain to fetchArtistItems(Request.Artist.getAlbums(itemId, instance))
-                        .filterIsInstance<Album>()
-                }
-
-                val firstProvider = albumsByProvider.entries.first()
-                val all = ProviderList(
-                    selectedDomain = firstProvider.key,
-                    items = firstProvider.value,
-                    options = albumsByProvider.keys.toList(),
-                )
-
                 _state.update {
                     it.copy(
-                        artistAlbumSections = ArtistSections(
+                        artistAlbumSections = (it.artistAlbumSections ?: ArtistSections()).copy(
                             library = DataState.Data(library),
-                            all = DataState.Data(all),
                         ),
                     )
                 }
             } catch (e: Exception) {
                 Logger.e("Failed to load artist album sections", e)
                 _state.update { it.copy(artistAlbumSections = ArtistSections.error()) }
+            }
+        }
+    }
+
+    fun loadAlbumsForProvider(mapping: ProviderMapping) {
+        viewModelScope.launch {
+            val albums = fetchArtistItems(
+                Request.Artist.getAlbums(
+                    mapping.itemId,
+                    mapping.providerInstance,
+                ),
+            ).filterIsInstance<Album>()
+
+            _state.update {
+                it.copy(
+                    artistAlbumSections = (it.artistAlbumSections ?: ArtistSections()).copy(
+                        all = DataState.Data(ProviderList(mapping.providerDomain, albums)),
+                    ),
+                )
             }
         }
     }
@@ -646,9 +655,8 @@ data class ArtistSections<T : AppMediaItem>(
 }
 
 data class ProviderList<T : AppMediaItem>(
-    val selectedDomain: String,
+    val domain: String,
     val items: List<T>,
-    val options: List<String>,
 )
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -50,7 +50,9 @@ fun ItemListScreen(
         ItemList(
             data = state.items,
             onNavigateClick = onNavigateClick,
-            onPlayClick = { _, _, _, _ -> },
+            onPlayClick = { item, option, radio, _ ->
+                actionsViewModel.onPlayClick(item, option, radio)
+            },
             playlistActions = actionsViewModel,
             libraryActions = actionsViewModel,
             progressActions = actionsViewModel,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -27,6 +28,7 @@ fun ItemListScreen(
     onNavigateClick: (AppMediaItem) -> Unit,
     onBack: () -> Unit,
     contentPadding: PaddingValues,
+    clickContext: ClickContext,
 ) {
     val state by itemListViewModel.state.collectAsStateWithLifecycle()
 
@@ -54,6 +56,7 @@ fun ItemListScreen(
             progressActions = actionsViewModel,
             contentPadding = contentPadding,
             viewMode = ViewMode.GRID,
+            clickContext = clickContext,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -1,6 +1,10 @@
 package io.music_assistant.client.ui.compose.item
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -11,6 +15,9 @@ import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.library.ItemList
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.common_back
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun ItemListScreen(
@@ -18,17 +25,30 @@ fun ItemListScreen(
     itemListViewModel: ItemListViewModel,
     actionsViewModel: ActionsViewModel,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onBack: () -> Unit,
     contentPadding: PaddingValues,
 ) {
     val state by itemListViewModel.state.collectAsStateWithLifecycle()
 
     TopBarLayout(
-        topBar = { TopAppBar(title = { Text(title) }) },
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            stringResource(Res.string.common_back),
+                        )
+                    }
+                },
+            )
+        },
     ) {
         ItemList(
             data = state.items,
             onNavigateClick = onNavigateClick,
-            onPlayClick = { _, _, _, _ ->  },
+            onPlayClick = { _, _, _, _ -> },
             playlistActions = actionsViewModel,
             libraryActions = actionsViewModel,
             progressActions = actionsViewModel,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -1,0 +1,39 @@
+package io.music_assistant.client.ui.compose.item
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.settings.ViewMode
+import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
+import io.music_assistant.client.ui.compose.library.ItemList
+import io.music_assistant.client.ui.compose.nav.TopBarLayout
+
+@Composable
+fun ItemListScreen(
+    title: String,
+    itemListViewModel: ItemListViewModel,
+    actionsViewModel: ActionsViewModel,
+    onNavigateClick: (AppMediaItem) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    val state by itemListViewModel.state.collectAsStateWithLifecycle()
+
+    TopBarLayout(
+        topBar = { TopAppBar(title = { Text(title) }) },
+    ) {
+        ItemList(
+            data = state.items,
+            onNavigateClick = onNavigateClick,
+            onPlayClick = { _, _, _, _ ->  },
+            playlistActions = actionsViewModel,
+            libraryActions = actionsViewModel,
+            progressActions = actionsViewModel,
+            contentPadding = contentPadding,
+            viewMode = ViewMode.GRID,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,11 @@ class ItemListViewModel(
                     itemList.artistId,
                     itemList.providerInstance,
                 )
+
+                is ItemList.ArtistLibrary -> Request.Artist.getAlbums(
+                    itemList.artistId,
+                    ServerMediaItem.LIBRARY_PROVIDER,
+                )
             }
 
             val items = mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
@@ -52,4 +58,7 @@ sealed interface ItemList {
 
     @Serializable
     data class ArtistTopTracks(val providerInstance: String, val artistId: String) : ItemList
+
+    @Serializable
+    data class ArtistLibrary(val artistId: String) : ItemList
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -39,11 +39,12 @@ class ItemListViewModel(
                 )
             }
 
-            val items = mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
-            _state.update {
-                it.copy(
-                    items = DataState.Data(items),
-                )
+            mediaItemRepository.fetchMediaItems(request) { items ->
+                _state.update {
+                    it.copy(
+                        items = DataState.Data(items),
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -26,6 +26,11 @@ class ItemListViewModel(
                     itemList.artistId,
                     itemList.providerInstance,
                 )
+
+                is ItemList.ArtistTopTracks -> Request.Artist.getTopTracks(
+                    itemList.artistId,
+                    itemList.providerInstance,
+                )
             }
 
             val items = mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
@@ -44,4 +49,7 @@ class ItemListViewModel(
 sealed interface ItemList {
     @Serializable
     data class ArtistAlbums(val providerInstance: String, val artistId: String) : ItemList
+
+    @Serializable
+    data class ArtistTopTracks(val providerInstance: String, val artistId: String) : ItemList
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -1,0 +1,47 @@
+package io.music_assistant.client.ui.compose.item
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.ui.compose.common.DataState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+class ItemListViewModel(
+    private val itemList: ItemList,
+    private val mediaItemRepository: MediaItemRepository,
+) : ViewModel() {
+    private val _state = MutableStateFlow(State())
+    val state = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val request = when (itemList) {
+                is ItemList.ArtistAlbums -> Request.Artist.getAlbums(
+                    itemList.artistId,
+                    itemList.providerInstance,
+                )
+            }
+
+            val items = mediaItemRepository.fetchMediaItems(request).getOrNull() ?: emptyList()
+            _state.update {
+                it.copy(
+                    items = DataState.Data(items),
+                )
+            }
+        }
+    }
+
+    data class State(val items: DataState<List<AppMediaItem>> = DataState.Loading())
+}
+
+@Serializable
+sealed interface ItemList {
+    @Serializable
+    data class ArtistAlbums(val providerInstance: String, val artistId: String) : ItemList
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
@@ -16,20 +16,17 @@ object ItemUseCases {
             return null
         }
 
-        val results = artist.providerMappings.map {
-            val itemId = it.itemId
-            val providerInstance = it.providerInstance
+        for (mapping in artist.providerMappings) {
+            val itemId = mapping.itemId
+            val providerInstance = mapping.providerInstance
             val result = mediaItemRepository.fetchMediaItems(request(itemId, providerInstance))
-
-            val albums = result.getOrNull()?.filterIsInstance<T>() ?: emptyList()
-            it to albums
-        }.firstOrNull { it.second.isNotEmpty() }
-
-        return if (results != null) {
-            ItemsWithMappings(results.second, results.first)
-        } else {
-            ItemsWithMappings(emptyList(), artist.providerMappings.first())
+            val items = result.getOrNull()?.filterIsInstance<T>() ?: emptyList()
+            if (items.isNotEmpty()) {
+                return ItemsWithMappings(items, mapping)
+            }
         }
+
+        return ItemsWithMappings(emptyList(), artist.providerMappings.first())
     }
 
     data class ItemsWithMappings<T : AppMediaItem>(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
@@ -12,7 +12,11 @@ object ItemUseCases {
         artist: Artist,
         request: (itemId: String, providerInstance: String) -> Request,
     ): ItemsWithMappings<T>? {
-        val results = artist.providerMappings!!.map {
+        if (artist.providerMappings.isNullOrEmpty()) {
+            return null
+        }
+
+        val results = artist.providerMappings.map {
             val itemId = it.itemId
             val providerInstance = it.providerInstance
             val result = mediaItemRepository.fetchMediaItems(request(itemId, providerInstance))
@@ -24,7 +28,7 @@ object ItemUseCases {
         return if (results != null) {
             ItemsWithMappings(results.second, results.first)
         } else {
-            null
+            ItemsWithMappings(emptyList(), artist.providerMappings.first())
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemUseCases.kt
@@ -1,0 +1,35 @@
+package io.music_assistant.client.ui.compose.item
+
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.server.ProviderMapping
+import io.music_assistant.client.data.repository.MediaItemRepository
+
+object ItemUseCases {
+    suspend inline fun <reified T : AppMediaItem> fetchArtistItemsAcrossProviders(
+        mediaItemRepository: MediaItemRepository,
+        artist: Artist,
+        request: (itemId: String, providerInstance: String) -> Request,
+    ): ItemsWithMappings<T>? {
+        val results = artist.providerMappings!!.map {
+            val itemId = it.itemId
+            val providerInstance = it.providerInstance
+            val result = mediaItemRepository.fetchMediaItems(request(itemId, providerInstance))
+
+            val albums = result.getOrNull()?.filterIsInstance<T>() ?: emptyList()
+            it to albums
+        }.firstOrNull { it.second.isNotEmpty() }
+
+        return if (results != null) {
+            ItemsWithMappings(results.second, results.first)
+        } else {
+            null
+        }
+    }
+
+    data class ItemsWithMappings<T : AppMediaItem>(
+        val items: List<T>,
+        val mapping: ProviderMapping,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import compose.icons.TablerIcons
 import compose.icons.tablericons.Plus
-import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.DataState
@@ -61,12 +60,12 @@ fun ItemList(
     libraryActions: LibraryActions,
     progressActions: ProgressActions,
     contentPadding: PaddingValues,
-    mediaType: MediaType,
     viewMode: ViewMode,
     hasMore: Boolean = false,
     isLoadingMore: Boolean = false,
     onLoadMore: () -> Unit = {},
     onGlobalSearch: (() -> Unit)? = null,
+    showPlaylistCreate: Boolean = false,
 ) {
     var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     if (showCreatePlaylistDialog) {
@@ -99,7 +98,7 @@ fun ItemList(
                             EmptyState(onGlobalSearch)
                         } else {
                             Column(modifier = Modifier.fillMaxSize()) {
-                                if (mediaType == MediaType.PLAYLIST) {
+                                if (showPlaylistCreate) {
                                     OutlinedButton(
                                         modifier = Modifier
                                             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
@@ -1,0 +1,196 @@
+package io.music_assistant.client.ui.compose.library
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import compose.icons.TablerIcons
+import compose.icons.tablericons.Plus
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.settings.ViewMode
+import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
+import io.music_assistant.client.ui.compose.common.items.CreatePlaylistDialog
+import io.music_assistant.client.ui.compose.common.items.LibraryActions
+import io.music_assistant.client.ui.compose.common.items.PlayHandler
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
+import io.music_assistant.client.ui.compose.common.items.ProgressActions
+import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.cd_add_playlist
+import musicassistantclient.composeapp.generated.resources.library_empty
+import musicassistantclient.composeapp.generated.resources.library_error
+import musicassistantclient.composeapp.generated.resources.library_search_global
+import musicassistantclient.composeapp.generated.resources.playlist_add_new
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Component for showing a list of media items from [data]. Supports pagination through
+ * [onLoadMore], [isLoadingMore] and [hasMore]. The empty state can optionally link to a global
+ * search with [onGlobalSearch].
+ */
+@Composable
+fun ItemList(
+    modifier: Modifier = Modifier,
+    data: DataState<List<AppMediaItem>>,
+    onNavigateClick: (AppMediaItem) -> Unit,
+    onPlayClick: PlayHandler<AppMediaItem>,
+    onCreatePlaylist: (String) -> Unit,
+    playlistActions: PlaylistActions,
+    libraryActions: LibraryActions,
+    progressActions: ProgressActions,
+    contentPadding: PaddingValues,
+    mediaType: MediaType,
+    viewMode: ViewMode,
+    hasMore: Boolean = false,
+    isLoadingMore: Boolean = false,
+    onLoadMore: () -> Unit = {},
+    onGlobalSearch: (() -> Unit)? = null,
+) {
+    var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
+    if (showCreatePlaylistDialog) {
+        CreatePlaylistDialog(
+            onDismiss = { showCreatePlaylistDialog = false },
+            onCreate = {
+                showCreatePlaylistDialog = false
+                onCreatePlaylist(it)
+            },
+        )
+    }
+
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .clearFocusOnScroll(),
+        ) {
+            // Content area
+            Box(modifier = Modifier.fillMaxSize()) {
+                when (data) {
+                    is DataState.Loading -> LoadingState()
+                    is DataState.Error -> ErrorState()
+                    is DataState.NoData -> EmptyState(onGlobalSearch)
+                    is DataState.Stale,
+                    is DataState.Data,
+                        -> {
+                        val items = data.dataOrNull.orEmpty()
+                        if (items.isEmpty()) {
+                            EmptyState(onGlobalSearch)
+                        } else {
+                            Column(modifier = Modifier.fillMaxSize()) {
+                                if (mediaType == MediaType.PLAYLIST) {
+                                    OutlinedButton(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                                        onClick = { showCreatePlaylistDialog = true },
+                                    ) {
+                                        Icon(
+                                            TablerIcons.Plus,
+                                            contentDescription = stringResource(Res.string.cd_add_playlist),
+                                        )
+                                        Spacer(Modifier.width(4.dp))
+                                        Text(stringResource(Res.string.playlist_add_new))
+                                    }
+                                }
+
+                                val gridState = rememberLazyGridState()
+                                AdaptiveMediaGrid(
+                                    modifier = Modifier.fillMaxSize(),
+                                    items = items,
+                                    isLoadingMore = isLoadingMore,
+                                    hasMore = hasMore,
+                                    viewMode = viewMode,
+                                    onNavigateClick = onNavigateClick,
+                                    onPlayClick = onPlayClick,
+                                    onLoadMore = onLoadMore,
+                                    gridState = gridState,
+                                    playlistActions = playlistActions,
+                                    libraryActions = libraryActions,
+                                    progressActions = progressActions,
+                                    contentPadding = contentPadding,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorState() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(Res.string.library_error),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun EmptyState(onGlobalSearch: (() -> Unit)? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.library_empty),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Offer escalation to global search only when an actual query yielded nothing.
+            if (onGlobalSearch != null) {
+                OutlinedButton(onClick = onGlobalSearch) {
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = null,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(stringResource(Res.string.library_search_global))
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
@@ -55,7 +55,7 @@ fun ItemList(
     data: DataState<List<AppMediaItem>>,
     onNavigateClick: (AppMediaItem) -> Unit,
     onPlayClick: PlayHandler<AppMediaItem>,
-    onCreatePlaylist: (String) -> Unit,
+    onCreatePlaylist: ((String) -> Unit)? = null,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
     progressActions: ProgressActions,
@@ -65,10 +65,9 @@ fun ItemList(
     isLoadingMore: Boolean = false,
     onLoadMore: () -> Unit = {},
     onGlobalSearch: (() -> Unit)? = null,
-    showPlaylistCreate: Boolean = false,
 ) {
     var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
-    if (showCreatePlaylistDialog) {
+    if (onCreatePlaylist != null && showCreatePlaylistDialog) {
         CreatePlaylistDialog(
             onDismiss = { showCreatePlaylistDialog = false },
             onCreate = {
@@ -98,7 +97,7 @@ fun ItemList(
                             EmptyState(onGlobalSearch)
                         } else {
                             Column(modifier = Modifier.fillMaxSize()) {
-                                if (showPlaylistCreate) {
+                                if (onCreatePlaylist != null) {
                                     OutlinedButton(
                                         modifier = Modifier
                                             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemList.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import compose.icons.TablerIcons
 import compose.icons.tablericons.Plus
+import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.DataState
@@ -36,6 +37,7 @@ import io.music_assistant.client.ui.compose.common.items.LibraryActions
 import io.music_assistant.client.ui.compose.common.items.PlayHandler
 import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.ProgressActions
+import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.cd_add_playlist
 import musicassistantclient.composeapp.generated.resources.library_empty
@@ -65,6 +67,7 @@ fun ItemList(
     isLoadingMore: Boolean = false,
     onLoadMore: () -> Unit = {},
     onGlobalSearch: (() -> Unit)? = null,
+    clickContext: ClickContext,
 ) {
     var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     if (onCreatePlaylist != null && showCreatePlaylistDialog) {
@@ -77,58 +80,60 @@ fun ItemList(
         )
     }
 
-    Box(modifier = modifier) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .clearFocusOnScroll(),
-        ) {
-            // Content area
-            Box(modifier = Modifier.fillMaxSize()) {
-                when (data) {
-                    is DataState.Loading -> LoadingState()
-                    is DataState.Error -> ErrorState()
-                    is DataState.NoData -> EmptyState(onGlobalSearch)
-                    is DataState.Stale,
-                    is DataState.Data,
-                        -> {
-                        val items = data.dataOrNull.orEmpty()
-                        if (items.isEmpty()) {
-                            EmptyState(onGlobalSearch)
-                        } else {
-                            Column(modifier = Modifier.fillMaxSize()) {
-                                if (onCreatePlaylist != null) {
-                                    OutlinedButton(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                                        onClick = { showCreatePlaylistDialog = true },
-                                    ) {
-                                        Icon(
-                                            TablerIcons.Plus,
-                                            contentDescription = stringResource(Res.string.cd_add_playlist),
-                                        )
-                                        Spacer(Modifier.width(4.dp))
-                                        Text(stringResource(Res.string.playlist_add_new))
+    ProvideClickActions(clickContext) {
+        Box(modifier = modifier) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clearFocusOnScroll(),
+            ) {
+                // Content area
+                Box(modifier = Modifier.fillMaxSize()) {
+                    when (data) {
+                        is DataState.Loading -> LoadingState()
+                        is DataState.Error -> ErrorState()
+                        is DataState.NoData -> EmptyState(onGlobalSearch)
+                        is DataState.Stale,
+                        is DataState.Data,
+                            -> {
+                            val items = data.dataOrNull.orEmpty()
+                            if (items.isEmpty()) {
+                                EmptyState(onGlobalSearch)
+                            } else {
+                                Column(modifier = Modifier.fillMaxSize()) {
+                                    if (onCreatePlaylist != null) {
+                                        OutlinedButton(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                                            onClick = { showCreatePlaylistDialog = true },
+                                        ) {
+                                            Icon(
+                                                TablerIcons.Plus,
+                                                contentDescription = stringResource(Res.string.cd_add_playlist),
+                                            )
+                                            Spacer(Modifier.width(4.dp))
+                                            Text(stringResource(Res.string.playlist_add_new))
+                                        }
                                     }
-                                }
 
-                                val gridState = rememberLazyGridState()
-                                AdaptiveMediaGrid(
-                                    modifier = Modifier.fillMaxSize(),
-                                    items = items,
-                                    isLoadingMore = isLoadingMore,
-                                    hasMore = hasMore,
-                                    viewMode = viewMode,
-                                    onNavigateClick = onNavigateClick,
-                                    onPlayClick = onPlayClick,
-                                    onLoadMore = onLoadMore,
-                                    gridState = gridState,
-                                    playlistActions = playlistActions,
-                                    libraryActions = libraryActions,
-                                    progressActions = progressActions,
-                                    contentPadding = contentPadding,
-                                )
+                                    val gridState = rememberLazyGridState()
+                                    AdaptiveMediaGrid(
+                                        modifier = Modifier.fillMaxSize(),
+                                        items = items,
+                                        isLoadingMore = isLoadingMore,
+                                        hasMore = hasMore,
+                                        viewMode = viewMode,
+                                        onNavigateClick = onNavigateClick,
+                                        onPlayClick = onPlayClick,
+                                        onLoadMore = onLoadMore,
+                                        gridState = gridState,
+                                        playlistActions = playlistActions,
+                                        libraryActions = libraryActions,
+                                        progressActions = progressActions,
+                                        contentPadding = contentPadding,
+                                    )
+                                }
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -113,7 +113,7 @@ fun LibraryListScreen(
                 onPlayClick = { item, option, radio, _ ->
                     libraryListViewModel.onPlayClick(item, option, radio)
                 },
-                onCreatePlaylist = libraryListViewModel::createPlaylist,
+                onCreatePlaylist = if (state.mediaType == MediaType.PLAYLIST) libraryListViewModel::createPlaylist else null,
                 playlistActions = actionsViewModel,
                 libraryActions = actionsViewModel,
                 progressActions = actionsViewModel,
@@ -129,7 +129,6 @@ fun LibraryListScreen(
                         null
                     }
                 },
-                showPlaylistCreate = state.mediaType == MediaType.PLAYLIST,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -3,43 +3,32 @@
 package io.music_assistant.client.ui.compose.library
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SearchOff
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import compose.icons.TablerIcons
-import compose.icons.tablericons.Plus
 import io.music_assistant.client.data.model.client.ClickContext
 import io.music_assistant.client.data.model.client.LibraryFilters
 import io.music_assistant.client.data.model.client.MediaType
@@ -51,13 +40,6 @@ import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.SelectOption
 import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
-import io.music_assistant.client.ui.compose.common.ToastState
-import io.music_assistant.client.ui.compose.common.clearFocusOnScroll
-import io.music_assistant.client.ui.compose.common.items.CreatePlaylistDialog
-import io.music_assistant.client.ui.compose.common.items.LibraryActions
-import io.music_assistant.client.ui.compose.common.items.PlayHandler
-import io.music_assistant.client.ui.compose.common.items.PlaylistActions
-import io.music_assistant.client.ui.compose.common.items.ProgressActions
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
@@ -65,13 +47,9 @@ import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import io.music_assistant.client.ui.compose.search.SearchInput
 import musicassistantclient.composeapp.generated.resources.Res
-import musicassistantclient.composeapp.generated.resources.cd_add_playlist
 import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.common_back
-import musicassistantclient.composeapp.generated.resources.library_empty
-import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.library_quick_search
-import musicassistantclient.composeapp.generated.resources.library_search_global
 import musicassistantclient.composeapp.generated.resources.media_type_albums
 import musicassistantclient.composeapp.generated.resources.media_type_artists
 import musicassistantclient.composeapp.generated.resources.media_type_audiobooks
@@ -80,12 +58,11 @@ import musicassistantclient.composeapp.generated.resources.media_type_playlists
 import musicassistantclient.composeapp.generated.resources.media_type_podcasts
 import musicassistantclient.composeapp.generated.resources.media_type_radio
 import musicassistantclient.composeapp.generated.resources.media_type_tracks
-import musicassistantclient.composeapp.generated.resources.playlist_add_new
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun ItemListScreen(
-    itemListViewModel: ItemListViewModel,
+fun LibraryListScreen(
+    libraryListViewModel: LibraryListViewModel,
     contentPadding: PaddingValues,
     actionsViewModel: ActionsViewModel,
     onNavigateClick: (AppMediaItem) -> Unit,
@@ -100,70 +77,74 @@ fun ItemListScreen(
         }
     }
     LaunchedEffect(Unit) {
-        itemListViewModel.toasts.collect { toast ->
+        libraryListViewModel.toasts.collect { toast ->
             toastState.showToast(toast)
         }
     }
 
-    val state by itemListViewModel.state.collectAsStateWithLifecycle()
-    val providerOptions by itemListViewModel.providerOptions.collectAsStateWithLifecycle()
-    val genreOptions by itemListViewModel.genreOptions.collectAsStateWithLifecycle()
+    val state by libraryListViewModel.state.collectAsStateWithLifecycle()
+    val providerOptions by libraryListViewModel.providerOptions.collectAsStateWithLifecycle()
+    val genreOptions by libraryListViewModel.genreOptions.collectAsStateWithLifecycle()
 
     TopBarLayout(
         topBar = {
-            ItemListTopBar(
+            LibraryListTopBar(
                 onBack = onBack,
-                onToggleViewMode = itemListViewModel::toggleViewMode,
+                onToggleViewMode = libraryListViewModel::toggleViewMode,
                 viewMode = state.viewMode,
                 searchQuery = state.searchQuery,
-                onSearchQueryChanged = itemListViewModel::onSearchQueryChanged,
-                onSearch = itemListViewModel::onSearch,
-                onSortChanged = { itemListViewModel.onSortChanged(it) },
+                onSearchQueryChanged = libraryListViewModel::onSearchQueryChanged,
+                onSearch = libraryListViewModel::onSearch,
+                onSortChanged = { libraryListViewModel.onSortChanged(it) },
                 mediaType = state.mediaType,
                 sortOption = state.sortOption,
                 filters = state.filters,
-                onFiltersChange = itemListViewModel::setFilters,
+                onFiltersChange = libraryListViewModel::setFilters,
                 providerOptions = providerOptions,
                 genreOptions = genreOptions,
-                onLoadFilterOptions = itemListViewModel::loadFilterOptions,
+                onLoadFilterOptions = libraryListViewModel::loadFilterOptions,
             )
         },
     ) {
-        var showCreatePlaylistDialog by rememberSaveable { mutableStateOf(false) }
         ProvideClickActions(ClickContext.LIBRARY) {
             ItemList(
-                showCreatePlaylistDialog = showCreatePlaylistDialog,
-                toastState = toastState,
+                data = state.dataState,
                 onNavigateClick = onNavigateClick,
-                onGlobalSearch = onGlobalSearch,
-                searchQuery = state.searchQuery,
                 onPlayClick = { item, option, radio, _ ->
-                    itemListViewModel.onPlayClick(item, option, radio)
+                    libraryListViewModel.onPlayClick(item, option, radio)
                 },
-                onCreatePlaylistClick = { showCreatePlaylistDialog = true },
-                onLoadMore = { itemListViewModel.loadMore() },
-                onDismissCreatePlaylistDialog = { showCreatePlaylistDialog = false },
-                onCreatePlaylist = { name ->
-                    itemListViewModel.createPlaylist(name)
-                    showCreatePlaylistDialog = false
-                },
+                onCreatePlaylist = libraryListViewModel::createPlaylist,
                 playlistActions = actionsViewModel,
                 libraryActions = actionsViewModel,
                 progressActions = actionsViewModel,
                 contentPadding = contentPadding,
-                dataState = state.dataState,
                 mediaType = state.mediaType,
-                isLoadingMore = state.isLoadingMore,
-                hasMore = state.hasMore,
                 viewMode = state.viewMode,
+                hasMore = state.hasMore,
+                isLoadingMore = state.isLoadingMore,
+                onLoadMore = libraryListViewModel::loadMore,
+                onGlobalSearch = state.searchQuery.let {
+                    if (it.isNotBlank()) {
+                        { onGlobalSearch(it) }
+                    } else {
+                        null
+                    }
+                },
             )
         }
+
+        ToastHost(
+            toastState = toastState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 48.dp),
+        )
     }
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun ItemListTopBar(
+private fun LibraryListTopBar(
     onBack: () -> Unit,
     onToggleViewMode: () -> Unit,
     viewMode: ViewMode,
@@ -286,162 +267,5 @@ private fun ItemListTopBar(
                 }
             },
         )
-    }
-}
-
-@Composable
-private fun ItemList(
-    modifier: Modifier = Modifier,
-    showCreatePlaylistDialog: Boolean,
-    toastState: ToastState,
-    onNavigateClick: (AppMediaItem) -> Unit,
-    onGlobalSearch: (query: String) -> Unit,
-    searchQuery: String,
-    onPlayClick: PlayHandler<AppMediaItem>,
-    onCreatePlaylistClick: () -> Unit,
-    onLoadMore: () -> Unit,
-    onDismissCreatePlaylistDialog: () -> Unit,
-    onCreatePlaylist: (String) -> Unit,
-    playlistActions: PlaylistActions,
-    libraryActions: LibraryActions,
-    progressActions: ProgressActions? = null,
-    contentPadding: PaddingValues,
-    dataState: DataState<List<AppMediaItem>>,
-    mediaType: MediaType,
-    isLoadingMore: Boolean,
-    hasMore: Boolean,
-    viewMode: ViewMode,
-) {
-    Box(modifier = modifier) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .clearFocusOnScroll(),
-        ) {
-            // Content area
-            Box(modifier = Modifier.fillMaxSize()) {
-                when (dataState) {
-                    is DataState.Loading -> LoadingState()
-                    is DataState.Error -> ErrorState()
-                    is DataState.NoData -> EmptyState(searchQuery, onGlobalSearch)
-                    is DataState.Stale,
-                    is DataState.Data,
-                        -> {
-                        val items = dataState.dataOrNull.orEmpty()
-                        if (items.isEmpty()) {
-                            EmptyState(searchQuery, onGlobalSearch)
-                        } else {
-                            Column(modifier = Modifier.fillMaxSize()) {
-                                if (mediaType == MediaType.PLAYLIST) {
-                                    OutlinedButton(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                                        onClick = onCreatePlaylistClick,
-                                    ) {
-                                        Icon(
-                                            TablerIcons.Plus,
-                                            contentDescription = stringResource(Res.string.cd_add_playlist),
-                                        )
-                                        Spacer(Modifier.width(4.dp))
-                                        Text(stringResource(Res.string.playlist_add_new))
-                                    }
-                                }
-
-                                val gridState = rememberLazyGridState()
-                                AdaptiveMediaGrid(
-                                    modifier = Modifier.fillMaxSize(),
-                                    items = items,
-                                    isLoadingMore = isLoadingMore,
-                                    hasMore = hasMore,
-                                    viewMode = viewMode,
-                                    onNavigateClick = onNavigateClick,
-                                    onPlayClick = onPlayClick,
-                                    onLoadMore = onLoadMore,
-                                    gridState = gridState,
-                                    playlistActions = playlistActions,
-                                    libraryActions = libraryActions,
-                                    progressActions = progressActions,
-                                    contentPadding = contentPadding,
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Toast host
-        ToastHost(
-            toastState = toastState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(bottom = 48.dp),
-        )
-
-        // Create Playlist Dialog
-        if (showCreatePlaylistDialog) {
-            CreatePlaylistDialog(
-                onDismiss = onDismissCreatePlaylistDialog,
-                onCreate = onCreatePlaylist,
-            )
-        }
-    }
-}
-
-@Composable
-private fun LoadingState() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        CircularProgressIndicator()
-    }
-}
-
-@Composable
-private fun ErrorState() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text(
-            text = stringResource(Res.string.library_error),
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.error,
-        )
-    }
-}
-
-@Composable
-private fun EmptyState(
-    searchQuery: String,
-    onGlobalSearch: (query: String) -> Unit,
-) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text(
-                text = stringResource(Res.string.library_empty),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            // Offer escalation to global search only when an actual query yielded nothing.
-            if (searchQuery.isNotBlank()) {
-                OutlinedButton(onClick = { onGlobalSearch(searchQuery) }) {
-                    Icon(
-                        Icons.Default.Search,
-                        contentDescription = null,
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(Res.string.library_search_global))
-                }
-            }
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -40,7 +40,6 @@ import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.SelectOption
 import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
-import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
@@ -106,31 +105,30 @@ fun LibraryListScreen(
             )
         },
     ) {
-        ProvideClickActions(ClickContext.LIBRARY) {
-            ItemList(
-                data = state.dataState,
-                onNavigateClick = onNavigateClick,
-                onPlayClick = { item, option, radio, _ ->
-                    libraryListViewModel.onPlayClick(item, option, radio)
-                },
-                onCreatePlaylist = if (state.mediaType == MediaType.PLAYLIST) libraryListViewModel::createPlaylist else null,
-                playlistActions = actionsViewModel,
-                libraryActions = actionsViewModel,
-                progressActions = actionsViewModel,
-                contentPadding = contentPadding,
-                viewMode = state.viewMode,
-                hasMore = state.hasMore,
-                isLoadingMore = state.isLoadingMore,
-                onLoadMore = libraryListViewModel::loadMore,
-                onGlobalSearch = state.searchQuery.let {
-                    if (it.isNotBlank()) {
-                        { onGlobalSearch(it) }
-                    } else {
-                        null
-                    }
-                },
-            )
-        }
+        ItemList(
+            data = state.dataState,
+            onNavigateClick = onNavigateClick,
+            onPlayClick = { item, option, radio, _ ->
+                libraryListViewModel.onPlayClick(item, option, radio)
+            },
+            onCreatePlaylist = if (state.mediaType == MediaType.PLAYLIST) libraryListViewModel::createPlaylist else null,
+            playlistActions = actionsViewModel,
+            libraryActions = actionsViewModel,
+            progressActions = actionsViewModel,
+            contentPadding = contentPadding,
+            viewMode = state.viewMode,
+            hasMore = state.hasMore,
+            isLoadingMore = state.isLoadingMore,
+            onLoadMore = libraryListViewModel::loadMore,
+            onGlobalSearch = state.searchQuery.let {
+                if (it.isNotBlank()) {
+                    { onGlobalSearch(it) }
+                } else {
+                    null
+                }
+            },
+            clickContext = ClickContext.LIBRARY,
+        )
 
         ToastHost(
             toastState = toastState,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -118,7 +118,6 @@ fun LibraryListScreen(
                 libraryActions = actionsViewModel,
                 progressActions = actionsViewModel,
                 contentPadding = contentPadding,
-                mediaType = state.mediaType,
                 viewMode = state.viewMode,
                 hasMore = state.hasMore,
                 isLoadingMore = state.isLoadingMore,
@@ -130,6 +129,7 @@ fun LibraryListScreen(
                         null
                     }
                 },
+                showPlaylistCreate = state.mediaType == MediaType.PLAYLIST,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
@@ -35,7 +35,7 @@ import musicassistantclient.composeapp.generated.resources.toast_error_create_pl
 import org.jetbrains.compose.resources.getString
 
 @OptIn(FlowPreview::class)
-class ItemListViewModel(
+class LibraryListViewModel(
     private val mediaType: MediaType,
     private val apiClient: ServiceClient,
     private val mainDataSource: MainDataSource,
@@ -248,7 +248,7 @@ class ItemListViewModel(
             }
 
             val request = getRequest(
-                this@ItemListViewModel.mediaType,
+                this@LibraryListViewModel.mediaType,
                 currentState.offset,
                 orderBy,
                 searchQuery,
@@ -420,7 +420,7 @@ class ItemListViewModel(
             updateState(DataState.Loading())
 
             val request = getRequest(
-                this@ItemListViewModel.mediaType,
+                this@LibraryListViewModel.mediaType,
                 0,
                 orderBy,
                 searchQuery,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/HomeRowsConfigTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HomeRowsConfigTest {
-    private fun itemCategory(id: String) = ItemCategory(
+    private fun itemCategory(id: String) = ItemCategory<Nothing>(
         id = id,
         title = id.toDisplayString(),
         items = emptyList(),


### PR DESCRIPTION
Closes #801

TODO:

- [x] Add provider switching for top tracks
- [x] Add "View all" link for sections
- [x] Limit section items
- [x] Flesh out item list screen
- [x] Handle empty sections and empty provider lists
- [x] Show first non-empty provider for "Discography" and "Top tracks"

Follow-ups:
- [x] Add sort/view mode to list screen
- [x] Add tests for `ItemUseCases`
- [ ] Show provider names (rather than domain) in filter
- [x] Use reactive version of `MediaItemRepository#fetchMediaItems` everywhere

## Is there anything about the code changes here that should be highlighted?

- I've expanded our `CategoryRow` composable to be able to handle `DataState` for loading, empty `NoData` states
- There's a new shared composable `ItemList` that is used by the "View all" screens for the artist as well as the library screens

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

