### PR TITLE
Fix queue items clearing when resuming app

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,7 +35,7 @@ class DirectTransport(
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         logger.e(throwable) { "Uncaught exception in DirectTransport scope" }
         when (_state.value) {
-            TransportState.Connected -> verifyConnection(probeReason = "direct_transport_scope_exception")
+            TransportState.Connected -> disconnect()
             TransportState.Connecting, is TransportState.Reconnecting ->
                 _state.value = TransportState.Failed(
                     Exception("Recovery machinery died: ${throwable.message}", throwable),
@@ -65,9 +64,6 @@ class DirectTransport(
 
     @Volatile
     private var messageCounter = 0L
-
-    private fun Job?.lifecycleLabel(): String =
-        this?.let { "active=${it.isActive},cancelled=${it.isCancelled},completed=${it.isCompleted}" } ?: "none"
 
     override fun connect() {
         connectionJob?.cancel()
@@ -149,42 +145,6 @@ class DirectTransport(
         }
     }
 
-    override fun verifyConnection(timeoutMs: Long, probeReason: String) {
-        val s = session ?: return
-        val countBefore = messageCounter
-        scope.launch {
-            val sendOk = try {
-                s.sendSerialized(Request.Auth.providers())
-                true
-            } catch (e: Exception) {
-                logger.i {
-                    "Direct connection probe failed immediately: probeReason=$probeReason " +
-                        "state=${_state.value} messageCounterBefore=$countBefore " +
-                        "error=${e.message ?: "no-message"}"
-                }
-                false
-            }
-
-            if (!sendOk) {
-                initiateReconnect("probe_ping_failed:$probeReason")
-                return@launch
-            }
-
-            delay(timeoutMs)
-
-            // If no messages arrived and session unchanged — connection is dead
-            val countAfter = messageCounter
-            if (countAfter == countBefore && session === s && _state.value == TransportState.Connected) {
-                logger.i {
-                    "Direct connection probe timed out: probeReason=$probeReason timeoutMs=$timeoutMs " +
-                        "messageCounterBefore=$countBefore messageCounterAfter=$countAfter " +
-                        "state=${_state.value}"
-                }
-                initiateReconnect("probe_timeout:$probeReason")
-            }
-        }
-    }
-
     override suspend fun send(message: JsonObject) {
         val s = session ?: error("Not connected")
         s.sendSerialized(message)
@@ -203,27 +163,5 @@ class DirectTransport(
 
     override fun close() {
         scope.cancel()
-    }
-
-    /**
-     * Transition to Reconnecting BEFORE nulling the session, so any concurrent
-     * sendRequest sees a non-Connected transport state and skips disconnect(Error).
-     */
-    private fun initiateReconnect(reason: String) {
-        logger.i {
-            "Direct reconnect initiated: reason=$reason state=${_state.value} " +
-                "connectionJob=${connectionJob.lifecycleLabel()} sessionPresent=${session != null} " +
-                "messageCounter=$messageCounter"
-        }
-        _state.value = TransportState.Reconnecting(0)
-        connectionJob?.cancel()
-        val s = session
-        session = null
-        if (s != null) {
-            scope.launch { s.close() }
-        }
-        connectionJob = scope.launch {
-            startReconnection()
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/DirectTransport.kt
@@ -8,7 +8,6 @@ import io.ktor.client.plugins.websocket.sendSerialized
 import io.ktor.client.plugins.websocket.ws
 import io.ktor.client.plugins.websocket.wss
 import io.ktor.http.HttpMethod
-import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -155,7 +154,7 @@ class DirectTransport(
         val countBefore = messageCounter
         scope.launch {
             val sendOk = try {
-                s.send(Frame.Ping(byteArrayOf()))
+                s.sendSerialized(Request.Auth.providers())
                 true
             } catch (e: Exception) {
                 logger.i {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -332,16 +332,6 @@ class KtorServiceClient(
             }
             return
         }
-
-        // AA hookup is functionally equivalent to phone foreground: cache may be
-        // empty, AA's first sendRequest assumes the gate handles staleness — but
-        // the gate trusts `isReadyForCommands`, which stays true for a half-open
-        // WS. Same probe as `onAppForeground` to catch that case.
-        val elapsed = currentTimeMillis() - backgroundedAt
-        if (elapsed > STALE_CONNECTION_THRESHOLD_MS && state is SessionState.Connected) {
-            logger.i { "External consumer active: probing connection after ${elapsed}ms in background" }
-            transport?.verifyConnection(probeReason = "external_consumer_active")
-        }
     }
 
     /**
@@ -419,15 +409,6 @@ class KtorServiceClient(
         if (backgroundedConnectionInfo != null) {
             reconnectFromCurrent("was Backgrounded")
             return
-        }
-
-        // Cheap probe for half-open TCP. Anything more invasive (re-auth, full
-        // reconnect) is request-driven via `ensureReadyForCommands` — see
-        // `feedback_request_driven_recovery` for the rationale.
-        val elapsed = currentTimeMillis() - backgroundedAt
-        if (elapsed > STALE_CONNECTION_THRESHOLD_MS && state is SessionState.Connected) {
-            logger.i { "App foregrounded: probing connection after ${elapsed}ms in background" }
-            transport?.verifyConnection(probeReason = "app_foreground")
         }
     }
 
@@ -1143,7 +1124,6 @@ class KtorServiceClient(
     private fun JsonObject.stringArg(name: String): String? = (this[name] as? JsonPrimitive)?.content
 
     companion object {
-        private const val STALE_CONNECTION_THRESHOLD_MS = 30_000L
         private const val ENSURE_READY_TIMEOUT_MS = 10_000L
 
         // Upper bound on a single connect attempt before it's declared stuck. Generous

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/TransportState.kt
@@ -19,13 +19,6 @@ interface Transport {
     fun connect()
     fun disconnect()
 
-    /**
-     * Probe connection liveness. Sends a WebSocket ping; if no activity within
-     * [timeoutMs], transitions to [TransportState.Reconnecting] and reconnects.
-     * Default no-op for transports with built-in keepalive (e.g. WebRTC ICE).
-     */
-    fun verifyConnection(timeoutMs: Long = 1000, probeReason: String = "unknown_caller") {}
-
-    /** Release the transport's coroutine scope. Call [disconnect] first; unusable after. */
+    /** Call [disconnect] first; unusable after. */
     fun close() {}
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -374,32 +374,22 @@ class MainDataSource(
             }
                 .debounce(Timings.EVENT_DEBOUNCE) // Small debounce to batch rapid updates, but don't delay initial load
                 .collect { input ->
-                    _playersData.update { oldValues ->
-                        when (input.players) {
-                            is DataState.Error -> DataState.Error()
-                            is DataState.Loading -> DataState.Loading()
-                            is DataState.NoData -> DataState.NoData()
-                            is DataState.Data -> DataState.Data(
-                                buildPlayerDataList(
-                                    input.players.data,
-                                    input.queues,
-                                    input.localData,
-                                    input.favoriteOverrides,
-                                    oldValues,
-                                ),
-                            )
-
-                            is DataState.Stale -> DataState.Stale(
-                                data = buildPlayerDataList(
-                                    input.players.data,
-                                    input.queues,
-                                    input.localData,
-                                    input.favoriteOverrides,
-                                    oldValues,
-                                ),
-                                disconnectedAt = input.players.disconnectedAt,
-                                reason = input.players.reason,
-                            )
+                    if (input.players !is DataState.Stale) {
+                        _playersData.update { oldValues ->
+                            when (input.players) {
+                                is DataState.Error -> DataState.Error()
+                                is DataState.Loading -> DataState.Loading()
+                                is DataState.NoData -> DataState.NoData()
+                                is DataState.Data -> DataState.Data(
+                                    buildPlayerDataList(
+                                        input.players.data,
+                                        input.queues,
+                                        input.localData,
+                                        input.favoriteOverrides,
+                                        oldValues,
+                                    ),
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/music-assistant/mobile-app/issues/863
Closes https://github.com/music-assistant/mobile-app/issues/874 (hopefully)

## Is there anything about the code changes here that should be highlighted?

The main change here is to remove the `verifyConnection` method and the related flows as it appeared to be introducing unneeded reconnects that lead to timing issues that in turn lead to the linked issues. The reasoning for just removing is discussed in the comments below and in the commit messages.

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

