### PR TITLE
Persist checkmark for active DSP preset

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
@@ -105,6 +105,7 @@ object APICommands {
     // DSP commands
     const val CONFIG_PLAYERS_DSP_GET = "config/players/dsp/get"
     const val CONFIG_PLAYERS_DSP_SAVE = "config/players/dsp/save"
+    const val CONFIG_PLAYERS_DSP_APPLY_PRESET = "config/players/dsp/apply_preset"
     const val CONFIG_DSP_PRESETS_GET = "config/dsp_presets/get"
 
     // Media type kinds

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
@@ -808,6 +808,14 @@ data class Request @OptIn(ExperimentalUuidApi::class) constructor(
             },
         )
 
+        fun applyPreset(playerId: String, presetId: String) = Request(
+            command = APICommands.CONFIG_PLAYERS_DSP_APPLY_PRESET,
+            args = buildJsonObject {
+                put("player_id", JsonPrimitive(playerId))
+                put("preset_id", JsonPrimitive(presetId))
+            },
+        )
+
         fun getPresets() = Request(command = APICommands.CONFIG_DSP_PRESETS_GET)
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/CarDspApplier.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/CarDspApplier.kt
@@ -2,9 +2,11 @@ package io.music_assistant.client.data
 
 import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.server.supportsDspApplyPreset
 import io.music_assistant.client.settings.CarDspAction
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.matches
+import io.music_assistant.client.utils.HasConnectionData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -78,7 +80,18 @@ class CarDspApplier(
                     logger.i { "$edge: preset '${action.name}' not found on server, skipping" }
                     return
                 }
-                dataSource.saveDspConfig(playerId, preset.config.copy(enabled = true))
+                val schemaVersion = (serviceClient.sessionState.value as? HasConnectionData)
+                    ?.serverInfo?.schemaVersion
+                val presetId = preset.presetId
+                val applied = if (presetId != null && supportsDspApplyPreset(schemaVersion)) {
+                    dataSource.applyDspPreset(playerId, presetId)
+                } else {
+                    dataSource.saveDspConfig(playerId, preset.config.copy(enabled = true))
+                }
+                if (applied == null) {
+                    logger.w { "$edge: failed to apply DSP preset '${preset.name}'" }
+                    return
+                }
                 logger.i { "$edge: applied DSP preset '${preset.name}'" }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -913,6 +913,10 @@ class MainDataSource(
             .getOrNull()?.resultAs<DspConfig>()
     }
 
+    suspend fun applyDspPreset(playerId: String, presetId: String): DspConfig? =
+        apiClient.sendRequest(Request.Dsp.applyPreset(playerId, presetId))
+            .getOrNull()?.resultAs<DspConfig>()
+
     suspend fun getDspPresets(): List<DspConfigPreset> =
         apiClient.sendRequest(Request.Dsp.getPresets())
             .getOrNull()?.resultAs<List<DspConfigPreset>>() ?: emptyList()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/DspClasses.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/DspClasses.kt
@@ -4,12 +4,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 
+/** First server API schema with `config/players/dsp/apply_preset` and the active `preset_id`. */
+const val DSP_APPLY_PRESET_MIN_SCHEMA = 38
+
+fun supportsDspApplyPreset(schemaVersion: Int?): Boolean =
+    schemaVersion != null && schemaVersion >= DSP_APPLY_PRESET_MIN_SCHEMA
+
 @Serializable
 data class DspConfig(
     @SerialName("enabled") val enabled: Boolean = false,
     @SerialName("input_gain") val inputGain: Double = 0.0,
     @SerialName("output_gain") val outputGain: Double = 0.0,
     @SerialName("filters") val filters: JsonArray = JsonArray(emptyList()),
+    @SerialName("preset_id") val presetId: String? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsDialog.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.server.DspConfigPreset
-import io.music_assistant.client.ui.alphaOn
 import musicassistantclient.composeapp.generated.resources.*
 import musicassistantclient.composeapp.generated.resources.Res
 import org.jetbrains.compose.resources.stringResource
@@ -141,10 +140,7 @@ private fun DspContent(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .alphaOn(state.config.enabled)
-                            .clickable(enabled = state.config.enabled) {
-                                onApplyPreset(preset)
-                            }
+                            .clickable { onApplyPreset(preset) }
                             .padding(horizontal = 16.dp, vertical = 12.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.server.DspConfig
 import io.music_assistant.client.data.model.server.DspConfigPreset
+import io.music_assistant.client.data.model.server.supportsDspApplyPreset
+import io.music_assistant.client.utils.HasConnectionData
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -12,6 +14,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+/** Resolves the server-reported active preset id to the (id, name) key shown as a checkmark. */
+internal fun appliedDspPresetKey(
+    config: DspConfig,
+    presets: List<DspConfigPreset>,
+): Pair<String?, String>? = config.presetId?.let { presetId ->
+    presets.firstOrNull { it.presetId == presetId }?.let { it.presetId to it.name }
+}
 
 class DspSettingsViewModel(
     private val dataSource: MainDataSource,
@@ -41,7 +51,13 @@ class DspSettingsViewModel(
                 }
                 if (config != null) {
                     val uniquePresets = presets.distinctBy { it.presetId to it.name }
-                    _state.value = DspDialogState.Content(config = config, presets = uniquePresets)
+                    _state.value = DspDialogState.Content(
+                        config = config,
+                        presets = uniquePresets,
+                        // Servers with apply_preset support report the active preset id in the
+                        // config; older servers never set it, so this is simply null there.
+                        appliedPresetKey = appliedDspPresetKey(config, uniquePresets),
+                    )
                 } else {
                     _state.value = DspDialogState.Error
                 }
@@ -53,8 +69,9 @@ class DspSettingsViewModel(
 
     fun toggleEnabled(playerId: String) {
         val current = (_state.value as? DspDialogState.Content) ?: return
-        val newConfig = current.config.copy(enabled = !current.config.enabled)
-        _state.update { current.copy(config = newConfig) }
+        // A manual save clears the active preset server-side, so drop the checkmark too.
+        val newConfig = current.config.copy(enabled = !current.config.enabled, presetId = null)
+        _state.update { current.copy(config = newConfig, appliedPresetKey = null) }
         viewModelScope.launch {
             val saved = dataSource.saveDspConfig(playerId, newConfig)
             if (saved == null) {
@@ -65,19 +82,34 @@ class DspSettingsViewModel(
 
     fun applyPreset(playerId: String, preset: DspConfigPreset) {
         val current = (_state.value as? DspDialogState.Content) ?: return
-        val configToSave = preset.config.copy(enabled = true)
+        val presetId = preset.presetId
+        val useApplyPreset = presetId != null && supportsDspApplyPreset(schemaVersion())
         viewModelScope.launch {
-            val saved = dataSource.saveDspConfig(playerId, configToSave)
+            val saved = if (useApplyPreset && presetId != null) {
+                dataSource.applyDspPreset(playerId, presetId)
+            } else {
+                dataSource.saveDspConfig(playerId, preset.config.copy(enabled = true))
+            }
             if (saved != null) {
                 _state.value = current.copy(
                     config = saved,
-                    appliedPresetKey = preset.presetId to preset.name,
+                    appliedPresetKey = if (useApplyPreset) {
+                        appliedDspPresetKey(saved, current.presets)
+                    } else {
+                        presetId to preset.name
+                    },
                 )
-                delay(1000)
-                _state.update { state ->
-                    (state as? DspDialogState.Content)?.copy(appliedPresetKey = null) ?: state
+                if (!useApplyPreset) {
+                    // Legacy servers can't report the active preset; show a transient checkmark.
+                    delay(1000)
+                    _state.update { state ->
+                        (state as? DspDialogState.Content)?.copy(appliedPresetKey = null) ?: state
+                    }
                 }
             }
         }
     }
+
+    private fun schemaVersion(): Int? =
+        (dataSource.apiClient.sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/DspRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/DspRequestTest.kt
@@ -1,0 +1,18 @@
+package io.music_assistant.client.api
+
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DspRequestTest {
+    @Test
+    fun applyPresetUsesDedicatedServerCommand() {
+        val request = Request.Dsp.applyPreset("player-1", "night-mode")
+
+        assertEquals(APICommands.CONFIG_PLAYERS_DSP_APPLY_PRESET, request.command)
+        val args = assertNotNull(request.args)
+        assertEquals("player-1", args.getValue("player_id").jsonPrimitive.content)
+        assertEquals("night-mode", args.getValue("preset_id").jsonPrimitive.content)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/DspSettingsViewModelTest.kt
@@ -1,0 +1,73 @@
+package io.music_assistant.client.ui.compose.home.players
+
+import io.music_assistant.client.data.model.server.DspConfig
+import io.music_assistant.client.data.model.server.DspConfigPreset
+import io.music_assistant.client.data.model.server.supportsDspApplyPreset
+import io.music_assistant.client.utils.myJson
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DspSettingsViewModelTest {
+    @Test
+    fun applyPresetSupportStartsAtSchema38() {
+        assertFalse(supportsDspApplyPreset(null))
+        assertFalse(supportsDspApplyPreset(37))
+        assertTrue(supportsDspApplyPreset(38))
+        assertTrue(supportsDspApplyPreset(53))
+    }
+
+    @Test
+    fun dspConfigDecodingSupportsAbsentNullAndPresentPresetId() {
+        val base = buildJsonObject {
+            put("enabled", true)
+            put("input_gain", 0.0)
+            put("output_gain", 0.0)
+            put("filters", JsonArray(emptyList()))
+        }
+
+        assertNull(myJson.decodeFromJsonElement<DspConfig>(base).presetId)
+        assertNull(
+            myJson.decodeFromJsonElement<DspConfig>(
+                JsonObject(base + ("preset_id" to JsonNull)),
+            ).presetId,
+        )
+        assertEquals(
+            "modern",
+            myJson.decodeFromJsonElement<DspConfig>(
+                JsonObject(base + ("preset_id" to JsonPrimitive("modern"))),
+            ).presetId,
+        )
+    }
+
+    @Test
+    fun serverPresetIdResolvesToDisplayedPresetKey() {
+        val matchingPreset = preset("room", "Room")
+        val otherPreset = preset("studio", "Studio")
+
+        assertEquals(
+            "room" to "Room",
+            appliedDspPresetKey(
+                DspConfig(presetId = "room"),
+                listOf(matchingPreset, otherPreset),
+            ),
+        )
+        assertNull(appliedDspPresetKey(DspConfig(presetId = "missing"), listOf(matchingPreset)))
+        assertNull(appliedDspPresetKey(DspConfig(), listOf(matchingPreset)))
+    }
+
+    private fun preset(id: String?, name: String) = DspConfigPreset(
+        name = name,
+        config = DspConfig(filters = JsonArray(emptyList())),
+        presetId = id,
+    )
+}


### PR DESCRIPTION
Closes #862 

## Is there anything about the code changes here that should be highlighted?

Use the config/players/dsp/apply_preset command (server API schema 38+, MA 2.10) so the server tracks the active preset and reports it back via preset_id on the player DSP config. The preset checkmark now persists across dialog opens on supporting servers; older servers keep the legacy transient (1s) checkmark behavior.

CarDspApplier uses the same dedicated apply path when available.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

