### PR TITLE
Surface dynamic radio stream metadata on iOS lock screen / CarPlay

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -1,7 +1,9 @@
 package io.music_assistant.client.data
 
 import io.music_assistant.client.data.model.client.ImageType
+import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.QueueTrack
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.image
@@ -83,8 +85,40 @@ internal object NowPlayingChannelChangeDetection {
 }
 
 /** Maps local-player state to the metadata channel. */
-internal fun buildNowPlayingTrack(playerData: PlayerData?): NowPlayingTrack? =
-    playerData?.queueInfo?.currentItem?.track?.toNowPlayingTrack()
+internal fun buildNowPlayingTrack(playerData: PlayerData?): NowPlayingTrack? {
+    val currentItem = playerData?.queueInfo?.currentItem ?: return null
+    return withRadioStreamMetadata(
+        base = currentItem.track.toNowPlayingTrack(),
+        playerData = playerData,
+        currentItem = currentItem,
+    )
+}
+
+/**
+ * Overlay the radio stream's dynamic metadata (from `currentMedia`) onto the static
+ * station entry. [NowPlayingTrack.mediaItemId] stays the station's so transport
+ * anchors correlate and Swift treats stream-title changes as same-track updates.
+ */
+private fun withRadioStreamMetadata(
+    base: NowPlayingTrack,
+    playerData: PlayerData,
+    currentItem: QueueTrack,
+): NowPlayingTrack {
+    if (currentItem.track.mediaType != MediaType.RADIO) return base
+    val media = playerData.player.currentMedia ?: return base
+    // The server always stamps queue_item_id when an MA queue item is current;
+    // media stamped otherwise is not this station's stream.
+    if (media.queueItemId != currentItem.id) return base
+    // A title equal to the station name carries no information (idle streams and
+    // the synthesized pre-play fallback both produce it).
+    val streamTitle = media.title?.takeIf { it.isNotBlank() && it != base.title } ?: return base
+    return base.copy(
+        title = streamTitle,
+        artist = media.artist?.takeIf { it.isNotBlank() },
+        album = base.title,
+        artworkUrl = media.imageUrl ?: base.artworkUrl,
+    )
+}
 
 /**
  * Maps local-player state to an anchor, or null when there is no current item.

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -2,8 +2,10 @@ package io.music_assistant.client.data
 
 import io.music_assistant.client.data.model.client.ImageInfo
 import io.music_assistant.client.data.model.client.ImageType
+import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.Player
 import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.PlayerMedia
 import io.music_assistant.client.data.model.client.PlayerType
 import io.music_assistant.client.data.model.client.Queue
 import io.music_assistant.client.data.model.client.QueueInfo
@@ -14,6 +16,7 @@ import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.testAudiobook
+import io.music_assistant.client.data.model.client.testRadio
 import io.music_assistant.client.data.model.client.testTrack
 import io.music_assistant.client.ui.compose.common.DataState
 import kotlin.test.Test
@@ -111,6 +114,82 @@ class NowPlayingTrackChannelTest {
             buildNowPlayingTrack(playerData(testAudiobook(), queueInfo(queueId = "queue-1")))!!
                 .isLongFormContent,
         )
+    }
+}
+
+class NowPlayingRadioStreamMetadataTest {
+    private fun streamMedia(
+        title: String? = "Song",
+        artist: String? = "Artist",
+        queueItemId: String? = "queue-item-1",
+        imageUrl: String? = null,
+    ) = PlayerMedia(
+        title = title,
+        artist = artist,
+        album = null,
+        imageUrl = imageUrl,
+        duration = null,
+        queueId = "queue-1",
+        queueItemId = queueItemId,
+        mediaType = MediaType.RADIO,
+        uri = null,
+    )
+
+    private fun radioTrack(media: PlayerMedia?): NowPlayingTrack =
+        buildNowPlayingTrack(
+            playerData(testRadio(), queueInfo(queueId = "queue-1"), currentMedia = media),
+        )!!
+
+    @Test
+    fun overlaysDynamicStreamMetadataKeepingStationIdentity() {
+        val built = radioTrack(streamMedia(imageUrl = "https://example.invalid/song.jpg"))
+        assertEquals("Song", built.title)
+        assertEquals("Artist", built.artist)
+        assertEquals("name", built.album)
+        assertEquals("id", built.mediaItemId)
+        assertEquals("https://example.invalid/song.jpg", built.artworkUrl)
+    }
+
+    @Test
+    fun streamTitleEqualToStationNameKeepsStaticPresentation() {
+        val built = radioTrack(streamMedia(title = "name"))
+        assertEquals("name", built.title)
+        assertNull(built.artist)
+        assertNull(built.album)
+    }
+
+    @Test
+    fun missingOrBlankStreamTitleKeepsStaticPresentation() {
+        assertEquals("name", radioTrack(null).title)
+        assertEquals("name", radioTrack(streamMedia(title = null)).title)
+        assertEquals("name", radioTrack(streamMedia(title = " ")).title)
+    }
+
+    @Test
+    fun mediaStampedWithAnotherQueueItemIsIgnored() {
+        val built = radioTrack(streamMedia(queueItemId = "queue-item-other"))
+        assertEquals("name", built.title)
+        assertNull(built.artist)
+    }
+
+    @Test
+    fun unstampedMediaIsIgnored() {
+        val built = radioTrack(streamMedia(queueItemId = null))
+        assertEquals("name", built.title)
+        assertNull(built.artist)
+    }
+
+    @Test
+    fun blankStreamArtistRendersAsNoArtist() {
+        assertNull(radioTrack(streamMedia(artist = " ")).artist)
+    }
+
+    @Test
+    fun nonRadioContentIgnoresCurrentMedia() {
+        val built = buildNowPlayingTrack(
+            playerData(testTrack(), queueInfo(queueId = "queue-1"), currentMedia = streamMedia()),
+        )!!
+        assertEquals("name", built.title)
     }
 }
 
@@ -267,7 +346,11 @@ private fun queueInfo(
     playbackSpeed = playbackSpeed,
 )
 
-private fun playerData(item: PlayableItem, queueInfo: QueueInfo): PlayerData = PlayerData(
+private fun playerData(
+    item: PlayableItem,
+    queueInfo: QueueInfo,
+    currentMedia: PlayerMedia? = null,
+): PlayerData = PlayerData(
     player = Player(
         id = "player-1",
         name = "Test player",
@@ -291,7 +374,7 @@ private fun playerData(item: PlayableItem, queueInfo: QueueInfo): PlayerData = P
         syncedTo = null,
         groupVolume = null,
         groupVolumeMuted = false,
-        currentMedia = null,
+        currentMedia = currentMedia,
     ),
     queue = DataState.Data(
         Queue(


### PR DESCRIPTION
Closes #832 

## Is there anything about the code changes here that should be highlighted?
The iOS now-playing track channel read only the static queue item, so radio playback showed the station name while the in-app player already rendered the stream's song/artist from player.currentMedia. In radio mode, overlay that dynamic metadata onto NowPlayingTrack: stream title and artist take the title/artist slots, the station name moves to the album slot, and mediaItemId stays the station's so iOS treats each stream-title change as a same-track update.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

