### PR TITLE
Localize server-provided strings

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.util.Locale
 
 actual fun currentTimeMillis(): Long = System.currentTimeMillis()
 
@@ -27,3 +28,5 @@ actual fun formatIsoDate(isoDate: String): String = try {
 } catch (_: Exception) {
     isoDate
 }
+
+actual fun platformLocale(): String = Locale.getDefault().toLanguageTag()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -28,6 +28,8 @@ import io.music_assistant.client.utils.SessionState
 import io.music_assistant.client.utils.createPlatformHttpClient
 import io.music_assistant.client.utils.currentTimeMillis
 import io.music_assistant.client.utils.myJson
+import io.music_assistant.client.utils.platformLocale
+import io.music_assistant.client.utils.serverLocalizationLocale
 import io.music_assistant.client.utils.update
 import io.music_assistant.client.webrtc.model.RemoteId
 import kotlinx.coroutines.CancellationException
@@ -791,7 +793,9 @@ class KtorServiceClient(
                     shouldAttempt = { _sessionState.value is SessionState.Connected },
                     onAttempt = { setAuthState(AuthProcessState.InProgress) },
                     send = {
-                        sendRequestRaw(Request.Auth.login(username, password, settings.deviceName.value))
+                        sendRequestRaw(
+                            Request.Auth.login(username, password, settings.deviceName.value),
+                        )
                     },
                 )
             ) {
@@ -853,7 +857,18 @@ class KtorServiceClient(
                             state.authProcessState != AuthProcessState.LoggedOut
                     },
                     onAttempt = { setAuthState(AuthProcessState.InProgress) },
-                    send = { sendRequestRaw(Request.Auth.authorize(token, settings.deviceName.value)) },
+                    send = {
+                        sendRequestRaw(
+                            Request.Auth.authorize(
+                                token,
+                                settings.deviceName.value,
+                                locale = serverLocalizationLocale(
+                                    (_sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion,
+                                    platformLocale(),
+                                ),
+                            ),
+                        )
+                    },
                 )
             ) {
                 AuthResolution.Aborted -> return

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
@@ -783,11 +783,16 @@ data class Request @OptIn(ExperimentalUuidApi::class) constructor(
 
         fun logout() = Request(command = APICommands.AUTH_LOGOUT)
 
-        fun authorize(token: String, deviceName: String) = Request(
+        fun authorize(
+            token: String,
+            deviceName: String,
+            locale: String? = null,
+        ) = Request(
             command = APICommands.AUTH,
             args = buildJsonObject {
                 put("token", JsonPrimitive(token))
                 put("device_name", JsonPrimitive(deviceName))
+                locale?.let { put("locale", JsonPrimitive(it)) }
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -10,3 +10,6 @@ expect fun currentTimeMillis(): Long
 expect fun monotonicMs(): Long
 
 expect fun formatIsoDate(isoDate: String): String
+
+/** Current device locale in a form accepted by the Music Assistant API. */
+expect fun platformLocale(): String

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ServerLocalization.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/utils/ServerLocalization.kt
@@ -1,0 +1,13 @@
+package io.music_assistant.client.utils
+
+/** Server schema that introduced localization of API response strings. */
+const val SERVER_LOCALIZATION_SCHEMA = 32
+
+/**
+ * Return the locale to send during authentication, or null for servers that predate localization.
+ * Unknown schemas intentionally retain the legacy payload for compatibility.
+ */
+fun serverLocalizationLocale(schemaVersion: Int?, locale: String): String? =
+    locale.takeIf {
+        it.isNotBlank() && schemaVersion != null && schemaVersion >= SERVER_LOCALIZATION_SCHEMA
+    }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/utils/ServerLocalizationTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/utils/ServerLocalizationTest.kt
@@ -1,0 +1,28 @@
+package io.music_assistant.client.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServerLocalizationTest {
+    @Test
+    fun schemaAtOrAboveThresholdUsesLocale() {
+        assertEquals("nl-NL", serverLocalizationLocale(schemaVersion = 32, locale = "nl-NL"))
+        assertEquals("nl-NL", serverLocalizationLocale(schemaVersion = 53, locale = "nl-NL"))
+    }
+
+    @Test
+    fun schemaBelowThresholdKeepsLegacyPayload() {
+        assertEquals(null, serverLocalizationLocale(schemaVersion = 31, locale = "nl-NL"))
+    }
+
+    @Test
+    fun unknownSchemaKeepsLegacyPayload() {
+        assertEquals(null, serverLocalizationLocale(schemaVersion = null, locale = "nl-NL"))
+    }
+
+    @Test
+    fun blankLocaleKeepsLegacyPayload() {
+        assertEquals(null, serverLocalizationLocale(schemaVersion = 32, locale = ""))
+        assertEquals(null, serverLocalizationLocale(schemaVersion = 32, locale = "   "))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/utils/PlatformTime.kt
@@ -6,6 +6,8 @@ import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSDateFormatterMediumStyle
 import platform.Foundation.NSDateFormatterNoStyle
 import platform.Foundation.NSISO8601DateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.preferredLanguages
 import platform.Foundation.timeIntervalSince1970
 import platform.posix.CLOCK_MONOTONIC
 import platform.posix.clock_gettime_nsec_np
@@ -33,3 +35,6 @@ actual fun formatIsoDate(isoDate: String): String {
     }
     return formatter.stringFromDate(date)
 }
+
+actual fun platformLocale(): String =
+    (NSLocale.preferredLanguages.firstOrNull() as? String).orEmpty()


### PR DESCRIPTION
Closes #641 

## Is there anything about the code changes here that should be highlighted?

This uses the server-provided localization strings for the homepage rows, gated on the MA server API version that introduced that.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

