### PR TITLE
Bump verified-compatible server version to 53

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/ServerInfo.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /** Highest server schema_version this client is built and tested against. */
-const val LOCAL_SCHEMA_VERSION = 51
+const val LOCAL_SCHEMA_VERSION = 53
 
 @Serializable
 data class ServerInfo(


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Neither 52 nor 53 require changes on our side, though we might want to look into the provider filtering for recommendation rows and the new shuffle support for play_media fills a real gap.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

