### PR TITLE
Add the Sendspin Noise KKpsk2 core, device identity, and PSK trust store

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -85,6 +85,9 @@ kotlin {
             implementation(libs.androidx.media)
             implementation(libs.androidx.browser)
 
+            // Noise primitives backend (JCA crypto via the JDK provider).
+            implementation(libs.cryptography.provider.jdk)
+
             implementation(libs.coil)
             implementation(libs.concentus)
         }
@@ -136,6 +139,9 @@ kotlin {
             implementation(libs.ktor.client.webrtc)
 
             implementation(libs.easyqrscan)
+
+            // Crypto primitives for the Sendspin Noise (encrypted) protocol.
+            implementation(libs.cryptography.core)
         }
 
         commonTest.dependencies {
@@ -147,6 +153,9 @@ kotlin {
 
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
+
+            // Noise primitives backend (CryptoKit: X25519, ChaCha20-Poly1305).
+            implementation(libs.cryptography.provider.cryptokit)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinIdentity.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinIdentity.kt
@@ -1,0 +1,16 @@
+package io.music_assistant.client.player.sendspin.identity
+
+import io.music_assistant.client.player.sendspin.noise.SendspinBase64
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+
+/**
+ * The device's long-lived Sendspin identity: a static X25519 keypair whose
+ * public key *is* the encrypted-protocol `client_id` (base64url, no padding,
+ * 43 chars). Servers key persistence (groups, settings, pairing records) on
+ * it, so it must be stable across restarts; losing it (reinstall/restore)
+ * makes this device appear as a new player.
+ */
+class SendspinIdentity(val keyPair: X25519KeyPair) {
+    /** base64url (no padding) form of the static public key. */
+    val clientId: String = SendspinBase64.encode(keyPair.publicKey)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinKeyStore.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinKeyStore.kt
@@ -1,0 +1,47 @@
+package io.music_assistant.client.player.sendspin.identity
+
+import com.russhwolf.settings.Settings
+import kotlin.io.encoding.Base64
+
+/**
+ * Byte-blob persistence for the Sendspin identity and trust state.
+ *
+ * Deliberately backed by the same app settings storage as everything else
+ * (SharedPreferences on Android, NSUserDefaults on iOS) — the MA auth token
+ * already lives there, so a separate hardened vault for the Sendspin PSKs
+ * would protect the least valuable secrets in the app while adding
+ * platform-keystore failure modes. If secrets ever move to secure storage,
+ * they should all move together.
+ *
+ * Reads of missing or undecodable data return null and never throw: storage
+ * loss must lead to clean identity regeneration, not a crash.
+ */
+interface SendspinKeyStore {
+    /** Returns the stored bytes, or null when absent or unreadable. */
+    fun read(key: String): ByteArray?
+
+    /** Stores [value] under [key], replacing any previous value. */
+    fun write(key: String, value: ByteArray)
+
+    fun delete(key: String)
+}
+
+/** [SendspinKeyStore] over the app's shared [Settings] storage. */
+class SettingsSendspinKeyStore(private val settings: Settings) : SendspinKeyStore {
+    override fun read(key: String): ByteArray? {
+        val encoded = settings.getStringOrNull(key) ?: return null
+        return try {
+            Base64.decode(encoded)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+
+    override fun write(key: String, value: ByteArray) {
+        settings.putString(key, Base64.encode(value))
+    }
+
+    override fun delete(key: String) {
+        settings.remove(key)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/TrustStore.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/identity/TrustStore.kt
@@ -1,0 +1,311 @@
+package io.music_assistant.client.player.sendspin.identity
+
+import io.music_assistant.client.player.sendspin.noise.PskCandidate
+import io.music_assistant.client.player.sendspin.noise.PskCategory
+import io.music_assistant.client.player.sendspin.noise.SendspinBase64
+import io.music_assistant.client.player.sendspin.noise.SendspinPsk
+import io.music_assistant.client.player.sendspin.noise.crypto.NoiseCrypto
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+import io.music_assistant.client.player.sendspin.pairing.PairingToken
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.atomicfu.updateAndGet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** A persisted long-term PSK record, as exposed to management. */
+class TrustRecordView(
+    val psk: ByteArray,
+    /** Bound server for stored-pubkey records; null for shared-PSK records. */
+    val serverId: String?,
+    /** True once the record has authenticated at least one session. */
+    val used: Boolean,
+)
+
+/**
+ * Persistent trust state: identity keypair, Pairing PSK, long-term records,
+ * config flags, and the live PSK-candidate set. Persisted as two entries: the
+ * identity (written only on regeneration) and one versioned trust blob rewritten
+ * whole per serialized mutation, bound to the identity public key — a
+ * regenerated identity resets the blob with it.
+ */
+class SendspinTrustStore private constructor(
+    private val keyStore: SendspinKeyStore,
+    private val crypto: NoiseCrypto,
+    val identity: SendspinIdentity,
+    initialState: TrustBlob,
+) {
+    private val state = atomic(initialState)
+
+    val clientId: String get() = identity.clientId
+
+    /** Raw per-device Pairing PSK (32 bytes). */
+    val pairingPsk: ByteArray get() = SendspinBase64.decode(state.value.pairingPsk)
+
+    val pairingPskEnabled: Boolean get() = state.value.pairingPskEnabled
+
+    val unpairedAccessEnabled: Boolean get() = state.value.unpairedAccessEnabled
+
+    /** The out-of-band pairing token for this device. */
+    fun pairingToken(): String = PairingToken.mint(identity.keyPair.publicKey, pairingPsk)
+
+    /** Derives the `psk_id` of [psk] (management identifies records by it). */
+    suspend fun pskIdOf(psk: ByteArray): String = SendspinPsk.pskId(crypto, psk)
+
+    /** Record-distribution shared record; defaults to the pre-provisioned one. */
+    suspend fun recordModePskId(): String? {
+        state.value.recordModePskId?.let { return it }
+        val defaultShared = state.value.records.firstOrNull { it.serverId == null }
+            ?: return null
+        return pskIdOf(SendspinBase64.decode(defaultShared.psk))
+    }
+
+    fun setRecordModePskId(pskId: String) {
+        mutate { it.copy(recordModePskId = pskId) }
+    }
+
+    /** Live PSK-candidate set, computed from current state on every call so
+     *  config mutations are visible to in-flight lookups immediately. */
+    fun pskCandidates(): List<PskCandidate> {
+        val snapshot = state.value
+        return buildList {
+            add(PskCandidate(SendspinPsk.SENTINEL_PSK, PskCategory.SENTINEL))
+            if (snapshot.pairingPskEnabled) {
+                add(PskCandidate(SendspinBase64.decode(snapshot.pairingPsk), PskCategory.PAIRING))
+            }
+            snapshot.records.forEach { record ->
+                add(
+                    PskCandidate(
+                        psk = SendspinBase64.decode(record.psk),
+                        category = if (record.serverId != null) {
+                            PskCategory.LONG_TERM_STORED
+                        } else {
+                            PskCategory.LONG_TERM_SHARED
+                        },
+                        serverId = record.serverId,
+                    ),
+                )
+            }
+        }
+    }
+
+    fun records(): List<TrustRecordView> = state.value.records.map {
+        TrustRecordView(
+            psk = SendspinBase64.decode(it.psk),
+            serverId = it.serverId,
+            used = it.used,
+        )
+    }
+
+    /** Persists a completed pairing's record; replaces any for the same server. */
+    fun recordLongTermPsk(psk: ByteArray, serverId: String) {
+        mutate { blob ->
+            blob.copy(
+                records = blob.records.filterNot { it.serverId == serverId } +
+                    TrustRecord(psk = SendspinBase64.encode(psk), serverId = serverId),
+            )
+        }
+    }
+
+    /** Appends without replacing (management add-record; psk_id conflicts are the caller's). */
+    fun addStoredRecord(psk: ByteArray, serverId: String) {
+        mutate { blob ->
+            blob.copy(
+                records = blob.records +
+                    TrustRecord(psk = SendspinBase64.encode(psk), serverId = serverId),
+            )
+        }
+    }
+
+    /** One-commit config patch; null fields keep their stored values. */
+    fun applyPairingConfigPatch(
+        pairingPsk: ByteArray? = null,
+        pairingPskEnabled: Boolean? = null,
+        recordModePskId: String? = null,
+        unpairedAccessEnabled: Boolean? = null,
+    ) {
+        require(pairingPsk == null || pairingPsk.size == PSK_SIZE) {
+            "pairing PSK must be $PSK_SIZE bytes"
+        }
+        mutate { blob ->
+            blob.copy(
+                pairingPsk = pairingPsk?.let { SendspinBase64.encode(it) } ?: blob.pairingPsk,
+                pairingPskEnabled = pairingPskEnabled ?: blob.pairingPskEnabled,
+                recordModePskId = recordModePskId ?: blob.recordModePskId,
+                unpairedAccessEnabled = unpairedAccessEnabled ?: blob.unpairedAccessEnabled,
+            )
+        }
+    }
+
+    /** Adds a shared-PSK record (no bound server). */
+    fun addSharedRecord(psk: ByteArray) {
+        mutate { blob ->
+            blob.copy(
+                records = blob.records +
+                    TrustRecord(psk = SendspinBase64.encode(psk), serverId = null),
+            )
+        }
+    }
+
+    /** Removes records matching [psk]; returns true when any was removed. */
+    fun removeRecord(psk: ByteArray): Boolean {
+        val encoded = SendspinBase64.encode(psk)
+        var removed = false
+        mutate { blob ->
+            val remaining = blob.records.filterNot { it.psk == encoded }
+            removed = remaining.size != blob.records.size
+            blob.copy(records = remaining)
+        }
+        return removed
+    }
+
+    /** Marks the record matching [psk] as having authenticated a session. */
+    fun markRecordUsed(psk: ByteArray) {
+        val encoded = SendspinBase64.encode(psk)
+        mutate { blob ->
+            blob.copy(
+                records = blob.records.map {
+                    if (it.psk == encoded) it.copy(used = true) else it
+                },
+            )
+        }
+    }
+
+    fun setPairingPskEnabled(enabled: Boolean) {
+        mutate { it.copy(pairingPskEnabled = enabled) }
+    }
+
+    fun setUnpairedAccessEnabled(enabled: Boolean) {
+        mutate { it.copy(unpairedAccessEnabled = enabled) }
+    }
+
+    /** Rotates the Pairing PSK (management-driven; never rotated locally). */
+    fun setPairingPsk(psk: ByteArray) {
+        require(psk.size == PSK_SIZE) { "pairing PSK must be $PSK_SIZE bytes" }
+        mutate { it.copy(pairingPsk = SendspinBase64.encode(psk)) }
+    }
+
+    private val persistLock = SynchronizedObject()
+
+    private fun mutate(transform: (TrustBlob) -> TrustBlob) {
+        // The lock keeps persist order identical to mutation order; otherwise two
+        // writes could land on disk reversed and resurrect old state after a restart.
+        synchronized(persistLock) {
+            val newState = state.updateAndGet(transform)
+            keyStore.write(TRUST_KEY, json.encodeToString(newState).encodeToByteArray())
+        }
+    }
+
+    companion object {
+        private const val IDENTITY_KEY = "sendspin.identity"
+        private const val TRUST_KEY = "sendspin.trust"
+        private const val KEY_SIZE = 32
+        private const val PSK_SIZE = 32
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /** Loads persisted state, regenerating cleanly on missing/corrupt storage. */
+        suspend fun load(keyStore: SendspinKeyStore, crypto: NoiseCrypto): SendspinTrustStore {
+            val identity = readIdentity(keyStore, crypto) ?: run {
+                val keyPair = crypto.generateX25519KeyPair()
+                keyStore.write(
+                    IDENTITY_KEY,
+                    json.encodeToString(
+                        IdentityBlob(
+                            privateKey = SendspinBase64.encode(keyPair.privateKey),
+                            publicKey = SendspinBase64.encode(keyPair.publicKey),
+                        ),
+                    ).encodeToByteArray(),
+                )
+                SendspinIdentity(keyPair)
+            }
+
+            val stored = readTrust(keyStore)
+            val trust = if (stored != null && stored.identityPublicKey == identity.clientId) {
+                stored
+            } else {
+                // Missing, corrupt, or bound to a previous identity: reset.
+                val fresh = TrustBlob(
+                    identityPublicKey = identity.clientId,
+                    pairingPsk = SendspinBase64.encode(crypto.randomBytes(PSK_SIZE)),
+                    records = listOf(
+                        // Pre-provisioned shared record for record-distribution mode.
+                        TrustRecord(
+                            psk = SendspinBase64.encode(crypto.randomBytes(PSK_SIZE)),
+                            serverId = null,
+                        ),
+                    ),
+                )
+                keyStore.write(TRUST_KEY, json.encodeToString(fresh).encodeToByteArray())
+                fresh
+            }
+            return SendspinTrustStore(keyStore, crypto, identity, trust)
+        }
+
+        private suspend fun readIdentity(
+            keyStore: SendspinKeyStore,
+            crypto: NoiseCrypto,
+        ): SendspinIdentity? {
+            val bytes = keyStore.read(IDENTITY_KEY) ?: return null
+            return try {
+                val blob = json.decodeFromString<IdentityBlob>(bytes.decodeToString())
+                val privateKey = SendspinBase64.decode(blob.privateKey)
+                val publicKey = SendspinBase64.decode(blob.publicKey)
+                check(privateKey.size == KEY_SIZE && publicKey.size == KEY_SIZE)
+                // A public key that no longer matches its private key is corruption.
+                check(crypto.x25519PublicKey(privateKey).contentEquals(publicKey))
+                SendspinIdentity(X25519KeyPair(privateKey, publicKey))
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun readTrust(keyStore: SendspinKeyStore): TrustBlob? {
+            val bytes = keyStore.read(TRUST_KEY) ?: return null
+            return try {
+                val blob = json.decodeFromString<TrustBlob>(bytes.decodeToString())
+                check(blob.version == TrustBlob.CURRENT_VERSION)
+                // A truncated blob is corrupt, not half-loaded.
+                check(SendspinBase64.decode(blob.pairingPsk).size == PSK_SIZE)
+                blob.records.forEach {
+                    check(SendspinBase64.decode(it.psk).size == PSK_SIZE)
+                }
+                blob
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}
+
+@Serializable
+internal data class IdentityBlob(
+    val version: Int = 1,
+    @SerialName("private_key") val privateKey: String,
+    @SerialName("public_key") val publicKey: String,
+)
+
+@Serializable
+internal data class TrustRecord(
+    val psk: String,
+    @SerialName("server_id") val serverId: String? = null,
+    val used: Boolean = false,
+)
+
+@Serializable
+internal data class TrustBlob(
+    val version: Int = CURRENT_VERSION,
+    @SerialName("identity_public_key") val identityPublicKey: String,
+    @SerialName("pairing_psk") val pairingPsk: String,
+    @SerialName("pairing_psk_enabled") val pairingPskEnabled: Boolean = true,
+    @SerialName("unpaired_access_enabled") val unpairedAccessEnabled: Boolean = false,
+    /** psk_id of the record-distribution shared record; null = the default. */
+    @SerialName("record_mode_psk_id") val recordModePskId: String? = null,
+    val records: List<TrustRecord> = emptyList(),
+) {
+    companion object {
+        const val CURRENT_VERSION = 1
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/model/Messages.kt
@@ -348,6 +348,150 @@ object CommandValueSerializer : KSerializer<CommandValue> {
     }
 }
 
+// MARK: - Encrypted-connection handshake messages
+//
+// These exist only on the Noise-encrypted protocol path; the legacy
+// (unencrypted) message models above are frozen and must stay byte-identical
+// on the wire.
+
+@Serializable
+data class ClientInitMessage(
+    override val type: String = "client/init",
+    val payload: ClientInitPayload,
+) : SendspinMessage
+
+@Serializable
+data class ClientInitPayload(
+    @SerialName("client_id") val clientId: String,
+    val version: Int = 1,
+    val suite: String,
+)
+
+@Serializable
+data class ServerInitMessage(
+    override val type: String = "server/init",
+    val payload: ServerInitPayload,
+) : SendspinMessage
+
+@Serializable
+data class ServerInitPayload(
+    @SerialName("server_id") val serverId: String,
+    val version: Int,
+)
+
+@Serializable
+data class NoiseHandshakeMessage(
+    override val type: String = "noise/handshake",
+    val payload: NoiseHandshakePayload,
+) : SendspinMessage
+
+@Serializable
+data class NoiseHandshakePayload(
+    /** base64url-encoded (no padding) Noise handshake message bytes. */
+    val data: String,
+)
+
+/** Encrypted-mode `server/hello`: carries only the server's friendly name. */
+@Serializable
+data class EncryptedServerHelloMessage(
+    override val type: String = "server/hello",
+    val payload: EncryptedServerHelloPayload,
+) : SendspinMessage
+
+@Serializable
+data class EncryptedServerHelloPayload(
+    val name: String,
+)
+
+/**
+ * Encrypted-mode `client/hello`: unlike the legacy shape it omits `client_id`
+ * and the core `version` (both carried by `client/init`) and adds trust and
+ * pairing advertisement fields.
+ */
+@Serializable
+data class EncryptedClientHelloMessage(
+    override val type: String = "client/hello",
+    val payload: EncryptedClientHelloPayload,
+) : SendspinMessage
+
+@Serializable
+data class EncryptedClientHelloPayload(
+    val name: String,
+    @SerialName("device_info") val deviceInfo: EncryptedDeviceInfo? = null,
+    @SerialName("trust_level") val trustLevel: String,
+    @SerialName("supported_roles") val supportedRoles: List<VersionedRole>,
+    @SerialName("player@v1_support") val playerV1Support: PlayerSupport? = null,
+    @SerialName("supported_pair_methods") val supportedPairMethods: List<PairMethodDescriptor>,
+    @SerialName("unpaired_access") val unpairedAccess: UnpairedAccess,
+)
+
+@Serializable
+data class EncryptedDeviceInfo(
+    @SerialName("product_name") val productName: String? = null,
+    val manufacturer: String? = null,
+    @SerialName("software_version") val softwareVersion: String? = null,
+)
+
+@Serializable
+data class PairMethodDescriptor(
+    val method: String,
+)
+
+@Serializable
+data class UnpairedAccess(
+    val enabled: Boolean,
+)
+
+@Serializable
+data class ServerActivateMessage(
+    override val type: String = "server/activate",
+    val payload: ServerActivatePayload,
+) : SendspinMessage
+
+@Serializable
+data class ServerActivatePayload(
+    val activities: List<String>,
+    /**
+     * Required on the first activation; persists across later activations
+     * that omit it.
+     */
+    @SerialName("active_roles") val activeRoles: List<String>? = null,
+    val pairing: ActivatePairing? = null,
+)
+
+@Serializable
+data class ActivatePairing(
+    val method: String,
+    @SerialName("pin_length") val pinLength: Int? = null,
+    val languages: List<String>? = null,
+)
+
+/**
+ * Delivers the long-term PSK for this (client, server) pair. In the Pairing
+ * PSK flow it starts the pairing attempt and carries the PSK directly.
+ */
+@Serializable
+data class ClientPairFinalizeMessage(
+    override val type: String = "client/pair-finalize",
+    val payload: ClientPairFinalizePayload,
+) : SendspinMessage
+
+@Serializable
+data class ClientPairFinalizePayload(
+    @SerialName("long_term_psk") val longTermPsk: String,
+)
+
+@Serializable
+data class PairAbortMessage(
+    override val type: String = "pair/abort",
+    val payload: PairAbortPayload,
+) : SendspinMessage
+
+@Serializable
+data class PairAbortPayload(
+    val reason: String,
+)
+
 // MARK: - Goodbye Messages
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseFraming.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseFraming.kt
@@ -1,0 +1,165 @@
+package io.music_assistant.client.player.sendspin.noise
+
+/**
+ * Message-type framing and fragmentation for the encrypted Sendspin channel.
+ *
+ * Once a connection is in Noise transport mode, every WebSocket binary frame
+ * carries one Noise ciphertext. After AEAD decryption, byte 0 of the plaintext
+ * is a uint8 message type:
+ *
+ * - `0` — JSON message body (UTF-8)
+ * - `1` — reserved
+ * - `2` / `3` — fragmentation (fragment-more / fragment-end)
+ * - `4..7` — player-role audio
+ * - other values — further roles, reserved ranges, application-specific roles
+ *
+ * A single Noise transport message is capped at 65535 bytes; both Sendspin
+ * cipher suites spend 16 bytes on the AEAD tag and 1 byte on the message type,
+ * leaving at most 65518 bytes of application payload per frame. Larger
+ * messages are split across frames using the fragment types:
+ *
+ * - fragment-more, opening a fragmented message: `[2][origType][data]`
+ * - fragment-more, continuation: `[2][data]`
+ * - fragment-end: `[3][data]`
+ *
+ * Only one fragmented message may be in flight per direction, and no other
+ * frame may interleave with it. Malformed sequences are protocol errors and
+ * must close the connection.
+ */
+object NoiseFraming {
+    const val TYPE_JSON: Int = 0
+    const val TYPE_FRAGMENT_MORE: Int = 2
+    const val TYPE_FRAGMENT_END: Int = 3
+
+    /** Largest Noise transport message allowed by the Noise specification. */
+    const val MAX_NOISE_MESSAGE: Int = 65535
+
+    /** AEAD tag size for both defined Sendspin cipher suites. */
+    const val AEAD_TAG_SIZE: Int = 16
+
+    /** Largest AEAD plaintext per frame (type byte + payload). */
+    const val MAX_FRAME_PLAINTEXT: Int = MAX_NOISE_MESSAGE - AEAD_TAG_SIZE
+
+    /** Largest application payload that fits one non-fragmented frame. */
+    const val MAX_UNFRAGMENTED_PAYLOAD: Int = MAX_FRAME_PLAINTEXT - 1
+
+    /** Returns true for message types in the player-role audio range. */
+    fun isPlayerAudioType(type: Int): Boolean = type in 4..7
+
+    /** Frame plaintexts for one message, fragmenting past [MAX_UNFRAGMENTED_PAYLOAD]. */
+    fun encode(type: Int, payload: ByteArray): List<ByteArray> {
+        require(type in 0..255) { "message type out of range: $type" }
+        require(type != TYPE_FRAGMENT_MORE && type != TYPE_FRAGMENT_END) {
+            "fragment types cannot be sent as application message types"
+        }
+        if (payload.size <= MAX_UNFRAGMENTED_PAYLOAD) {
+            val frame = ByteArray(1 + payload.size)
+            frame[0] = type.toByte()
+            payload.copyInto(frame, 1)
+            return listOf(frame)
+        }
+
+        val frames = mutableListOf<ByteArray>()
+        var offset = 0
+        // Opening fragment-more frame carries [2][origType][data].
+        run {
+            val dataLen = minOf(MAX_FRAME_PLAINTEXT - 2, payload.size)
+            val frame = ByteArray(2 + dataLen)
+            frame[0] = TYPE_FRAGMENT_MORE.toByte()
+            frame[1] = type.toByte()
+            payload.copyInto(frame, 2, 0, dataLen)
+            frames.add(frame)
+            offset = dataLen
+        }
+        // Continuations carry [2][data]; the final frame is [3][data].
+        while (true) {
+            val remaining = payload.size - offset
+            val dataLen = minOf(MAX_FRAME_PLAINTEXT - 1, remaining)
+            val last = dataLen == remaining
+            val frame = ByteArray(1 + dataLen)
+            frame[0] = (if (last) TYPE_FRAGMENT_END else TYPE_FRAGMENT_MORE).toByte()
+            payload.copyInto(frame, 1, offset, offset + dataLen)
+            frames.add(frame)
+            offset += dataLen
+            if (last) return frames
+        }
+    }
+
+    /** One fully reassembled application message. */
+    class Message(val type: Int, val payload: ByteArray) {
+        /** `[type][payload]` — the exact bytes audio consumers expect. */
+        fun toFrameBytes(): ByteArray {
+            val bytes = ByteArray(1 + payload.size)
+            bytes[0] = type.toByte()
+            payload.copyInto(bytes, 1)
+            return bytes
+        }
+    }
+
+    /** Raised on malformed frame sequences; the connection must be closed. */
+    class ProtocolException(message: String) : Exception(message)
+
+    /**
+     * Per-direction decoder over decrypted frame plaintexts. Returns null while a
+     * fragmented message is being reassembled; throws [ProtocolException] on the
+     * spec's malformed sequences.
+     */
+    class Decoder {
+        private var inFlightType: Int = -1
+        private var buffer: MutableList<ByteArray>? = null
+
+        fun decode(plaintext: ByteArray): Message? {
+            if (plaintext.isEmpty()) throw ProtocolException("empty frame plaintext")
+            val type = plaintext[0].toInt() and 0xFF
+            val inFlight = buffer != null
+            return when (type) {
+                TYPE_FRAGMENT_MORE -> {
+                    if (!inFlight) {
+                        startFragment(plaintext)
+                    } else {
+                        buffer!!.add(plaintext.copyOfRange(1, plaintext.size))
+                    }
+                    null
+                }
+
+                TYPE_FRAGMENT_END -> {
+                    val parts = buffer
+                        ?: throw ProtocolException("fragment-end with no fragmented message in flight")
+                    parts.add(plaintext.copyOfRange(1, plaintext.size))
+                    val total = parts.sumOf { it.size }
+                    val payload = ByteArray(total)
+                    var offset = 0
+                    for (part in parts) {
+                        part.copyInto(payload, offset)
+                        offset += part.size
+                    }
+                    val message = Message(inFlightType, payload)
+                    buffer = null
+                    inFlightType = -1
+                    message
+                }
+
+                else -> {
+                    if (inFlight) {
+                        throw ProtocolException(
+                            "non-fragment frame (type $type) while a fragmented message is in flight",
+                        )
+                    }
+                    Message(type, plaintext.copyOfRange(1, plaintext.size))
+                }
+            }
+        }
+
+        private fun startFragment(plaintext: ByteArray) {
+            if (plaintext.size < 2) {
+                throw ProtocolException("opening fragment missing origType")
+            }
+            val origType = plaintext[1].toInt() and 0xFF
+            if (origType == TYPE_FRAGMENT_MORE || origType == TYPE_FRAGMENT_END) {
+                throw ProtocolException("fragmented message with fragment origType $origType")
+            }
+            inFlightType = origType
+            buffer = mutableListOf(plaintext.copyOfRange(2, plaintext.size))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseProtocol.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseProtocol.kt
@@ -1,0 +1,495 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.noise.crypto.NoiseCrypto
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+
+/**
+ * A focused implementation of the Noise Protocol Framework (revision 34)
+ * state machines for the `25519_ChaChaPoly_SHA256` suite, covering the
+ * handshake patterns Sendspin needs. Production uses `KKpsk2` with the client
+ * as Noise responder (the server is always the Noise initiator regardless of
+ * who opened the WebSocket); the initiator role and the extra patterns exist
+ * for reference-vector and loopback testing.
+ *
+ * Written greenfield against the spec (https://noiseprotocol.org/noise.html);
+ * `sander/noise-kotlin` (MIT) was assessed as a vendoring candidate and served
+ * as a design reference for the state-machine split, but it implements neither
+ * PSK tokens nor the KK pattern, so no code was reused. Correctness is pinned
+ * by the cacophony reference vectors run in the common test suite; do not edit
+ * this file without re-running them.
+ */
+
+internal const val DH_LEN = 32
+internal const val HASH_LEN = 32
+internal const val KEY_LEN = 32
+internal const val TAG_LEN = 16
+
+/** Raised on any Noise-level failure (AEAD failure, malformed message). */
+class NoiseException(message: String) : Exception(message)
+
+enum class NoiseRole { INITIATOR, RESPONDER }
+
+internal enum class Token { E, S, EE, ES, SE, SS, PSK }
+
+/**
+ * A handshake pattern: pre-message static keys plus per-message token lists.
+ * `hasPsk` marks psk-modified patterns, where processing an `e` token also
+ * mixes the ephemeral public key into the chaining key.
+ */
+internal class NoisePattern(
+    val name: String,
+    val initiatorPreSharesStatic: Boolean,
+    val responderPreSharesStatic: Boolean,
+    val messages: List<List<Token>>,
+    val hasPsk: Boolean,
+) {
+    companion object {
+        val KK = NoisePattern(
+            name = "KK",
+            initiatorPreSharesStatic = true,
+            responderPreSharesStatic = true,
+            messages = listOf(
+                listOf(Token.E, Token.ES, Token.SS),
+                listOf(Token.E, Token.EE, Token.SE),
+            ),
+            hasPsk = false,
+        )
+
+        val KKPSK2 = NoisePattern(
+            name = "KKpsk2",
+            initiatorPreSharesStatic = true,
+            responderPreSharesStatic = true,
+            messages = listOf(
+                listOf(Token.E, Token.ES, Token.SS),
+                listOf(Token.E, Token.EE, Token.SE, Token.PSK),
+            ),
+            hasPsk = true,
+        )
+
+        val NNPSK2 = NoisePattern(
+            name = "NNpsk2",
+            initiatorPreSharesStatic = false,
+            responderPreSharesStatic = false,
+            messages = listOf(
+                listOf(Token.E),
+                listOf(Token.E, Token.EE, Token.PSK),
+            ),
+            hasPsk = true,
+        )
+    }
+}
+
+/**
+ * Noise CipherState: a ChaCha20-Poly1305 key plus a per-direction message
+ * counter. An unkeyed CipherState passes data through unchanged (used before
+ * any DH output is mixed in).
+ */
+class CipherState internal constructor(private val crypto: NoiseCrypto) {
+    private var key: ByteArray? = null
+
+    // Internal visibility so tests can drive the counter to its limit.
+    internal var nonce: ULong = 0u
+
+    val hasKey: Boolean get() = key != null
+
+    internal fun initializeKey(newKey: ByteArray?) {
+        key = newKey
+        nonce = 0u
+    }
+
+    private fun checkNonceNotExhausted() {
+        // The final counter value is reserved: reusing a (key, nonce) pair
+        // after wraparound would be catastrophic for ChaCha20-Poly1305, so
+        // the session must end first.
+        if (nonce == ULong.MAX_VALUE) {
+            throw NoiseException("cipher nonce exhausted")
+        }
+    }
+
+    private fun nonceBytes(): ByteArray {
+        // ChaChaPoly nonce per Noise: 4 zero bytes then the counter as
+        // little-endian uint64.
+        val n = nonce
+        val bytes = ByteArray(NONCE_LEN)
+        for (i in 0 until COUNTER_LEN) {
+            bytes[NONCE_LEN - COUNTER_LEN + i] = ((n shr (Byte.SIZE_BITS * i)) and 0xFFu).toByte()
+        }
+        return bytes
+    }
+
+    private companion object {
+        const val NONCE_LEN = 12
+        const val COUNTER_LEN = 8
+    }
+
+    suspend fun encryptWithAd(associatedData: ByteArray, plaintext: ByteArray): ByteArray {
+        val k = key ?: return plaintext
+        checkNonceNotExhausted()
+        val ciphertext = crypto.aeadEncrypt(k, nonceBytes(), associatedData, plaintext)
+        nonce++
+        return ciphertext
+    }
+
+    suspend fun decryptWithAd(associatedData: ByteArray, ciphertext: ByteArray): ByteArray {
+        val k = key ?: return ciphertext
+        checkNonceNotExhausted()
+        val plaintext = crypto.aeadDecrypt(k, nonceBytes(), associatedData, ciphertext)
+            ?: throw NoiseException("AEAD authentication failed")
+        nonce++
+        return plaintext
+    }
+}
+
+/**
+ * Noise SymmetricState: the chaining key and handshake hash, plus an inner
+ * CipherState for handshake-phase encryption.
+ */
+internal class SymmetricState private constructor(
+    private val crypto: NoiseCrypto,
+    val cipher: CipherState,
+) {
+    private lateinit var chainingKey: ByteArray
+    lateinit var handshakeHash: ByteArray
+        private set
+
+    companion object {
+        suspend fun initialize(crypto: NoiseCrypto, protocolName: String): SymmetricState {
+            val state = SymmetricState(crypto, CipherState(crypto))
+            val nameBytes = protocolName.encodeToByteArray()
+            state.handshakeHash = if (nameBytes.size <= HASH_LEN) {
+                nameBytes.copyOf(HASH_LEN)
+            } else {
+                crypto.sha256(nameBytes)
+            }
+            state.chainingKey = state.handshakeHash.copyOf()
+            return state
+        }
+    }
+
+    private suspend fun hkdf(inputKeyMaterial: ByteArray, outputs: Int): List<ByteArray> {
+        val tempKey = crypto.hmacSha256(chainingKey, inputKeyMaterial)
+        val out1 = crypto.hmacSha256(tempKey, byteArrayOf(0x01))
+        if (outputs == 1) return listOf(out1)
+        val out2 = crypto.hmacSha256(tempKey, out1 + byteArrayOf(0x02))
+        if (outputs == 2) return listOf(out1, out2)
+        val out3 = crypto.hmacSha256(tempKey, out2 + byteArrayOf(0x03))
+        return listOf(out1, out2, out3)
+    }
+
+    suspend fun mixKey(inputKeyMaterial: ByteArray) {
+        val (ck, tempK) = hkdf(inputKeyMaterial, 2)
+        chainingKey = ck
+        cipher.initializeKey(tempK.copyOf(KEY_LEN))
+    }
+
+    suspend fun mixHash(data: ByteArray) {
+        handshakeHash = crypto.sha256(handshakeHash + data)
+    }
+
+    suspend fun mixKeyAndHash(inputKeyMaterial: ByteArray) {
+        val outputs = hkdf(inputKeyMaterial, 3)
+        chainingKey = outputs[0]
+        mixHash(outputs[1])
+        cipher.initializeKey(outputs[2].copyOf(KEY_LEN))
+    }
+
+    suspend fun encryptAndHash(plaintext: ByteArray): ByteArray {
+        val ciphertext = cipher.encryptWithAd(handshakeHash, plaintext)
+        mixHash(ciphertext)
+        return ciphertext
+    }
+
+    suspend fun decryptAndHash(ciphertext: ByteArray): ByteArray {
+        val plaintext = cipher.decryptWithAd(handshakeHash, ciphertext)
+        mixHash(ciphertext)
+        return plaintext
+    }
+
+    suspend fun split(): Pair<CipherState, CipherState> {
+        val (tempK1, tempK2) = hkdf(ByteArray(0), 2)
+        val c1 = CipherState(crypto)
+        c1.initializeKey(tempK1.copyOf(KEY_LEN))
+        val c2 = CipherState(crypto)
+        c2.initializeKey(tempK2.copyOf(KEY_LEN))
+        return c1 to c2
+    }
+}
+
+/**
+ * The transport-phase key material produced by a completed handshake:
+ * one CipherState per direction plus the final handshake hash `h` (used by
+ * Sendspin as the prologue of an in-band re-handshake).
+ */
+class NoiseTransport internal constructor(
+    private val sending: CipherState,
+    private val receiving: CipherState,
+    val handshakeHash: ByteArray,
+) {
+    suspend fun encrypt(plaintext: ByteArray): ByteArray {
+        if (plaintext.size + TAG_LEN > NoiseFraming.MAX_NOISE_MESSAGE) {
+            throw NoiseException("transport plaintext too large: ${plaintext.size}")
+        }
+        return sending.encryptWithAd(ByteArray(0), plaintext)
+    }
+
+    suspend fun decrypt(ciphertext: ByteArray): ByteArray {
+        if (ciphertext.size > NoiseFraming.MAX_NOISE_MESSAGE) {
+            throw NoiseException("transport ciphertext too large: ${ciphertext.size}")
+        }
+        return receiving.decryptWithAd(ByteArray(0), ciphertext)
+    }
+}
+
+/** Result of processing the final handshake message. */
+class HandshakeResult internal constructor(
+    val transport: NoiseTransport,
+    val handshakeHash: ByteArray,
+)
+
+/**
+ * Noise HandshakeState for the two-message interactive patterns above.
+ *
+ * Drive it by alternating [writeMessage] and [readMessage] according to the
+ * role: the initiator writes message 1 and reads message 2; the responder
+ * reads message 1 and writes message 2. After the second message, [result]
+ * carries the transport CipherStates and the final handshake hash.
+ */
+class HandshakeState private constructor(
+    private val crypto: NoiseCrypto,
+    private val pattern: NoisePattern,
+    private val role: NoiseRole,
+    private val localStatic: X25519KeyPair?,
+    private var remoteStaticPublic: ByteArray?,
+    private var psk: ByteArray?,
+    private var localEphemeral: X25519KeyPair?,
+) {
+    private lateinit var symmetric: SymmetricState
+    private var remoteEphemeralPublic: ByteArray? = null
+    private var messageIndex = 0
+
+    // Once any read or write fails, the symmetric state is partially mutated
+    // and must never be reused — the whole handshake must be discarded.
+    private var poisoned = false
+
+    var result: HandshakeResult? = null
+        private set
+
+    val isComplete: Boolean get() = result != null
+
+    /** The running handshake hash `h`. */
+    val handshakeHash: ByteArray get() = symmetric.handshakeHash
+
+    companion object {
+        internal suspend fun initialize(
+            crypto: NoiseCrypto,
+            pattern: NoisePattern,
+            role: NoiseRole,
+            prologue: ByteArray,
+            localStatic: X25519KeyPair? = null,
+            remoteStaticPublic: ByteArray? = null,
+            psk: ByteArray? = null,
+            localEphemeral: X25519KeyPair? = null,
+        ): HandshakeState {
+            // The PSK may be supplied later via providePsk: with the psk2
+            // modifier it is first needed only when processing the second
+            // message, after the peer has identified it by psk_id.
+            require(psk == null || psk.size == KEY_LEN) { "PSK must be $KEY_LEN bytes" }
+            val state = HandshakeState(
+                crypto,
+                pattern,
+                role,
+                localStatic,
+                remoteStaticPublic,
+                psk,
+                localEphemeral,
+            )
+            state.symmetric = SymmetricState.initialize(
+                crypto,
+                "Noise_${pattern.name}_25519_ChaChaPoly_SHA256",
+            )
+            state.symmetric.mixHash(prologue)
+            // Pre-messages: the initiator's static public key first, then the
+            // responder's, each hashed (never sent) because both sides know
+            // them in advance in K-type patterns.
+            if (pattern.initiatorPreSharesStatic) {
+                state.symmetric.mixHash(state.staticPublicFor(NoiseRole.INITIATOR))
+            }
+            if (pattern.responderPreSharesStatic) {
+                state.symmetric.mixHash(state.staticPublicFor(NoiseRole.RESPONDER))
+            }
+            return state
+        }
+
+        /**
+         * The Sendspin production configuration: `KKpsk2` with the client as
+         * responder. The server's public key is the initiator static. The PSK
+         * may be null here and supplied later via [providePsk], once the
+         * first handshake message has identified it by `psk_id`.
+         */
+        suspend fun sendspinResponder(
+            crypto: NoiseCrypto,
+            prologue: ByteArray,
+            clientStatic: X25519KeyPair,
+            serverStaticPublic: ByteArray,
+            psk: ByteArray?,
+        ): HandshakeState = initialize(
+            crypto = crypto,
+            pattern = NoisePattern.KKPSK2,
+            role = NoiseRole.RESPONDER,
+            prologue = prologue,
+            localStatic = clientStatic,
+            remoteStaticPublic = serverStaticPublic,
+            psk = psk,
+        )
+    }
+
+    /**
+     * Supplies the PSK after handshaking has begun — used by the Sendspin
+     * client, which selects the PSK by the `psk_id` carried in the first
+     * handshake message's payload before processing the second message.
+     */
+    fun providePsk(psk: ByteArray) {
+        require(psk.size == KEY_LEN) { "PSK must be $KEY_LEN bytes" }
+        check(!isComplete) { "handshake already complete" }
+        this.psk = psk
+    }
+
+    private fun staticPublicFor(owner: NoiseRole): ByteArray =
+        if (owner == role) {
+            localStatic?.publicKey ?: throw NoiseException("missing local static key")
+        } else {
+            remoteStaticPublic ?: throw NoiseException("missing remote static key")
+        }
+
+    private val writesMessage: Boolean
+        get() = (messageIndex % 2 == 0) == (role == NoiseRole.INITIATOR)
+
+    private fun localEphemeralPrivate(): ByteArray =
+        localEphemeral?.privateKey ?: throw NoiseException("missing local ephemeral")
+
+    private fun localStaticPrivate(): ByteArray =
+        localStatic?.privateKey ?: throw NoiseException("missing local static")
+
+    private fun remoteEphemeral(): ByteArray =
+        remoteEphemeralPublic ?: throw NoiseException("missing remote ephemeral")
+
+    private fun remoteStatic(): ByteArray =
+        remoteStaticPublic ?: throw NoiseException("missing remote static")
+
+    private suspend fun processDhToken(token: Token) {
+        val secret = when (token) {
+            Token.EE -> crypto.dh(localEphemeralPrivate(), remoteEphemeral())
+            Token.SS -> crypto.dh(localStaticPrivate(), remoteStatic())
+
+            // ES mixes DH(initiator ephemeral, responder static);
+            // SE mixes DH(initiator static, responder ephemeral).
+            Token.ES -> if (role == NoiseRole.INITIATOR) {
+                crypto.dh(localEphemeralPrivate(), remoteStatic())
+            } else {
+                crypto.dh(localStaticPrivate(), remoteEphemeral())
+            }
+
+            Token.SE -> if (role == NoiseRole.INITIATOR) {
+                crypto.dh(localStaticPrivate(), remoteEphemeral())
+            } else {
+                crypto.dh(localEphemeralPrivate(), remoteStatic())
+            }
+
+            else -> throw NoiseException("not a DH token: $token")
+        }
+        symmetric.mixKey(secret)
+    }
+
+    /** Writes the next handshake message carrying [payload]. */
+    suspend fun writeMessage(payload: ByteArray): ByteArray {
+        check(!poisoned) { "handshake state discarded after an earlier failure" }
+        check(!isComplete) { "handshake already complete" }
+        check(writesMessage) { "not this side's turn to write" }
+        return poisonOnFailure {
+            val tokens = pattern.messages[messageIndex]
+            var out = ByteArray(0)
+            for (token in tokens) {
+                when (token) {
+                    Token.E -> {
+                        val e = localEphemeral ?: crypto.generateX25519KeyPair().also {
+                            localEphemeral = it
+                        }
+                        out += e.publicKey
+                        symmetric.mixHash(e.publicKey)
+                        if (pattern.hasPsk) symmetric.mixKey(e.publicKey)
+                    }
+
+                    Token.S -> throw NoiseException("S token unsupported in these patterns")
+                    Token.PSK -> symmetric.mixKeyAndHash(
+                        psk ?: throw NoiseException("PSK required but not provided"),
+                    )
+
+                    else -> processDhToken(token)
+                }
+            }
+            out += symmetric.encryptAndHash(payload)
+            advance()
+            out
+        }
+    }
+
+    /** Reads a received handshake message, returning its payload. */
+    suspend fun readMessage(message: ByteArray): ByteArray {
+        check(!poisoned) { "handshake state discarded after an earlier failure" }
+        check(!isComplete) { "handshake already complete" }
+        check(!writesMessage) { "not this side's turn to read" }
+        return poisonOnFailure {
+            val tokens = pattern.messages[messageIndex]
+            var offset = 0
+            for (token in tokens) {
+                when (token) {
+                    Token.E -> {
+                        if (message.size - offset < DH_LEN) {
+                            throw NoiseException("handshake message too short for ephemeral key")
+                        }
+                        val re = message.copyOfRange(offset, offset + DH_LEN)
+                        offset += DH_LEN
+                        remoteEphemeralPublic = re
+                        symmetric.mixHash(re)
+                        if (pattern.hasPsk) symmetric.mixKey(re)
+                    }
+
+                    Token.S -> throw NoiseException("S token unsupported in these patterns")
+                    Token.PSK -> symmetric.mixKeyAndHash(
+                        psk ?: throw NoiseException("PSK required but not provided"),
+                    )
+
+                    else -> processDhToken(token)
+                }
+            }
+            val ciphertext = message.copyOfRange(offset, message.size)
+            if (symmetric.cipher.hasKey && ciphertext.size < TAG_LEN) {
+                throw NoiseException("handshake message too short for AEAD tag")
+            }
+            val payload = symmetric.decryptAndHash(ciphertext)
+            advance()
+            payload
+        }
+    }
+
+    private inline fun <T> poisonOnFailure(block: () -> T): T = try {
+        block()
+    } catch (e: Exception) {
+        poisoned = true
+        throw e
+    }
+
+    private suspend fun advance() {
+        messageIndex++
+        if (messageIndex == pattern.messages.size) {
+            val (c1, c2) = symmetric.split()
+            // c1 protects initiator-to-responder traffic, c2 the reverse.
+            val transport = if (role == NoiseRole.INITIATOR) {
+                NoiseTransport(sending = c1, receiving = c2, handshakeHash = symmetric.handshakeHash)
+            } else {
+                NoiseTransport(sending = c2, receiving = c1, handshakeHash = symmetric.handshakeHash)
+            }
+            result = HandshakeResult(transport, symmetric.handshakeHash)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/README.md
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/README.md
@@ -1,0 +1,55 @@
+# Sendspin Noise layer
+
+Implements the encrypted Sendspin connection's cryptographic core:
+`Noise_KKpsk2_25519_ChaChaPoly_SHA256` (Noise Protocol Framework rev. 34),
+with the server as Noise initiator and this client as responder, regardless of
+which side opened the WebSocket.
+
+## Spec mapping
+
+| Spec section | Code |
+| --- | --- |
+| connection.md §Encryption / §Pattern / §Cipher Suites | `NoiseProtocol.kt` |
+| connection.md §Pre-Shared Key (psk_id, sentinel, categories) | `SendspinPsk.kt` |
+| connection.md §Prologue, §Failure Handling; messaging.md §client/init, §server/init, §noise/handshake | `SendspinHandshake.kt` |
+| messaging.md §Binary Message ID Structure, §Fragmentation | `NoiseFraming.kt` |
+| pairing.md §Pairing Token | `../pairing/PairingToken.kt` |
+| crypto primitives | `crypto/NoiseCrypto.kt` (interface), `crypto/CryptographyKotlinNoiseCrypto.kt` |
+
+## Provenance
+
+The Noise state machines (`CipherState`, `SymmetricState`, `HandshakeState`)
+were written greenfield against the Noise specification. The JVM-only
+`sander/noise-kotlin` library (MIT) was assessed for vendoring and used as a
+design reference for the state-machine split, but no code was reused: it
+implements neither PSK tokens nor the KK pattern.
+
+Primitives come from cryptography-kotlin (pinned, pre-1.0), which wraps
+OS-native crypto: the JDK/JCA provider on Android and CryptoKit on iOS. Note
+that on iOS the `cryptography-provider-cryptokit` artifact is required — the
+`cryptography-provider-apple` (CommonCrypto) artifact does not register XDH or
+ChaCha20-Poly1305. The `NoiseCrypto` interface exists so the backend is
+swappable (e.g. libsodium bindings) and so tests can inject fixed keys.
+
+## Test vectors
+
+Correctness is pinned by reference vectors in
+`commonTest/.../noise/NoiseTestVectors.kt`, covering
+`Noise_KKpsk2_25519_ChaChaPoly_SHA256` plus `KK` and `NNpsk2` siblings — all
+handshake messages, transport ciphertexts, and the final handshake hash, in
+both roles (`NoiseKkpsk2VectorTest`). **Do not modify `NoiseProtocol.kt`
+without re-running them** (they are part of the common test suite, executed
+by the Android host-test and iOS simulator test lanes).
+
+To regenerate the fixture:
+
+1. Fetch the cacophony vector set distributed with snow:
+   `https://raw.githubusercontent.com/mcginty/snow/main/tests/vectors/cacophony.txt`
+   (the sibling `snow.txt` set contains no PSK-pattern vectors).
+2. Filter to the relevant protocols:
+   `jq '{vectors: [.vectors[] | select(.protocol_name | test("^Noise_(KKpsk2|KK|NNpsk2)_25519_ChaChaPoly_SHA256$"))]}' cacophony.txt`
+3. Embed the resulting JSON in the `NoiseTestVectors.json` raw string.
+
+Published constants (sentinel PSK, sentinel psk_id, the pairing-token
+reference vector) are asserted against the spec's literal values in
+`PskIdDerivationTest` and `PairingTokenCodecTest`.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinBase64.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinBase64.kt
@@ -1,0 +1,22 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import kotlin.io.encoding.Base64
+
+/**
+ * Base64url without padding, the encoding Sendspin uses for identities
+ * (`client_id`/`server_id`), `psk_id` values, and `noise/handshake` data.
+ */
+object SendspinBase64 {
+    private val codec = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
+
+    fun encode(bytes: ByteArray): String = codec.encode(bytes)
+
+    /** Decodes strictly; throws [IllegalArgumentException] on malformed input. */
+    fun decode(text: String): ByteArray = codec.decode(text)
+
+    fun decodeOrNull(text: String): ByteArray? = try {
+        codec.decode(text)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinHandshake.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinHandshake.kt
@@ -1,0 +1,209 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.model.ClientInitMessage
+import io.music_assistant.client.player.sendspin.model.ClientInitPayload
+import io.music_assistant.client.player.sendspin.model.NoiseHandshakeMessage
+import io.music_assistant.client.player.sendspin.model.NoiseHandshakePayload
+import io.music_assistant.client.player.sendspin.model.ServerInitMessage
+import io.music_assistant.client.player.sendspin.noise.crypto.NoiseCrypto
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** The only cipher suite this client implements. */
+const val SENDSPIN_SUITE_CHACHAPOLY = "25519_ChaChaPoly_SHA256"
+
+/** Core message-format version this client speaks (exact-match field). */
+const val SENDSPIN_CORE_VERSION = 1
+
+/**
+ * Any failure while establishing the encrypted channel. Per the spec's
+ * failure-handling rules the caller closes the WebSocket without sending any
+ * application-level error message.
+ */
+class HandshakeFailedException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
+
+/** Frames the handshake driver can receive during the cleartext phase. */
+sealed interface HandshakeFrame {
+    class Text(val text: String) : HandshakeFrame
+    class Binary(val bytes: ByteArray) : HandshakeFrame
+}
+
+/** Minimal transport view the initial (cleartext) handshake runs over. */
+interface HandshakeIo {
+    suspend fun sendText(text: String)
+    suspend fun receive(): HandshakeFrame
+}
+
+/** The established encrypted channel plus its authentication context. */
+class HandshakeOutcome(
+    val transport: NoiseTransport,
+    val handshakeHash: ByteArray,
+    val serverId: String,
+    val matched: PskCandidate,
+)
+
+/**
+ * Client-side encrypted-connection establishment: `client/init`/`server/init`,
+ * then the two `noise/handshake` messages (server is the Noise initiator).
+ * The initial prologue is the exact transmitted bytes of both init messages —
+ * never a re-encoding; a re-handshake's prologue is the prior handshake hash.
+ */
+class SendspinHandshake(
+    private val crypto: NoiseCrypto,
+    private val clientStatic: X25519KeyPair,
+    private val pskCandidates: suspend () -> List<PskCandidate>,
+    private val messageTimeoutMillis: Long = 30_000,
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    val clientId: String get() = SendspinBase64.encode(clientStatic.publicKey)
+
+    private suspend fun <T> awaitNext(what: String, block: suspend () -> T): T = try {
+        withTimeout(messageTimeoutMillis) { block() }
+    } catch (e: TimeoutCancellationException) {
+        throw HandshakeFailedException("timed out waiting for $what", e)
+    }
+
+    /** Full initial establishment; on failure the caller closes the socket
+     *  without an application-level error. */
+    suspend fun runInitial(io: HandshakeIo): HandshakeOutcome {
+        val clientInitText = json.encodeToString(
+            ClientInitMessage(
+                payload = ClientInitPayload(
+                    clientId = clientId,
+                    version = SENDSPIN_CORE_VERSION,
+                    suite = SENDSPIN_SUITE_CHACHAPOLY,
+                ),
+            ),
+        )
+        io.sendText(clientInitText)
+
+        val serverInitText = awaitNext("server/init") { receiveText(io) }
+        val serverInit = try {
+            json.decodeFromString<ServerInitMessage>(serverInitText)
+        } catch (e: Exception) {
+            throw HandshakeFailedException("malformed server/init", e)
+        }
+        if (serverInit.type != "server/init") {
+            throw HandshakeFailedException("expected server/init, got ${serverInit.type}")
+        }
+        if (serverInit.payload.version != SENDSPIN_CORE_VERSION) {
+            throw HandshakeFailedException(
+                "unsupported core version ${serverInit.payload.version}",
+            )
+        }
+        val serverId = serverInit.payload.serverId
+        val serverStaticPublic = SendspinBase64.decodeOrNull(serverId)
+            ?.takeIf { it.size == DH_LEN }
+            ?: throw HandshakeFailedException("malformed server_id")
+
+        // Prologue: exact wire bytes of client/init then server/init.
+        val prologue = clientInitText.encodeToByteArray() + serverInitText.encodeToByteArray()
+
+        return runNoiseExchange(
+            prologue = prologue,
+            serverId = serverId,
+            serverStaticPublic = serverStaticPublic,
+            sendMessage = { io.sendText(it) },
+            receiveMessage = { receiveText(io) },
+        )
+    }
+
+    private suspend fun receiveText(io: HandshakeIo): String =
+        when (val frame = io.receive()) {
+            is HandshakeFrame.Text -> frame.text
+            is HandshakeFrame.Binary ->
+                throw HandshakeFailedException("unexpected binary frame during handshake")
+        }
+
+    /** The two-message Noise exchange; a re-handshake caller routes messages
+     *  through the encrypted channel and passes the prior hash as [prologue]. */
+    suspend fun runNoiseExchange(
+        prologue: ByteArray,
+        serverId: String,
+        serverStaticPublic: ByteArray,
+        sendMessage: suspend (String) -> Unit,
+        receiveMessage: suspend () -> String,
+    ): HandshakeOutcome {
+        val handshake = HandshakeState.sendspinResponder(
+            crypto = crypto,
+            prologue = prologue,
+            clientStatic = clientStatic,
+            serverStaticPublic = serverStaticPublic,
+            psk = null,
+        )
+
+        // Noise message 1 (server → client). Its payload is decryptable
+        // without the PSK and carries the psk_id selecting one.
+        val message1Text = awaitNext("noise handshake message 1") { receiveMessage() }
+        val message1 = parseHandshakeMessage(message1Text)
+        val payload1 = try {
+            handshake.readMessage(message1)
+        } catch (e: NoiseException) {
+            throw HandshakeFailedException("noise message 1 failed", e)
+        }
+        val matched = selectCandidate(extractPskId(payload1), serverId)
+        handshake.providePsk(matched.psk)
+
+        // Noise message 2 (client → server); inner payload is the literal
+        // two-byte JSON object.
+        val message2 = try {
+            handshake.writeMessage("{}".encodeToByteArray())
+        } catch (e: NoiseException) {
+            throw HandshakeFailedException("noise message 2 failed", e)
+        }
+        sendMessage(
+            json.encodeToString(
+                NoiseHandshakeMessage(payload = NoiseHandshakePayload(SendspinBase64.encode(message2))),
+            ),
+        )
+
+        val result = handshake.result
+            ?: throw HandshakeFailedException("handshake did not complete")
+        return HandshakeOutcome(
+            transport = result.transport,
+            handshakeHash = result.handshakeHash,
+            serverId = serverId,
+            matched = matched,
+        )
+    }
+
+    private fun parseHandshakeMessage(text: String): ByteArray {
+        val message = try {
+            json.decodeFromString<NoiseHandshakeMessage>(text)
+        } catch (e: Exception) {
+            throw HandshakeFailedException("malformed noise/handshake message", e)
+        }
+        if (message.type != "noise/handshake") {
+            throw HandshakeFailedException("expected noise/handshake, got ${message.type}")
+        }
+        return SendspinBase64.decodeOrNull(message.payload.data)
+            ?: throw HandshakeFailedException("malformed noise/handshake data")
+    }
+
+    private fun extractPskId(payload: ByteArray): String = try {
+        val element = Json.parseToJsonElement(payload.decodeToString())
+        element.jsonObject.getValue("psk_id").jsonPrimitive.content
+    } catch (e: Exception) {
+        throw HandshakeFailedException("malformed noise message 1 inner payload", e)
+    }
+
+    private suspend fun selectCandidate(pskId: String, serverId: String): PskCandidate {
+        val matched = pskCandidates().firstOrNull { SendspinPsk.pskId(crypto, it.psk) == pskId }
+            ?: throw HandshakeFailedException("no PSK candidate for psk_id")
+        if (matched.category == PskCategory.LONG_TERM_STORED && matched.serverId != serverId) {
+            // Stored-pubkey model: the matched record must belong to the
+            // server that presented itself in server/init.
+            throw HandshakeFailedException("matched PSK bound to a different server")
+        }
+        return matched
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinPsk.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinPsk.kt
@@ -1,0 +1,56 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.noise.crypto.NoiseCrypto
+
+/**
+ * The three Sendspin PSK categories share one `psk_id` namespace; the client
+ * stores each PSK tagged with its category, and on a `psk_id` match the
+ * category determines trust handling.
+ */
+enum class PskCategory {
+    /** The published sentinel constant — no authentication on its own. */
+    SENTINEL,
+
+    /** This device's per-device Pairing PSK. */
+    PAIRING,
+
+    /** A per-server long-term PSK persisted with the server's `server_id`. */
+    LONG_TERM_STORED,
+
+    /** A shared long-term PSK persisted without a bound `server_id`. */
+    LONG_TERM_SHARED,
+}
+
+/**
+ * One PSK the client is willing to complete a handshake with. [serverId] is
+ * set only for [PskCategory.LONG_TERM_STORED] records, where a post-match
+ * check requires it to equal the `server_id` from `server/init`.
+ */
+class PskCandidate(
+    val psk: ByteArray,
+    val category: PskCategory,
+    val serverId: String? = null,
+)
+
+object SendspinPsk {
+    /** Label prefixed to a PSK when deriving its `psk_id`. */
+    private val PSK_ID_LABEL = "sendspin-psk-id-v1".encodeToByteArray()
+
+    /** Label whose SHA-256 is the sentinel PSK. */
+    internal val SENTINEL_LABEL = "sendspin-sentinel-psk-v1".encodeToByteArray()
+
+    /** `SHA-256("sendspin-sentinel-psk-v1")`, a published constant. */
+    val SENTINEL_PSK: ByteArray = byteArrayOf(
+        0x1b, 0x5e, 0x24, 0xdb.toByte(), 0xc1.toByte(), 0xae.toByte(), 0xd9.toByte(), 0x5f,
+        0xc2.toByte(), 0xa5.toByte(), 0xa3.toByte(), 0x38, 0xa9.toByte(), 0x0c, 0x05, 0xdf.toByte(),
+        0x44, 0xbd.toByte(), 0x10, 0xf5.toByte(), 0xec.toByte(), 0x1f, 0x4c, 0xd6.toByte(),
+        0x6c, 0xbf.toByte(), 0x86.toByte(), 0x27, 0x27, 0x67, 0xb9.toByte(), 0xd3.toByte(),
+    )
+
+    /** The sentinel PSK's published `psk_id`. */
+    const val SENTINEL_PSK_ID: String = "GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo"
+
+    /** `psk_id = base64url(SHA-256("sendspin-psk-id-v1" || PSK))`, 43 chars. */
+    suspend fun pskId(crypto: NoiseCrypto, psk: ByteArray): String =
+        SendspinBase64.encode(crypto.sha256(PSK_ID_LABEL + psk))
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/crypto/CryptographyKotlinNoiseCrypto.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/crypto/CryptographyKotlinNoiseCrypto.kt
@@ -1,0 +1,113 @@
+package io.music_assistant.client.player.sendspin.noise.crypto
+
+import co.touchlab.kermit.Logger
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.DelicateCryptographyApi
+import dev.whyoleg.cryptography.algorithms.ChaCha20Poly1305
+import dev.whyoleg.cryptography.algorithms.HMAC
+import dev.whyoleg.cryptography.algorithms.SHA256
+import dev.whyoleg.cryptography.algorithms.XDH
+import dev.whyoleg.cryptography.random.CryptographyRandom
+
+/**
+ * [NoiseCrypto] backed by cryptography-kotlin, which delegates to OS-native
+ * crypto: the JCA (JDK provider) on Android and CryptoKit on iOS. The
+ * provider artifacts are per-target runtime dependencies;
+ * `CryptographyProvider.Default` resolves whichever one is registered on the
+ * current platform.
+ *
+ * Android note: X25519 (`XDH`) through the platform JCA arrives with API 33;
+ * on older API levels (minSdk is below that) resolution depends on the
+ * runtime's registered providers (Conscrypt ships ChaCha20-Poly1305 from
+ * API 28). If X25519 is unavailable at runtime the handshake fails and the
+ * session surfaces the error; the `cryptography-provider-jdk-bc` BouncyCastle
+ * artifact is the documented drop-in fallback should field reports show this.
+ */
+class CryptographyKotlinNoiseCrypto(
+    private val provider: CryptographyProvider = CryptographyProvider.Default,
+) : NoiseCrypto {
+    private val logger = Logger.withTag("NoiseCrypto")
+
+    // Resolved once — hashing and DH hit these on the hot path. The AEAD
+    // algorithm is deliberately NOT cached: the JDK provider pools Cipher
+    // instances per algorithm handle, and a shared pool trips the JDK's
+    // key+nonce-reuse guard when one process runs both Noise roles
+    // (loopback tests) — encrypt and decrypt legitimately use the same
+    // key and nonce there.
+    private val xdh by lazy { provider.get(XDH) }
+    private val sha256Hasher by lazy { provider.get(SHA256).hasher() }
+    private val hmac by lazy { provider.get(HMAC) }
+
+    override suspend fun generateX25519KeyPair(): X25519KeyPair {
+        val keyPair = xdh.keyPairGenerator(XDH.Curve.X25519).generateKey()
+        return X25519KeyPair(
+            privateKey = keyPair.privateKey.encodeToByteArray(XDH.PrivateKey.Format.RAW),
+            publicKey = keyPair.publicKey.encodeToByteArray(XDH.PublicKey.Format.RAW),
+        )
+    }
+
+    override suspend fun x25519PublicKey(privateKey: ByteArray): ByteArray {
+        // The X25519 public key is by definition the DH of the private key
+        // with the curve's base point (u = 9), per RFC 7748.
+        val basePoint = ByteArray(32).also { it[0] = 9 }
+        return dh(privateKey, basePoint)
+    }
+
+    override suspend fun dh(privateKey: ByteArray, publicKey: ByteArray): ByteArray {
+        val private = xdh.privateKeyDecoder(XDH.Curve.X25519)
+            .decodeFromByteArray(XDH.PrivateKey.Format.RAW, privateKey)
+        val public = xdh.publicKeyDecoder(XDH.Curve.X25519)
+            .decodeFromByteArray(XDH.PublicKey.Format.RAW, publicKey)
+        return private.sharedSecretGenerator().generateSharedSecretToByteArray(public)
+    }
+
+    @OptIn(DelicateCryptographyApi::class)
+    override suspend fun aeadEncrypt(
+        key: ByteArray,
+        nonce: ByteArray,
+        associatedData: ByteArray,
+        plaintext: ByteArray,
+    ): ByteArray {
+        val cipherKey = provider.get(ChaCha20Poly1305)
+            .keyDecoder()
+            .decodeFromByteArray(ChaCha20Poly1305.Key.Format.RAW, key)
+        // Explicit caller-managed nonce: Noise supplies its own counter-based
+        // nonces, so the auto-IV encrypt() variants (which prepend a random
+        // IV) must not be used here.
+        return cipherKey.cipher().encryptWithIv(nonce, plaintext, associatedData)
+    }
+
+    @OptIn(DelicateCryptographyApi::class)
+    override suspend fun aeadDecrypt(
+        key: ByteArray,
+        nonce: ByteArray,
+        associatedData: ByteArray,
+        ciphertext: ByteArray,
+    ): ByteArray? {
+        val cipherKey = provider.get(ChaCha20Poly1305)
+            .keyDecoder()
+            .decodeFromByteArray(ChaCha20Poly1305.Key.Format.RAW, key)
+        return try {
+            cipherKey.cipher().decryptWithIv(nonce, ciphertext, associatedData)
+        } catch (e: Exception) {
+            // Tag/AAD mismatch surfaces as an exception from the underlying
+            // platform crypto; Noise treats it as a nullable auth failure.
+            // Logged at debug because this catch is broad: a configuration
+            // bug (wrong key/IV size) would otherwise masquerade as a forged
+            // message.
+            logger.d(e) { "AEAD decrypt failed" }
+            null
+        }
+    }
+
+    override suspend fun sha256(data: ByteArray): ByteArray = sha256Hasher.hash(data)
+
+    override suspend fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val hmacKey = hmac
+            .keyDecoder(SHA256)
+            .decodeFromByteArray(HMAC.Key.Format.RAW, key)
+        return hmacKey.signatureGenerator().generateSignature(data)
+    }
+
+    override fun randomBytes(count: Int): ByteArray = CryptographyRandom.nextBytes(count)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/crypto/NoiseCrypto.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/noise/crypto/NoiseCrypto.kt
@@ -1,0 +1,60 @@
+package io.music_assistant.client.player.sendspin.noise.crypto
+
+/** A raw X25519 keypair: both keys are 32 bytes. */
+class X25519KeyPair(val privateKey: ByteArray, val publicKey: ByteArray)
+
+/**
+ * The crypto primitives the Sendspin Noise implementation is built on
+ * (`Noise_KKpsk2_25519_ChaChaPoly_SHA256`): X25519 Diffie-Hellman,
+ * ChaCha20-Poly1305 AEAD, and SHA-256/HMAC-SHA-256 (HKDF is derived from HMAC
+ * by the protocol layer).
+ *
+ * All key material crosses this boundary as raw bytes so the backing library
+ * is swappable (currently cryptography-kotlin over JDK/CryptoKit; libsodium
+ * bindings would be a drop-in alternative) and so tests can drive the Noise
+ * state machine with fixed keys from reference vectors.
+ */
+interface NoiseCrypto {
+    /** Generates a fresh X25519 keypair from a CSPRNG. */
+    suspend fun generateX25519KeyPair(): X25519KeyPair
+
+    /** Derives the X25519 public key for a raw 32-byte private key. */
+    suspend fun x25519PublicKey(privateKey: ByteArray): ByteArray
+
+    /**
+     * X25519 Diffie-Hellman: returns the raw 32-byte shared secret between a
+     * local private key and a remote public key.
+     */
+    suspend fun dh(privateKey: ByteArray, publicKey: ByteArray): ByteArray
+
+    /**
+     * ChaCha20-Poly1305 encryption with an explicit 12-byte nonce and
+     * associated data. Returns ciphertext with the 16-byte tag appended.
+     */
+    suspend fun aeadEncrypt(
+        key: ByteArray,
+        nonce: ByteArray,
+        associatedData: ByteArray,
+        plaintext: ByteArray,
+    ): ByteArray
+
+    /**
+     * ChaCha20-Poly1305 decryption with an explicit 12-byte nonce and
+     * associated data. Returns null when authentication fails.
+     */
+    suspend fun aeadDecrypt(
+        key: ByteArray,
+        nonce: ByteArray,
+        associatedData: ByteArray,
+        ciphertext: ByteArray,
+    ): ByteArray?
+
+    /** One-shot SHA-256. */
+    suspend fun sha256(data: ByteArray): ByteArray
+
+    /** HMAC-SHA-256 with a raw key. */
+    suspend fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray
+
+    /** CSPRNG bytes (PSKs, nonces). */
+    fun randomBytes(count: Int): ByteArray
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/pairing/PairingToken.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/pairing/PairingToken.kt
@@ -1,0 +1,104 @@
+package io.music_assistant.client.player.sendspin.pairing
+
+/**
+ * The Sendspin pairing token: a single case-insensitive ASCII string carrying
+ * the client's static public key and its Pairing PSK, transferred out of band
+ * (copy/paste, QR) into a server to begin the Pairing PSK flow.
+ *
+ * ```
+ * token   = "SP:" || version || body
+ * payload = client_key (32 bytes) || pairing_psk (32 bytes)
+ * ```
+ *
+ * The body is the RFC 4648 base32 encoding of the payload with `=` padding
+ * stripped and every `2` transliterated to `9` (avoiding the easily-confused
+ * 2/Z pair in transcription), so a version-0 token is 107 characters drawn
+ * from the QR alphanumeric set.
+ */
+object PairingToken {
+    private const val PREFIX = "SP:"
+    private const val VERSION = '0'
+    private const val BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+    private const val KEY_SIZE = 32
+    private const val PAYLOAD_SIZE = KEY_SIZE * 2
+    private const val BASE32_GROUP_CHARS = 8
+    private const val BITS_PER_CHAR = 5
+    private const val BITS_PER_BYTE = 8
+    private const val CHAR_MASK = 0x1F
+    private const val BYTE_MASK = 0xFF
+
+    class Decoded(val clientKey: ByteArray, val pairingPsk: ByteArray)
+
+    fun mint(clientPublicKey: ByteArray, pairingPsk: ByteArray): String {
+        require(clientPublicKey.size == KEY_SIZE) { "client key must be $KEY_SIZE bytes" }
+        require(pairingPsk.size == KEY_SIZE) { "pairing PSK must be $KEY_SIZE bytes" }
+        val body = base32Encode(clientPublicKey + pairingPsk)
+            .replace("=", "")
+            .replace('2', '9')
+        return "$PREFIX$VERSION$body"
+    }
+
+    /**
+     * Lenient decode of operator-supplied input: trims whitespace, is
+     * case-insensitive, and tolerates a missing `SP:` prefix. Returns null on
+     * anything malformed.
+     */
+    fun decode(input: String): Decoded? {
+        var text = input.trim().uppercase()
+        if (text.startsWith(PREFIX)) text = text.removePrefix(PREFIX)
+        if (text.isEmpty() || text[0] != VERSION) return null
+        val body = text.substring(1).replace('9', '2')
+        val remainder = body.length % BASE32_GROUP_CHARS
+        val padded = if (remainder == 0) {
+            body
+        } else {
+            body + "=".repeat(BASE32_GROUP_CHARS - remainder)
+        }
+        val payload = base32Decode(padded) ?: return null
+        if (payload.size != PAYLOAD_SIZE) return null
+        return Decoded(
+            clientKey = payload.copyOfRange(0, KEY_SIZE),
+            pairingPsk = payload.copyOfRange(KEY_SIZE, PAYLOAD_SIZE),
+        )
+    }
+
+    private fun base32Encode(data: ByteArray): String {
+        val sb = StringBuilder()
+        var buffer = 0
+        var bits = 0
+        for (byte in data) {
+            buffer = (buffer shl BITS_PER_BYTE) or (byte.toInt() and BYTE_MASK)
+            bits += BITS_PER_BYTE
+            while (bits >= BITS_PER_CHAR) {
+                sb.append(BASE32_ALPHABET[(buffer shr (bits - BITS_PER_CHAR)) and CHAR_MASK])
+                bits -= BITS_PER_CHAR
+            }
+        }
+        if (bits > 0) {
+            sb.append(BASE32_ALPHABET[(buffer shl (BITS_PER_CHAR - bits)) and CHAR_MASK])
+        }
+        while (sb.length % BASE32_GROUP_CHARS != 0) sb.append('=')
+        return sb.toString()
+    }
+
+    private fun base32Decode(text: String): ByteArray? {
+        val stripped = text.trimEnd('=')
+        val out = ArrayList<Byte>(stripped.length * BITS_PER_CHAR / BITS_PER_BYTE)
+        var buffer = 0
+        var bits = 0
+        for (char in stripped) {
+            val value = BASE32_ALPHABET.indexOf(char)
+            if (value < 0) return null
+            buffer = (buffer shl BITS_PER_CHAR) or value
+            bits += BITS_PER_CHAR
+            if (bits >= BITS_PER_BYTE) {
+                out.add(((buffer shr (bits - BITS_PER_BYTE)) and BYTE_MASK).toByte())
+                bits -= BITS_PER_BYTE
+            }
+        }
+        // A canonical encoder leaves leftover bits zero; anything else is malformed.
+        if (bits > 0 && (buffer and ((1 shl bits) - 1)) != 0) return null
+        return out.toByteArray()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/LegacyWireGoldenTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/LegacyWireGoldenTest.kt
@@ -1,0 +1,142 @@
+package io.music_assistant.client.player.sendspin
+
+import io.music_assistant.client.player.sendspin.audio.Codec
+import io.music_assistant.client.player.sendspin.model.ClientAuthMessage
+import io.music_assistant.client.player.sendspin.model.ClientHelloMessage
+import io.music_assistant.client.player.sendspin.model.ClientStateMessage
+import io.music_assistant.client.player.sendspin.model.ClientStatePayload
+import io.music_assistant.client.player.sendspin.model.ClientTimeMessage
+import io.music_assistant.client.player.sendspin.model.ClientTimePayload
+import io.music_assistant.client.player.sendspin.model.PlayerStateObject
+import io.music_assistant.client.player.sendspin.model.PlayerStateValue
+import io.music_assistant.client.utils.myJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the exact wire bytes of the legacy (unencrypted) protocol's outbound
+ * messages. Older Music Assistant servers must keep seeing a byte-identical
+ * client, so any change to these fixtures is a compatibility break and must
+ * be deliberate.
+ */
+class LegacyWireGoldenTest {
+    private val config = SendspinConfig(
+        clientId = "client-golden",
+        deviceName = "Golden Device",
+        codecPreference = Codec.FLAC,
+        bufferCapacityBytes = 15_000_000,
+        serverHost = "example.local",
+        serverPort = 8095,
+        mainConnectionPort = 8095,
+        authToken = "token-golden",
+    )
+
+    @Test
+    fun authMessageWireBytesAreUnchanged() {
+        val expected = """
+            {
+                "type": "auth",
+                "token": "token-golden",
+                "client_id": "client-golden"
+            }
+        """.trimIndent()
+        assertEquals(
+            expected,
+            myJson.encodeToString(
+                ClientAuthMessage(token = "token-golden", clientId = "client-golden"),
+            ),
+        )
+    }
+
+    @Test
+    fun clientStateWireBytesAreUnchanged() {
+        val expected = """
+            {
+                "type": "client/state",
+                "payload": {
+                    "player": {
+                        "state": "synchronized"
+                    },
+                    "available": true
+                }
+            }
+        """.trimIndent()
+        assertEquals(
+            expected,
+            myJson.encodeToString(
+                ClientStateMessage(
+                    payload = ClientStatePayload(
+                        player = PlayerStateObject(state = PlayerStateValue.SYNCHRONIZED),
+                        available = true,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun clientTimeWireBytesAreUnchanged() {
+        val expected = """
+            {
+                "type": "client/time",
+                "payload": {
+                    "client_transmitted": 123456789
+                }
+            }
+        """.trimIndent()
+        assertEquals(
+            expected,
+            myJson.encodeToString(
+                ClientTimeMessage(payload = ClientTimePayload(clientTransmitted = 123456789L)),
+            ),
+        )
+    }
+
+    @Test
+    fun clientHelloWireShapeIsUnchanged() {
+        val capabilities = SendspinCapabilities.buildClientHello(config, Codec.OPUS)
+        val actual = myJson.encodeToString(ClientHelloMessage(payload = capabilities))
+
+        // Head and structural fields pinned exactly; the supported_formats list
+        // is the 15-entry sample-rate × bit-depth expansion, pinned by its
+        // first entry, count, and tail.
+        val expectedHead = """
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "client-golden",
+                    "name": "Golden Device",
+                    "device_info": {
+                        "model": "Mobile Application",
+                        "model_id": "mobile_app",
+                        "manufacturer": "Music Assistant",
+                        "manufacturer_id": "music_assistant",
+                        "software_version": "1.0.0"
+                    },
+                    "version": 1,
+                    "supported_roles": [
+                        "player@v1"
+                    ],
+                    "player@v1_support": {
+                        "supported_formats": [
+                            {
+                                "codec": "opus",
+                                "channels": 2,
+                                "sample_rate": 44100,
+                                "bit_depth": 16
+                            },
+        """.trimIndent()
+        val expectedTail = """
+                        ],
+                        "buffer_capacity": 15000000,
+                        "supported_commands": []
+                    }
+                }
+            }
+        """.trimIndent()
+
+        assertEquals(expectedHead, actual.substring(0, expectedHead.length))
+        assertEquals(expectedTail, actual.substring(actual.length - expectedTail.length))
+        assertEquals(15, Regex("\"codec\": \"opus\"").findAll(actual).count())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/FakeSendspinKeyStore.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/FakeSendspinKeyStore.kt
@@ -1,0 +1,23 @@
+package io.music_assistant.client.player.sendspin.identity
+
+/** In-memory [SendspinKeyStore] with corruption injection for recovery tests. */
+class FakeSendspinKeyStore : SendspinKeyStore {
+    val entries = mutableMapOf<String, ByteArray>()
+    var writeCount = 0
+        private set
+
+    override fun read(key: String): ByteArray? = entries[key]?.copyOf()
+
+    override fun write(key: String, value: ByteArray) {
+        writeCount++
+        entries[key] = value.copyOf()
+    }
+
+    override fun delete(key: String) {
+        entries.remove(key)
+    }
+
+    fun corrupt(key: String) {
+        entries[key] = "corrupted \u0000 blob".encodeToByteArray()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinIdentityTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/SendspinIdentityTest.kt
@@ -1,0 +1,80 @@
+package io.music_assistant.client.player.sendspin.identity
+
+import io.music_assistant.client.player.sendspin.noise.SendspinBase64
+import io.music_assistant.client.player.sendspin.noise.crypto.CryptographyKotlinNoiseCrypto
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class SendspinIdentityTest {
+    private val crypto = CryptographyKotlinNoiseCrypto()
+
+    @Test
+    fun firstLoadCreatesAndPersistsIdentityAndPairingPsk() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val store = SendspinTrustStore.load(keyStore, crypto)
+
+        assertEquals(43, store.clientId.length)
+        assertEquals(32, SendspinBase64.decode(store.clientId).size)
+        assertEquals(32, store.pairingPsk.size)
+        assertTrue(store.pairingToken().startsWith("SP:0"))
+        assertEquals(2, keyStore.entries.size)
+    }
+
+    @Test
+    fun subsequentLoadsYieldSameClientIdAndPairingToken() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+        val second = SendspinTrustStore.load(keyStore, crypto)
+
+        assertEquals(first.clientId, second.clientId)
+        assertEquals(first.pairingToken(), second.pairingToken())
+    }
+
+    @Test
+    fun missingStorageRegeneratesWithoutCrash() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+        keyStore.entries.clear()
+
+        val second = SendspinTrustStore.load(keyStore, crypto)
+        assertNotEquals(first.clientId, second.clientId)
+        assertEquals(43, second.clientId.length)
+    }
+
+    @Test
+    fun corruptIdentityRegeneratesAndResetsTrustRecordsAtomically() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+        first.recordLongTermPsk(ByteArray(32) { 1 }, serverId = "server-a")
+
+        keyStore.corrupt("sendspin.identity")
+        val second = SendspinTrustStore.load(keyStore, crypto)
+
+        assertNotEquals(first.clientId, second.clientId)
+        // Records belonging to the old identity are gone; only the fresh
+        // pre-provisioned shared record remains.
+        assertTrue(second.records().none { it.serverId == "server-a" })
+        assertNotEquals(first.pairingToken(), second.pairingToken())
+    }
+
+    @Test
+    fun identityWithMismatchedPublicKeyIsTreatedAsCorrupt() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+
+        // Overwrite the stored public key half with a different valid key.
+        val other = crypto.generateX25519KeyPair()
+        val stored = keyStore.entries.getValue("sendspin.identity").decodeToString()
+        val tampered = stored.replace(
+            first.clientId,
+            SendspinBase64.encode(other.publicKey),
+        )
+        keyStore.write("sendspin.identity", tampered.encodeToByteArray())
+
+        val second = SendspinTrustStore.load(keyStore, crypto)
+        assertNotEquals(first.clientId, second.clientId)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/TrustStoreRecoveryTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/identity/TrustStoreRecoveryTest.kt
@@ -1,0 +1,127 @@
+package io.music_assistant.client.player.sendspin.identity
+
+import io.music_assistant.client.player.sendspin.noise.PskCategory
+import io.music_assistant.client.player.sendspin.noise.SendspinPsk
+import io.music_assistant.client.player.sendspin.noise.crypto.CryptographyKotlinNoiseCrypto
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TrustStoreRecoveryTest {
+    private val crypto = CryptographyKotlinNoiseCrypto()
+
+    @Test
+    fun corruptTrustBlobResetsTrustButKeepsIdentity() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+        first.recordLongTermPsk(ByteArray(32) { 5 }, serverId = "server-a")
+
+        keyStore.corrupt("sendspin.trust")
+        val second = SendspinTrustStore.load(keyStore, crypto)
+
+        assertEquals(first.clientId, second.clientId)
+        assertTrue(second.records().none { it.serverId == "server-a" })
+        assertFalse(first.pairingPsk.contentEquals(second.pairingPsk))
+    }
+
+    @Test
+    fun freshStoreHasOnePreProvisionedSharedRecord() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        val records = store.records()
+        assertEquals(1, records.size)
+        assertEquals(null, records[0].serverId)
+        assertFalse(records[0].used)
+    }
+
+    @Test
+    fun candidatesContainSentinelPairingAndRecords() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        val longTerm = ByteArray(32) { 9 }
+        store.recordLongTermPsk(longTerm, serverId = "server-a")
+
+        val candidates = store.pskCandidates()
+        assertContentEquals(
+            SendspinPsk.SENTINEL_PSK,
+            candidates.single { it.category == PskCategory.SENTINEL }.psk,
+        )
+        assertContentEquals(
+            store.pairingPsk,
+            candidates.single { it.category == PskCategory.PAIRING }.psk,
+        )
+        val stored = candidates.single { it.category == PskCategory.LONG_TERM_STORED }
+        assertContentEquals(longTerm, stored.psk)
+        assertEquals("server-a", stored.serverId)
+        assertEquals(1, candidates.count { it.category == PskCategory.LONG_TERM_SHARED })
+    }
+
+    @Test
+    fun disablingPairingMethodRemovesCandidateImmediately() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        assertTrue(store.pskCandidates().any { it.category == PskCategory.PAIRING })
+        store.setPairingPskEnabled(false)
+        assertTrue(store.pskCandidates().none { it.category == PskCategory.PAIRING })
+        store.setPairingPskEnabled(true)
+        assertTrue(store.pskCandidates().any { it.category == PskCategory.PAIRING })
+    }
+
+    @Test
+    fun mutationsPersistAcrossReload() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val first = SendspinTrustStore.load(keyStore, crypto)
+        val longTerm = ByteArray(32) { 3 }
+        first.recordLongTermPsk(longTerm, serverId = "server-b")
+        first.markRecordUsed(longTerm)
+        first.setUnpairedAccessEnabled(true)
+
+        val second = SendspinTrustStore.load(keyStore, crypto)
+        val record = second.records().single { it.serverId == "server-b" }
+        assertContentEquals(longTerm, record.psk)
+        assertTrue(record.used)
+        assertTrue(second.unpairedAccessEnabled)
+    }
+
+    @Test
+    fun recordForSameServerIsReplacedNotDuplicated() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        store.recordLongTermPsk(ByteArray(32) { 1 }, serverId = "server-a")
+        store.recordLongTermPsk(ByteArray(32) { 2 }, serverId = "server-a")
+
+        val records = store.records().filter { it.serverId == "server-a" }
+        assertEquals(1, records.size)
+        assertContentEquals(ByteArray(32) { 2 }, records[0].psk)
+    }
+
+    @Test
+    fun removeRecordDeletesOnlyMatchingPsk() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        val pskA = ByteArray(32) { 1 }
+        store.recordLongTermPsk(pskA, serverId = "server-a")
+        store.recordLongTermPsk(ByteArray(32) { 2 }, serverId = "server-b")
+
+        assertTrue(store.removeRecord(pskA))
+        assertFalse(store.removeRecord(pskA))
+        assertTrue(store.records().any { it.serverId == "server-b" })
+        assertTrue(store.records().none { it.serverId == "server-a" })
+    }
+
+    @Test
+    fun everyMutationRewritesWholeBlobOnce() = runTest {
+        val keyStore = FakeSendspinKeyStore()
+        val store = SendspinTrustStore.load(keyStore, crypto)
+        val writesAfterLoad = keyStore.writeCount
+        store.setUnpairedAccessEnabled(true)
+        assertEquals(writesAfterLoad + 1, keyStore.writeCount)
+    }
+
+    @Test
+    fun pairingPskRotationChangesToken() = runTest {
+        val store = SendspinTrustStore.load(FakeSendspinKeyStore(), crypto)
+        val before = store.pairingToken()
+        store.setPairingPsk(ByteArray(32) { 7 })
+        assertNotEquals(before, store.pairingToken())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseFramingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseFramingTest.kt
@@ -1,0 +1,133 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NoiseFramingTest {
+    private fun roundTrip(type: Int, payload: ByteArray): NoiseFraming.Message {
+        val frames = NoiseFraming.encode(type, payload)
+        frames.forEach { assertTrue(it.size <= NoiseFraming.MAX_FRAME_PLAINTEXT) }
+        val decoder = NoiseFraming.Decoder()
+        var result: NoiseFraming.Message? = null
+        frames.forEachIndexed { index, frame ->
+            val decoded = decoder.decode(frame)
+            if (index < frames.size - 1) assertNull(decoded) else result = decoded
+        }
+        return result!!
+    }
+
+    @Test
+    fun smallJsonMessageUsesSingleFrame() {
+        val payload = """{"type":"server/hello"}""".encodeToByteArray()
+        val frames = NoiseFraming.encode(NoiseFraming.TYPE_JSON, payload)
+        assertEquals(1, frames.size)
+        assertEquals(0, frames[0][0].toInt())
+        assertContentEquals(payload, frames[0].copyOfRange(1, frames[0].size))
+        val message = roundTrip(NoiseFraming.TYPE_JSON, payload)
+        assertEquals(NoiseFraming.TYPE_JSON, message.type)
+        assertContentEquals(payload, message.payload)
+    }
+
+    @Test
+    fun payloadAtLimitStaysUnfragmented() {
+        val payload = ByteArray(NoiseFraming.MAX_UNFRAGMENTED_PAYLOAD) { it.toByte() }
+        assertEquals(1, NoiseFraming.encode(NoiseFraming.TYPE_JSON, payload).size)
+    }
+
+    @Test
+    fun oversizedJsonPayloadRoundTripsThroughFragments() {
+        val payload = Random(42).nextBytes(200_000)
+        val frames = NoiseFraming.encode(NoiseFraming.TYPE_JSON, payload)
+        assertTrue(frames.size > 1)
+        assertEquals(NoiseFraming.TYPE_FRAGMENT_MORE, frames.first()[0].toInt())
+        assertEquals(NoiseFraming.TYPE_JSON, frames.first()[1].toInt())
+        assertEquals(NoiseFraming.TYPE_FRAGMENT_END, frames.last()[0].toInt())
+        val message = roundTrip(NoiseFraming.TYPE_JSON, payload)
+        assertEquals(NoiseFraming.TYPE_JSON, message.type)
+        assertContentEquals(payload, message.payload)
+    }
+
+    @Test
+    fun oversizedAudioPayloadRestoresFrameBytesExactly() {
+        val payload = Random(7).nextBytes(NoiseFraming.MAX_UNFRAGMENTED_PAYLOAD + 1)
+        val message = roundTrip(4, payload)
+        assertEquals(4, message.type)
+        val frameBytes = message.toFrameBytes()
+        assertEquals(4, frameBytes[0].toInt())
+        assertContentEquals(payload, frameBytes.copyOfRange(1, frameBytes.size))
+    }
+
+    @Test
+    fun oneByteOverLimitFragmentsIntoTwoFrames() {
+        val payload = ByteArray(NoiseFraming.MAX_UNFRAGMENTED_PAYLOAD + 1)
+        val frames = NoiseFraming.encode(NoiseFraming.TYPE_JSON, payload)
+        assertEquals(2, frames.size)
+        assertContentEquals(payload, roundTrip(NoiseFraming.TYPE_JSON, payload).payload)
+    }
+
+    @Test
+    fun fragmentEndWithNothingInFlightIsProtocolError() {
+        val decoder = NoiseFraming.Decoder()
+        assertFailsWith<NoiseFraming.ProtocolException> {
+            decoder.decode(byteArrayOf(3, 1, 2, 3))
+        }
+    }
+
+    @Test
+    fun nonFragmentFrameWhileFragmentInFlightIsProtocolError() {
+        val decoder = NoiseFraming.Decoder()
+        assertNull(decoder.decode(byteArrayOf(2, 0, 9, 9)))
+        assertFailsWith<NoiseFraming.ProtocolException> {
+            decoder.decode(byteArrayOf(0, 1, 2))
+        }
+    }
+
+    @Test
+    fun fragmentOrigTypeCannotBeAFragmentType() {
+        val decoder = NoiseFraming.Decoder()
+        assertFailsWith<NoiseFraming.ProtocolException> {
+            decoder.decode(byteArrayOf(2, 3, 9))
+        }
+    }
+
+    @Test
+    fun emptyFramePlaintextIsProtocolError() {
+        assertFailsWith<NoiseFraming.ProtocolException> {
+            NoiseFraming.Decoder().decode(ByteArray(0))
+        }
+    }
+
+    @Test
+    fun openingFragmentMissingOrigTypeIsProtocolError() {
+        assertFailsWith<NoiseFraming.ProtocolException> {
+            NoiseFraming.Decoder().decode(byteArrayOf(2))
+        }
+    }
+
+    @Test
+    fun encoderRejectsFragmentTypesAsApplicationTypes() {
+        assertFailsWith<IllegalArgumentException> {
+            NoiseFraming.encode(NoiseFraming.TYPE_FRAGMENT_MORE, ByteArray(1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            NoiseFraming.encode(NoiseFraming.TYPE_FRAGMENT_END, ByteArray(1))
+        }
+    }
+
+    @Test
+    fun decoderIsReusableAcrossMessages() {
+        val decoder = NoiseFraming.Decoder()
+        val big = Random(1).nextBytes(70_000)
+        var last: NoiseFraming.Message? = null
+        NoiseFraming.encode(NoiseFraming.TYPE_JSON, big).forEach { last = decoder.decode(it) }
+        assertContentEquals(big, last!!.payload)
+        val small = decoder.decode(byteArrayOf(4, 42))!!
+        assertEquals(4, small.type)
+        assertContentEquals(byteArrayOf(42), small.payload)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseKkpsk2VectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseKkpsk2VectorTest.kt
@@ -1,0 +1,282 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.noise.crypto.CryptographyKotlinNoiseCrypto
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Runs the cacophony reference vectors for the 25519_ChaChaPoly_SHA256
+ * handshake patterns implemented here, asserting byte-exact handshake
+ * messages, transport ciphertexts, and the final handshake hash from both the
+ * initiator and responder perspectives. Because the vectors run against the
+ * real cryptography-kotlin backend, they also prove the platform primitives
+ * (X25519, ChaCha20-Poly1305, SHA-256, HMAC) on every test target.
+ */
+class NoiseKkpsk2VectorTest {
+    private class Vector(
+        val protocolName: String,
+        val initPrologue: ByteArray,
+        val initStatic: ByteArray?,
+        val initEphemeral: ByteArray,
+        val respStatic: ByteArray?,
+        val respEphemeral: ByteArray,
+        val psk: ByteArray?,
+        val handshakeHash: ByteArray,
+        val messages: List<Pair<ByteArray, ByteArray>>,
+    )
+
+    private fun String.decodeHex(): ByteArray {
+        check(length % 2 == 0)
+        return ByteArray(length / 2) { i ->
+            substring(2 * i, 2 * i + 2).toInt(16).toByte()
+        }
+    }
+
+    private fun loadVectors(): List<Vector> {
+        val root = Json.parseToJsonElement(NoiseTestVectors.json).jsonObject
+        return root.getValue("vectors").jsonArray.map { element ->
+            val obj = element.jsonObject
+            fun hex(key: String): ByteArray? = obj[key]?.jsonPrimitive?.content?.decodeHex()
+            Vector(
+                protocolName = obj.getValue("protocol_name").jsonPrimitive.content,
+                initPrologue = hex("init_prologue") ?: ByteArray(0),
+                initStatic = hex("init_static"),
+                initEphemeral = hex("init_ephemeral")!!,
+                respStatic = hex("resp_static"),
+                respEphemeral = hex("resp_ephemeral")!!,
+                psk = obj["init_psks"]?.jsonArray?.firstOrNull()
+                    ?.jsonPrimitive?.content?.decodeHex(),
+                handshakeHash = hex("handshake_hash")!!,
+                messages = obj.getValue("messages").jsonArray.map { m ->
+                    val msg = m.jsonObject
+                    Pair(
+                        msg.getValue("payload").jsonPrimitive.content.decodeHex(),
+                        msg.getValue("ciphertext").jsonPrimitive.content.decodeHex(),
+                    )
+                },
+            )
+        }
+    }
+
+    private fun patternFor(name: String): NoisePattern = when (name) {
+        "Noise_KK_25519_ChaChaPoly_SHA256" -> NoisePattern.KK
+        "Noise_KKpsk2_25519_ChaChaPoly_SHA256" -> NoisePattern.KKPSK2
+        "Noise_NNpsk2_25519_ChaChaPoly_SHA256" -> NoisePattern.NNPSK2
+        else -> error("unexpected vector protocol: $name")
+    }
+
+    private suspend fun keyPairFrom(
+        crypto: CryptographyKotlinNoiseCrypto,
+        privateKey: ByteArray?,
+    ): X25519KeyPair? = privateKey?.let {
+        X25519KeyPair(privateKey = it, publicKey = crypto.x25519PublicKey(it))
+    }
+
+    private suspend fun runVector(vector: Vector) {
+        val crypto = CryptographyKotlinNoiseCrypto()
+        val pattern = patternFor(vector.protocolName)
+        val initStatic = keyPairFrom(crypto, vector.initStatic)
+        val respStatic = keyPairFrom(crypto, vector.respStatic)
+
+        val initiator = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = pattern,
+            role = NoiseRole.INITIATOR,
+            prologue = vector.initPrologue,
+            localStatic = initStatic,
+            remoteStaticPublic = respStatic?.publicKey,
+            psk = vector.psk,
+            localEphemeral = keyPairFrom(crypto, vector.initEphemeral),
+        )
+        val responder = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = pattern,
+            role = NoiseRole.RESPONDER,
+            prologue = vector.initPrologue,
+            localStatic = respStatic,
+            remoteStaticPublic = initStatic?.publicKey,
+            psk = vector.psk,
+            localEphemeral = keyPairFrom(crypto, vector.respEphemeral),
+        )
+
+        // Two handshake messages: initiator writes the first, responder the
+        // second; each side must produce the vector's exact ciphertext.
+        val handshakeMessages = pattern.messages.size
+        for (index in 0 until handshakeMessages) {
+            val (payload, expectedCiphertext) = vector.messages[index]
+            val writer = if (index % 2 == 0) initiator else responder
+            val reader = if (index % 2 == 0) responder else initiator
+            val written = writer.writeMessage(payload)
+            assertContentEquals(
+                expectedCiphertext,
+                written,
+                "${vector.protocolName} handshake message $index",
+            )
+            assertContentEquals(payload, reader.readMessage(written))
+        }
+
+        assertTrue(initiator.isComplete)
+        assertTrue(responder.isComplete)
+        val initResult = initiator.result!!
+        val respResult = responder.result!!
+        assertContentEquals(vector.handshakeHash, initResult.handshakeHash)
+        assertContentEquals(vector.handshakeHash, respResult.handshakeHash)
+
+        // Remaining messages exercise transport mode, alternating directions
+        // starting with the initiator.
+        for (index in handshakeMessages until vector.messages.size) {
+            val (payload, expectedCiphertext) = vector.messages[index]
+            val sender = if (index % 2 == 0) initResult.transport else respResult.transport
+            val receiver = if (index % 2 == 0) respResult.transport else initResult.transport
+            val encrypted = sender.encrypt(payload)
+            assertContentEquals(
+                expectedCiphertext,
+                encrypted,
+                "${vector.protocolName} transport message $index",
+            )
+            assertContentEquals(payload, receiver.decrypt(encrypted))
+        }
+    }
+
+    @Test
+    fun kkpsk2VectorPasses() = runTest {
+        val vector = loadVectors().single {
+            it.protocolName == "Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+        }
+        assertEquals(6, vector.messages.size)
+        runVector(vector)
+    }
+
+    @Test
+    fun kkVectorPasses() = runTest {
+        runVector(loadVectors().single { it.protocolName == "Noise_KK_25519_ChaChaPoly_SHA256" })
+    }
+
+    @Test
+    fun nnpsk2VectorPasses() = runTest {
+        runVector(loadVectors().single { it.protocolName == "Noise_NNpsk2_25519_ChaChaPoly_SHA256" })
+    }
+
+    @Test
+    fun exhaustedNonceFailsInsteadOfWrapping() = runTest {
+        val crypto = CryptographyKotlinNoiseCrypto()
+        val cipher = CipherState(crypto)
+        cipher.initializeKey(ByteArray(32) { 1 })
+        cipher.nonce = ULong.MAX_VALUE
+        var failed = false
+        try {
+            cipher.encryptWithAd(ByteArray(0), byteArrayOf(1))
+        } catch (_: NoiseException) {
+            failed = true
+        }
+        assertTrue(failed, "the reserved final counter value must error, never wrap")
+
+        cipher.initializeKey(ByteArray(32) { 1 })
+        cipher.nonce = ULong.MAX_VALUE
+        failed = false
+        try {
+            cipher.decryptWithAd(ByteArray(0), ByteArray(17))
+        } catch (_: NoiseException) {
+            failed = true
+        }
+        assertTrue(failed)
+    }
+
+    @Test
+    fun failedHandshakeStateCannotBeReused() = runTest {
+        // Fresh keys rather than the shared vector fixture: the JDK provider
+        // pools Cipher instances and refuses back-to-back initialization with
+        // an identical key+nonce, which re-decrypting the vector's first
+        // message across tests would trigger.
+        val crypto = CryptographyKotlinNoiseCrypto()
+        val initStatic = crypto.generateX25519KeyPair()
+        val respStatic = crypto.generateX25519KeyPair()
+        val psk = crypto.randomBytes(32)
+        val initiator = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = NoisePattern.KKPSK2,
+            role = NoiseRole.INITIATOR,
+            prologue = ByteArray(0),
+            localStatic = initStatic,
+            remoteStaticPublic = respStatic.publicKey,
+            psk = psk,
+        )
+        val responder = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = NoisePattern.KKPSK2,
+            role = NoiseRole.RESPONDER,
+            prologue = ByteArray(0),
+            localStatic = respStatic,
+            remoteStaticPublic = initStatic.publicKey,
+            psk = psk,
+        )
+        // A corrupted first message fails AEAD and partially mutates the
+        // symmetric state; the handshake must refuse any further use.
+        val message1 = initiator.writeMessage(ByteArray(0))
+        val corrupted = message1.copyOf()
+        corrupted[corrupted.size - 1] = (corrupted.last().toInt() xor 1).toByte()
+        var failed = false
+        try {
+            responder.readMessage(corrupted)
+        } catch (_: NoiseException) {
+            failed = true
+        }
+        assertTrue(failed)
+
+        var refused = false
+        try {
+            responder.readMessage(message1)
+        } catch (_: IllegalStateException) {
+            refused = true
+        }
+        assertTrue(refused, "a failed handshake state must be discarded, not retried")
+    }
+
+    @Test
+    fun tamperedTransportCiphertextFailsAuthentication() = runTest {
+        val crypto = CryptographyKotlinNoiseCrypto()
+        val vector = loadVectors().single {
+            it.protocolName == "Noise_KKpsk2_25519_ChaChaPoly_SHA256"
+        }
+        val initiator = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = NoisePattern.KKPSK2,
+            role = NoiseRole.INITIATOR,
+            prologue = vector.initPrologue,
+            localStatic = keyPairFrom(crypto, vector.initStatic),
+            remoteStaticPublic = keyPairFrom(crypto, vector.respStatic)?.publicKey,
+            psk = vector.psk,
+            localEphemeral = keyPairFrom(crypto, vector.initEphemeral),
+        )
+        val responder = HandshakeState.initialize(
+            crypto = crypto,
+            pattern = NoisePattern.KKPSK2,
+            role = NoiseRole.RESPONDER,
+            prologue = vector.initPrologue,
+            localStatic = keyPairFrom(crypto, vector.respStatic),
+            remoteStaticPublic = keyPairFrom(crypto, vector.initStatic)?.publicKey,
+            psk = vector.psk,
+            localEphemeral = keyPairFrom(crypto, vector.respEphemeral),
+        )
+        responder.readMessage(initiator.writeMessage(ByteArray(0)))
+        initiator.readMessage(responder.writeMessage(ByteArray(0)))
+
+        val ciphertext = initiator.result!!.transport.encrypt("hello".encodeToByteArray())
+        ciphertext[0] = (ciphertext[0].toInt() xor 0x01).toByte()
+        var failed = false
+        try {
+            responder.result!!.transport.decrypt(ciphertext)
+        } catch (_: NoiseException) {
+            failed = true
+        }
+        assertTrue(failed, "tampered ciphertext must fail AEAD authentication")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseTestVectors.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/NoiseTestVectors.kt
@@ -1,0 +1,144 @@
+package io.music_assistant.client.player.sendspin.noise
+
+/**
+ * Reference handshake + transport vectors for the Noise protocol suites used by
+ * (or adjacent to) Sendspin encryption, embedded as JSON so every test target
+ * (JVM host tests, iOS simulator tests) can read them without platform
+ * resource-loading machinery.
+ *
+ * Provenance: extracted from the cacophony vector set distributed with the
+ * `snow` Noise implementation (https://github.com/mcginty/snow,
+ * tests/vectors/cacophony.txt), filtered to the 25519_ChaChaPoly_SHA256
+ * suites relevant here. See player/sendspin/noise/README.md for how to
+ * regenerate.
+ */
+internal object NoiseTestVectors {
+    const val json: String = """
+{
+  "vectors": [
+    {
+      "protocol_name": "Noise_KK_25519_ChaChaPoly_SHA256",
+      "init_prologue": "4a6f686e2047616c74",
+      "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+      "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+      "init_remote_static": "31e0303fd6418d2f8c0e78b91f22e8caed0fbe48656dcf4767e4834f701b8f62",
+      "resp_prologue": "4a6f686e2047616c74",
+      "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+      "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+      "resp_remote_static": "6bc3822a2aa7f4e6981d6538692b3cdf3e6df9eea6ed269eb41d93c22757b75a",
+      "handshake_hash": "24c6b51ecb76277140ca018b5985bc9f03de321dae2d34dcae433dafef0131d9",
+      "messages": [
+        {
+          "payload": "4c756477696720766f6e204d69736573",
+          "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c79440177015efc1fe7a37c629af7120a96274e6ab7afcc9261901d0e09ae32a5bb96"
+        },
+        {
+          "payload": "4d757272617920526f746862617264",
+          "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f144808843b274d3429adc47ca093ba63ef90f8da89fda108db471dccfa4894aa7b00003"
+        },
+        {
+          "payload": "462e20412e20486179656b",
+          "ciphertext": "966b05bc69ec01b8454d3160a214e6f24a3d884eb31ec2408af63f"
+        },
+        {
+          "payload": "4361726c204d656e676572",
+          "ciphertext": "0ad887fba4f611bbb4afe44ba3556b8164332ca7d5934634d63d80"
+        },
+        {
+          "payload": "4a65616e2d426170746973746520536179",
+          "ciphertext": "012b28ae646ae7830e2c5472cb023eab071c1db3d8413ec69b513b83832f974c2d"
+        },
+        {
+          "payload": "457567656e2042f6686d20766f6e2042617765726b",
+          "ciphertext": "bb3e6a48160d9c5971d37f975727294e0d868342db31832e54d07191ab0ca3c3703b5ed3d9"
+        }
+      ]
+    },
+    {
+      "protocol_name": "Noise_NNpsk2_25519_ChaChaPoly_SHA256",
+      "init_prologue": "4a6f686e2047616c74",
+      "init_psks": [
+        "54686973206973206d7920417573747269616e20706572737065637469766521"
+      ],
+      "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+      "resp_prologue": "4a6f686e2047616c74",
+      "resp_psks": [
+        "54686973206973206d7920417573747269616e20706572737065637469766521"
+      ],
+      "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+      "handshake_hash": "bb9704f2303bd8b98b40fdb2ee50c2a9a46d7d20ea4d0949ae3094e376b29b1c",
+      "messages": [
+        {
+          "payload": "4c756477696720766f6e204d69736573",
+          "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944d44698de33ea6b7eea8023b48a284404489f9976c5f03417e8e2d6db7ab6bb9f"
+        },
+        {
+          "payload": "4d757272617920526f746862617264",
+          "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f14480884361200acbacd001a0d19a826982488f52573687652551ca5e903db095fedc7a"
+        },
+        {
+          "payload": "462e20412e20486179656b",
+          "ciphertext": "5ac8678baf0ef0cf884ab3271236b7ee57a02519505f4a4be09b95"
+        },
+        {
+          "payload": "4361726c204d656e676572",
+          "ciphertext": "fe899e844ac0d348a3ab679b83c95fd1099f734a0dc085955adce2"
+        },
+        {
+          "payload": "4a65616e2d426170746973746520536179",
+          "ciphertext": "f8800be62325c8bd6794f7e533bb90316c6ba569a4223e644175f4e5e458e840fd"
+        },
+        {
+          "payload": "457567656e2042f6686d20766f6e2042617765726b",
+          "ciphertext": "2f60885aedcd5b5c142a3190208b540407ab4477528ea8d15bd795416575e58121098a4a9f"
+        }
+      ]
+    },
+    {
+      "protocol_name": "Noise_KKpsk2_25519_ChaChaPoly_SHA256",
+      "init_prologue": "4a6f686e2047616c74",
+      "init_psks": [
+        "54686973206973206d7920417573747269616e20706572737065637469766521"
+      ],
+      "init_static": "e61ef9919cde45dd5f82166404bd08e38bceb5dfdfded0a34c8df7ed542214d1",
+      "init_ephemeral": "893e28b9dc6ca8d611ab664754b8ceb7bac5117349a4439a6b0569da977c464a",
+      "init_remote_static": "31e0303fd6418d2f8c0e78b91f22e8caed0fbe48656dcf4767e4834f701b8f62",
+      "resp_prologue": "4a6f686e2047616c74",
+      "resp_psks": [
+        "54686973206973206d7920417573747269616e20706572737065637469766521"
+      ],
+      "resp_static": "4a3acbfdb163dec651dfa3194dece676d437029c62a408b4c5ea9114246e4893",
+      "resp_ephemeral": "bbdb4cdbd309f1a1f2e1456967fe288cadd6f712d65dc7b7793d5e63da6b375b",
+      "resp_remote_static": "6bc3822a2aa7f4e6981d6538692b3cdf3e6df9eea6ed269eb41d93c22757b75a",
+      "handshake_hash": "7f3c5fdcdd3767e2835473a2683971490339f5bbeee82c3690bc606e14db70ed",
+      "messages": [
+        {
+          "payload": "4c756477696720766f6e204d69736573",
+          "ciphertext": "ca35def5ae56cec33dc2036731ab14896bc4c75dbb07a61f879f8e3afa4c7944babf6443250c604872e33233c3b9a29df5c6d334ae2d53f1bd7f0b265a716b37"
+        },
+        {
+          "payload": "4d757272617920526f746862617264",
+          "ciphertext": "95ebc60d2b1fa672c1f46a8aa265ef51bfe38e7ccb39ec5be34069f14480884366a1f5f0d79fe93ae476bd1897a7a8ae92764898aa5d49e07b5849f35865ba"
+        },
+        {
+          "payload": "462e20412e20486179656b",
+          "ciphertext": "2eb2686b8814a7c0178fe18bfeeafe3e07312d69486d45e6572546"
+        },
+        {
+          "payload": "4361726c204d656e676572",
+          "ciphertext": "eea5791a890cd573a5c2e2345a8f98b0d1f0727acd24584fcddde5"
+        },
+        {
+          "payload": "4a65616e2d426170746973746520536179",
+          "ciphertext": "ab2e1a411abaaa3df9cb497dffe4cfb70af6c71f0815b3c33b35e22329dee72f3e"
+        },
+        {
+          "payload": "457567656e2042f6686d20766f6e2042617765726b",
+          "ciphertext": "ed22a0392c6afbfd6a6adea92b1faf13c4df24072f7060a20b1500609621c6957ac86d82f9"
+        }
+      ]
+    }
+  ]
+}
+"""
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/PskIdDerivationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/PskIdDerivationTest.kt
@@ -1,0 +1,34 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.noise.crypto.CryptographyKotlinNoiseCrypto
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class PskIdDerivationTest {
+    private val crypto = CryptographyKotlinNoiseCrypto()
+
+    @Test
+    fun sentinelPskIsHashOfPublishedLabel() = runTest {
+        assertContentEquals(
+            SendspinPsk.SENTINEL_PSK,
+            crypto.sha256(SendspinPsk.SENTINEL_LABEL),
+        )
+    }
+
+    @Test
+    fun sentinelPskIdMatchesPublishedConstant() = runTest {
+        assertEquals(
+            SendspinPsk.SENTINEL_PSK_ID,
+            SendspinPsk.pskId(crypto, SendspinPsk.SENTINEL_PSK),
+        )
+    }
+
+    @Test
+    fun pskIdIs43CharacterBase64Url() = runTest {
+        val id = SendspinPsk.pskId(crypto, ByteArray(32) { it.toByte() })
+        assertEquals(43, id.length)
+        assertEquals(32, SendspinBase64.decode(id).size)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinHandshakeTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/noise/SendspinHandshakeTest.kt
@@ -1,0 +1,264 @@
+package io.music_assistant.client.player.sendspin.noise
+
+import io.music_assistant.client.player.sendspin.model.NoiseHandshakeMessage
+import io.music_assistant.client.player.sendspin.model.NoiseHandshakePayload
+import io.music_assistant.client.player.sendspin.model.ServerInitMessage
+import io.music_assistant.client.player.sendspin.model.ServerInitPayload
+import io.music_assistant.client.player.sendspin.noise.crypto.CryptographyKotlinNoiseCrypto
+import io.music_assistant.client.player.sendspin.noise.crypto.X25519KeyPair
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SendspinHandshakeTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private class PipeIo : HandshakeIo {
+        val clientToServer = Channel<String>(Channel.UNLIMITED)
+        val serverToClient = Channel<HandshakeFrame>(Channel.UNLIMITED)
+
+        override suspend fun sendText(text: String) {
+            clientToServer.send(text)
+        }
+
+        override suspend fun receive(): HandshakeFrame = serverToClient.receive()
+    }
+
+    /**
+     * A minimal in-test Sendspin server: Noise initiator over the piped
+     * frames, with overridable behavior to exercise each failure branch.
+     */
+    private inner class FakeServer(
+        val crypto: CryptographyKotlinNoiseCrypto,
+        val serverStatic: X25519KeyPair,
+        val clientStaticPublic: ByteArray,
+        val psk: ByteArray,
+    ) {
+        val serverId: String get() = SendspinBase64.encode(serverStatic.publicKey)
+        var receivedClientInit: String? = null
+        var transport: NoiseTransport? = null
+
+        suspend fun run(
+            io: PipeIo,
+            serverInitVersion: Int = SENDSPIN_CORE_VERSION,
+            innerPayloadOverride: String? = null,
+        ) {
+            val clientInitText = io.clientToServer.receive()
+            receivedClientInit = clientInitText
+            val serverInitText = json.encodeToString(
+                ServerInitMessage(payload = ServerInitPayload(serverId, serverInitVersion)),
+            )
+            io.serverToClient.send(HandshakeFrame.Text(serverInitText))
+
+            val prologue =
+                clientInitText.encodeToByteArray() + serverInitText.encodeToByteArray()
+            val initiator = HandshakeState.initialize(
+                crypto = crypto,
+                pattern = NoisePattern.KKPSK2,
+                role = NoiseRole.INITIATOR,
+                prologue = prologue,
+                localStatic = serverStatic,
+                remoteStaticPublic = clientStaticPublic,
+                psk = psk,
+            )
+            val innerPayload = innerPayloadOverride
+                ?: """{"psk_id":"${SendspinPsk.pskId(crypto, psk)}"}"""
+            val message1 = initiator.writeMessage(innerPayload.encodeToByteArray())
+            io.serverToClient.send(
+                HandshakeFrame.Text(
+                    json.encodeToString(
+                        NoiseHandshakeMessage(
+                            payload = NoiseHandshakePayload(SendspinBase64.encode(message1)),
+                        ),
+                    ),
+                ),
+            )
+
+            val message2Text = io.clientToServer.receive()
+            val message2 = json.decodeFromString<NoiseHandshakeMessage>(message2Text)
+            val payload2 = initiator.readMessage(SendspinBase64.decode(message2.payload.data))
+            assertContentEquals("{}".encodeToByteArray(), payload2)
+            transport = initiator.result!!.transport
+        }
+    }
+
+    private suspend fun newFixture(): Triple<CryptographyKotlinNoiseCrypto, X25519KeyPair, X25519KeyPair> {
+        val crypto = CryptographyKotlinNoiseCrypto()
+        return Triple(crypto, crypto.generateX25519KeyPair(), crypto.generateX25519KeyPair())
+    }
+
+    @Test
+    fun sentinelHandshakeEstablishesInteroperableTransport() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, SendspinPsk.SENTINEL_PSK)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(PskCandidate(SendspinPsk.SENTINEL_PSK, PskCategory.SENTINEL))
+            },
+        )
+        val io = PipeIo()
+        val serverJob = launch { server.run(io) }
+        val outcome = handshake.runInitial(io)
+        serverJob.join()
+
+        assertEquals(PskCategory.SENTINEL, outcome.matched.category)
+        assertEquals(server.serverId, outcome.serverId)
+
+        // The first wire frame is a well-formed client/init.
+        val clientInit = Json.parseToJsonElement(server.receivedClientInit!!).jsonObject
+        assertEquals("client/init", clientInit.getValue("type").jsonPrimitive.content)
+        val payload = clientInit.getValue("payload").jsonObject
+        assertEquals(handshake.clientId, payload.getValue("client_id").jsonPrimitive.content)
+        assertEquals("1", payload.getValue("version").jsonPrimitive.content)
+        assertEquals(
+            SENDSPIN_SUITE_CHACHAPOLY,
+            payload.getValue("suite").jsonPrimitive.content,
+        )
+
+        // Both directions of the established channel interoperate.
+        val fromServer = server.transport!!.encrypt("server says hi".encodeToByteArray())
+        assertContentEquals(
+            "server says hi".encodeToByteArray(),
+            outcome.transport.decrypt(fromServer),
+        )
+        val fromClient = outcome.transport.encrypt("client says hi".encodeToByteArray())
+        assertContentEquals(
+            "client says hi".encodeToByteArray(),
+            server.transport!!.decrypt(fromClient),
+        )
+    }
+
+    @Test
+    fun unknownPskIdFailsHandshake() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val serverPsk = ByteArray(32) { 0x42 }
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, serverPsk)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(PskCandidate(SendspinPsk.SENTINEL_PSK, PskCategory.SENTINEL))
+            },
+        )
+        val io = PipeIo()
+        backgroundScope.launch { runCatching { server.run(io) } }
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(io) }
+    }
+
+    @Test
+    fun malformedInnerPayloadFailsHandshake() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, SendspinPsk.SENTINEL_PSK)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(PskCandidate(SendspinPsk.SENTINEL_PSK, PskCategory.SENTINEL))
+            },
+        )
+        val io = PipeIo()
+        backgroundScope.launch { runCatching { server.run(io, innerPayloadOverride = "not-json") } }
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(io) }
+    }
+
+    @Test
+    fun storedRecordBoundToDifferentServerFailsAfterMatch() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val longTermPsk = ByteArray(32) { 0x17 }
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, longTermPsk)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(
+                    PskCandidate(
+                        psk = longTermPsk,
+                        category = PskCategory.LONG_TERM_STORED,
+                        serverId = "someone-else",
+                    ),
+                )
+            },
+        )
+        val io = PipeIo()
+        backgroundScope.launch { runCatching { server.run(io) } }
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(io) }
+    }
+
+    @Test
+    fun storedRecordBoundToThisServerSucceeds() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val longTermPsk = ByteArray(32) { 0x17 }
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, longTermPsk)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(
+                    PskCandidate(
+                        psk = longTermPsk,
+                        category = PskCategory.LONG_TERM_STORED,
+                        serverId = server.serverId,
+                    ),
+                )
+            },
+        )
+        val io = PipeIo()
+        val serverJob = launch { server.run(io) }
+        val outcome = handshake.runInitial(io)
+        serverJob.join()
+        assertEquals(PskCategory.LONG_TERM_STORED, outcome.matched.category)
+    }
+
+    @Test
+    fun unsupportedServerInitVersionFailsHandshake() = runTest {
+        val (crypto, clientStatic, serverStatic) = newFixture()
+        val server = FakeServer(crypto, serverStatic, clientStatic.publicKey, SendspinPsk.SENTINEL_PSK)
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = {
+                listOf(PskCandidate(SendspinPsk.SENTINEL_PSK, PskCategory.SENTINEL))
+            },
+        )
+        val io = PipeIo()
+        backgroundScope.launch { runCatching { server.run(io, serverInitVersion = 2) } }
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(io) }
+    }
+
+    @Test
+    fun binaryFrameDuringHandshakeFails() = runTest {
+        val (crypto, clientStatic, _) = newFixture()
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = { emptyList() },
+        )
+        val io = PipeIo()
+        io.serverToClient.send(HandshakeFrame.Binary(byteArrayOf(1, 2, 3)))
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(io) }
+    }
+
+    @Test
+    fun silentServerTimesOutAsHandshakeFailure() = runTest {
+        val (crypto, clientStatic, _) = newFixture()
+        val handshake = SendspinHandshake(
+            crypto = crypto,
+            clientStatic = clientStatic,
+            pskCandidates = { emptyList() },
+            messageTimeoutMillis = 50,
+        )
+        assertFailsWith<HandshakeFailedException> { handshake.runInitial(PipeIo()) }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/pairing/PairingTokenCodecTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/pairing/PairingTokenCodecTest.kt
@@ -1,0 +1,78 @@
+package io.music_assistant.client.player.sendspin.pairing
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PairingTokenCodecTest {
+    // Specification reference vector: client_key = 0x00..0x1f,
+    // pairing_psk = 0xe0..0xff.
+    private val referenceClientKey = ByteArray(32) { it.toByte() }
+    private val referencePsk = ByteArray(32) { (0xe0 + it).toByte() }
+    private val referenceToken =
+        "SP:0AAAQEAYEAUDAOCAJBIFQYDIOB4IBCEQTCQKRMFYYDENBWHA5DYP6BYPC4PSOLZXH5DU6V97M5XXO74HR6LZ7J5PW674PT6X37T6757Y"
+
+    @Test
+    fun mintMatchesSpecificationReferenceVector() {
+        assertEquals(referenceToken, PairingToken.mint(referenceClientKey, referencePsk))
+    }
+
+    @Test
+    fun tokenIs107CharactersPlusPrefix() {
+        assertEquals(4 + 103, referenceToken.length)
+    }
+
+    @Test
+    fun decodeReferenceVectorRecoversPayload() {
+        val decoded = PairingToken.decode(referenceToken)!!
+        assertContentEquals(referenceClientKey, decoded.clientKey)
+        assertContentEquals(referencePsk, decoded.pairingPsk)
+    }
+
+    @Test
+    fun decodeIsLenientWithOperatorInput() {
+        val sloppy = "  ${referenceToken.lowercase()}\n"
+        val decoded = PairingToken.decode(sloppy)!!
+        assertContentEquals(referenceClientKey, decoded.clientKey)
+        assertContentEquals(referencePsk, decoded.pairingPsk)
+    }
+
+    @Test
+    fun decodeToleratesMissingPrefix() {
+        val decoded = PairingToken.decode(referenceToken.removePrefix("SP:"))!!
+        assertContentEquals(referenceClientKey, decoded.clientKey)
+    }
+
+    @Test
+    fun decodeRejectsUnknownVersion() {
+        assertNull(PairingToken.decode("SP:1" + referenceToken.substring(4)))
+    }
+
+    @Test
+    fun decodeRejectsWrongPayloadLength() {
+        assertNull(PairingToken.decode("SP:0AAAA"))
+    }
+
+    @Test
+    fun decodeRejectsIllegalCharacters() {
+        assertNull(PairingToken.decode(referenceToken.replace('A', '!')))
+    }
+
+    @Test
+    fun decodeRejectsNonCanonicalTrailingBits() {
+        // The 103-char body leaves 3 trailing bits; a canonical encoder zeroes
+        // them, so an altered final character that sets them must be rejected
+        // rather than aliasing to the same payload.
+        assertNull(PairingToken.decode(referenceToken.dropLast(1) + "B"))
+    }
+
+    @Test
+    fun mintDecodeRoundTripsArbitraryKeys() {
+        val key = ByteArray(32) { (it * 7 + 3).toByte() }
+        val psk = ByteArray(32) { (255 - it).toByte() }
+        val decoded = PairingToken.decode(PairingToken.mint(key, psk))!!
+        assertContentEquals(key, decoded.clientKey)
+        assertContentEquals(psk, decoded.pairingPsk)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,9 @@ androidx-compose-ui-test = "1.11.4"
 robolectric = "4.16.1"
 detekt = "1.23.8"
 turbine = "1.2.1"
+# Pre-1.0 crypto primitives library; pinned deliberately. Wraps OS-native
+# crypto (JDK provider on Android, CryptoKit on iOS) behind one commonMain API.
+cryptographyKotlin = "0.6.0"
 
 
 [libraries]
@@ -124,6 +127,12 @@ compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.r
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core", version.ref = "cryptographyKotlin" }
+cryptography-provider-jdk = { module = "dev.whyoleg.cryptography:cryptography-provider-jdk", version.ref = "cryptographyKotlin" }
+# The CryptoKit provider (not "apple"/CommonCrypto) is required on iOS: it is
+# the one registering XDH (X25519) and ChaCha20-Poly1305.
+cryptography-provider-cryptokit = { module = "dev.whyoleg.cryptography:cryptography-provider-cryptokit", version.ref = "cryptographyKotlin" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
I have the new Sendspin encryption working. For review-ability I've split it into three PRs, of which this is the first. It's "just" the encryption bits, not actually wired into anything. The second commit refactors the connection establishing bits into protocol sessions while still only supporting the legacy approach, and the third finishes by wiring it all together.

## Is there anything about the code changes here that should be highlighted?
- noise: Noise Protocol Framework state machines for Noise_KKpsk2_25519_ChaChaPoly_SHA256, pinned by cacophony reference vectors; the Sendspin handshake driver (init exchange, raw-byte prologue, psk_id candidate selection, stored-pubkey post-match); message-type framing and fragmentation; psk_id derivation and sentinel constants; crypto primitives behind a swappable NoiseCrypto interface, backed by cryptography-kotlin (JCA on Android, CryptoKit on iOS).
- identity: persisted X25519 device identity + versioned single-blob trust store (Pairing PSK, long-term records, config flags, live PSK-candidate set) over the app's regular settings storage, with clean regeneration on missing or corrupt data.
- pairing/PairingToken: the out-of-band token codec (base32, 2->9 transliteration, canonical-bits validation) with the spec vector.
- model/Messages: encrypted-protocol message models alongside the frozen legacy models; LegacyWireGoldenTest pins the legacy wire bytes.
- 
## Are there any additional changes not related to the issue above?

I'm marking this as a Chore so it doesn't go into the changelog. I figured we add the third and final PR into the changelog with a simple 'Enable Sendspin encryption' title, since that's what users will care about.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

