### PR TITLE
feat: carry album art on the dedicated WebRTC image channel

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
@@ -330,7 +330,7 @@ class WebRTCTransport(
             null
         } ?: return
 
-        httpProxy.attachChannel { json ->
+        val attachment = httpProxy.attachChannel { json ->
             channel.send(myJson.encodeToString(JsonObject.serializer(), json))
         }
         try {
@@ -351,7 +351,7 @@ class WebRTCTransport(
             // The inbound stream ends when the channel dies. Run the detach uncancellable so
             // callers are failed even when this job is torn down mid-collect.
             withContext(NonCancellable) {
-                httpProxy.detachChannel(IllegalStateException("http_proxy channel closed"))
+                httpProxy.detachChannel(attachment, IllegalStateException("http_proxy channel closed"))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/WebRTCTransport.kt
@@ -6,6 +6,7 @@ package io.music_assistant.client.api
 import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.music_assistant.client.utils.myJson
+import io.music_assistant.client.webrtc.DataChannelInbound
 import io.music_assistant.client.webrtc.DataChannelWrapper
 import io.music_assistant.client.webrtc.SignalingClient
 import io.music_assistant.client.webrtc.WebRTCConnectionManager
@@ -15,6 +16,7 @@ import io.music_assistant.client.webrtc.model.WebRTCConnectionState
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -25,6 +27,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -35,6 +38,10 @@ private const val HTTP_PROXY_TYPE_SCAN_WINDOW = 256
 private const val HTTP_PROXY_TYPE_TOKEN = "\"type\":\"http-proxy-response\""
 private const val CHUNK_TYPE_TOKEN = "\"__chunk__\""
 private const val MAX_CHUNK_COUNT = 256
+
+// Server API schema that introduced label-based data-channel routing and the dedicated
+// `http_proxy` channel (music-assistant/server#5635, MA 2.10).
+private const val HTTP_PROXY_CHANNEL_SCHEMA = 49
 internal const val MAX_PENDING_CHUNK_GROUPS = 16
 private const val MAX_REASSEMBLED_BYTES = 16 * 1024 * 1024
 
@@ -164,6 +171,10 @@ class WebRTCTransport(
     private var stateMonitorJob: Job? = null
     private var reconnectionJob: Job? = null
     private var networkWatchJob: Job? = null
+    private var httpProxyChannelJob: Job? = null
+
+    // Feature detection runs once per connection; cleared with the manager it belongs to.
+    private var httpProxyChannelRequested = false
 
     val sendspinDataChannel: DataChannelWrapper?
         get() = manager?.sendspinDataChannel
@@ -275,6 +286,7 @@ class WebRTCTransport(
                             httpProxy.dispatchRawResponse(jsonString)
                         } else {
                             val jsonObject = myJson.decodeFromString<JsonObject>(jsonString)
+                            maybeOpenHttpProxyChannel(mgr, jsonObject)
                             _messages.emit(jsonObject)
                         }
                     } catch (e: Exception) {
@@ -286,6 +298,60 @@ class WebRTCTransport(
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 logger.d { "WebRTC message listener ended: ${e.message}" }
+            }
+        }
+    }
+
+    /**
+     * Opens the dedicated image channel once per connection, as soon as the server proves it
+     * can route the label. `server_info` is the first frame on `ma-api` and carries the
+     * schema version; a server below [HTTP_PROXY_CHANNEL_SCHEMA] mistakes an unknown label
+     * for the API channel and drops the whole session, so this must never be speculative.
+     */
+    private fun maybeOpenHttpProxyChannel(mgr: WebRTCConnectionManager, message: JsonObject) {
+        if (httpProxyChannelRequested) return
+        val schema = (message["schema_version"] as? JsonPrimitive)?.intOrNull ?: return
+        if (schema < HTTP_PROXY_CHANNEL_SCHEMA) {
+            logger.i { "Server schema $schema predates the image channel — proxying over ma-api" }
+            httpProxyChannelRequested = true
+            return
+        }
+        httpProxyChannelRequested = true
+        httpProxyChannelJob = scope.launch { serveHttpProxyChannel(mgr) }
+    }
+
+    private suspend fun serveHttpProxyChannel(mgr: WebRTCConnectionManager) {
+        val channel = try {
+            mgr.openHttpProxyChannel()
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            // Proxying over the API channel remains a working fallback.
+            logger.w(e) { "http_proxy channel unavailable — images stay on ma-api" }
+            null
+        } ?: return
+
+        httpProxy.attachChannel { json ->
+            channel.send(myJson.encodeToString(JsonObject.serializer(), json))
+        }
+        try {
+            // Listener-local, like the ma-api reassembler: a schema-49 server that predates
+            // the binary framing still answers here in hex, chunked when oversized.
+            val chunkReassembler = WebRTCChunkReassembler()
+            channel.inbound.collect { inbound ->
+                when (inbound) {
+                    is DataChannelInbound.Text ->
+                        chunkReassembler.accept(inbound.text)
+                            ?.let { httpProxy.dispatchProxyChannelText(it) }
+
+                    is DataChannelInbound.Binary ->
+                        httpProxy.dispatchProxyChannelBinary(inbound.bytes)
+                }
+            }
+        } finally {
+            // The inbound stream ends when the channel dies. Run the detach uncancellable so
+            // callers are failed even when this job is torn down mid-collect.
+            withContext(NonCancellable) {
+                httpProxy.detachChannel(IllegalStateException("http_proxy channel closed"))
             }
         }
     }
@@ -351,6 +417,9 @@ class WebRTCTransport(
         stateMonitorJob = null
         networkWatchJob?.cancel()
         networkWatchJob = null
+        httpProxyChannelJob?.cancel()
+        httpProxyChannelJob = null
+        httpProxyChannelRequested = false
         val mgr = manager
         manager = null
         if (mgr != null) {
@@ -372,6 +441,9 @@ class WebRTCTransport(
         messageListenerJob = null
         stateMonitorJob?.cancel()
         stateMonitorJob = null
+        httpProxyChannelJob?.cancel()
+        httpProxyChannelJob = null
+        httpProxyChannelRequested = false
         manager?.disconnect()
         manager = null
         httpProxy.cancelAll(IllegalStateException("WebRTC transport cleanup"))

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCConnectionManager.kt
@@ -20,9 +20,11 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Manages WebRTC connection lifecycle and orchestrates signaling + peer connection.
@@ -78,6 +80,7 @@ class WebRTCConnectionManager(
     private var peerConnection: PeerConnectionWrapper? = null
     private var dataChannel: DataChannelWrapper? = null
     private var sendspinDataChannelInternal: DataChannelWrapper? = null
+    private var httpProxyDataChannelInternal: DataChannelWrapper? = null
     private var signalingMessageListenerJob: Job? = null
     private var iceCandidateJob: Job? = null
     private var dataChannelListenerJob: Job? = null
@@ -103,6 +106,37 @@ class WebRTCConnectionManager(
      */
     val sendspinDataChannel: DataChannelWrapper?
         get() = sendspinDataChannelInternal
+
+    /**
+     * Opens the dedicated image channel, on which the server answers proxied HTTP requests
+     * (album art, previews) so they stop queueing ahead of API traffic on `ma-api`.
+     *
+     * Opened on demand rather than before the offer, because a server older than schema 49
+     * mistakes an unknown channel label for the API channel and drops the whole remote
+     * session. Callers must therefore gate on the schema version first. No SDP
+     * renegotiation is involved: `m=application` already exists from `ma-api`, so the new
+     * channel is signalled in-band.
+     *
+     * Idempotent — returns the live channel if one is already open, null if it cannot be
+     * opened (the `ma-api` proxy path remains a working fallback).
+     */
+    suspend fun openHttpProxyChannel(): DataChannelWrapper? {
+        httpProxyDataChannelInternal?.let { return it }
+        val pc = peerConnection ?: return null
+        val channel = pc.createDataChannel(label = HTTP_PROXY_CHANNEL_LABEL, ordered = true)
+        httpProxyDataChannelInternal = channel
+        val opened = withTimeoutOrNull(CHANNEL_OPEN_TIMEOUT_MS) {
+            channel.state.first { it == DataChannelState.Open }
+        }
+        if (opened == null) {
+            logger.w { "http_proxy channel did not open within ${CHANNEL_OPEN_TIMEOUT_MS}ms" }
+            channel.close()
+            httpProxyDataChannelInternal = null
+            return null
+        }
+        logger.i { "http_proxy data channel ready for use" }
+        return channel
+    }
 
     /**
      * Connect to Music Assistant server via WebRTC.
@@ -580,6 +614,9 @@ class WebRTCConnectionManager(
         sendspinDataChannelInternal?.close()
         sendspinDataChannelInternal = null
 
+        httpProxyDataChannelInternal?.close()
+        httpProxyDataChannelInternal = null
+
         peerConnection?.close()
         peerConnection = null
 
@@ -593,5 +630,11 @@ class WebRTCConnectionManager(
         // that genuinely-dead links don't feel sticky. See the DISCONNECTED branch in the
         // connection-state collector for rationale.
         private const val ICE_DISCONNECT_GRACE_MS = 4_000L
+
+        // Label the server routes proxied HTTP requests on (schema 49+).
+        private const val HTTP_PROXY_CHANNEL_LABEL = "http_proxy"
+
+        // Matches the web frontend's own wait for a late-opened data channel.
+        private const val CHANNEL_OPEN_TIMEOUT_MS = 10_000L
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxy.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxy.kt
@@ -25,10 +25,21 @@ import kotlinx.serialization.json.put
  *
  * Wire protocol (matches `music-assistant/frontend` → `src/plugins/remote/webrtc-transport.ts`):
  *   Request : { "type": "http-proxy-request",  "id": "...", "method": "GET", "path": "...", "headers": {...} }
- *   Response: { "type": "http-proxy-response", "id": "...", "status": 200, "headers": {...}, "body": "<hex>" }
  *
- * Rides the shared `ma-api` data channel. A Semaphore caps in-flight requests so artwork
- * bursts don't head-of-line-block control-plane RPCs on the same SCTP stream.
+ * Responses come in two framings, chosen by the channel the request went out on:
+ *  - `ma-api` (any server): one JSON message with the body hex-encoded, which costs about
+ *    2.7x the image once oversized-message chunking is applied on top.
+ *    `{ "type": "http-proxy-response", "id", "status", "headers", "body": "<hex>" }`
+ *  - `http_proxy` (server schema 49+, MA 2.10): a small JSON header carrying the body length,
+ *    followed by the body as raw binary messages — the image costs its own size and no more.
+ *    `{ "type": "http-proxy-response", "id", "status", "headers", "size": N }` then N bytes.
+ *    Those binary frames carry no request id, so the server holds the channel for a whole
+ *    reply; replies never interleave there and one reassembly slot is enough.
+ *
+ * A Semaphore caps in-flight requests. On `ma-api` that stops artwork bursts from
+ * head-of-line-blocking control-plane RPCs on the same SCTP stream; the dedicated channel
+ * exists to remove that contention entirely, but the server bounds its own concurrency at
+ * the same figure so the cap stays useful there too.
  */
 class WebRTCHttpProxy(
     private val sender: suspend (JsonObject) -> Unit,
@@ -38,12 +49,53 @@ class WebRTCHttpProxy(
 
     private val pendingMutex = Mutex()
 
-    // CRITICAL: deferred carries the RAW JSON STRING, not a parsed JsonObject. Both JSON parsing
-    // AND hex decoding happen in the awaiter's coroutine — never on the message-listener coroutine.
-    // For a 2 MB hex-encoded image body, full kotlinx.serialization parse is 100–500 ms; if that
-    // ran on the listener it would queue every subsequent control-plane RPC and server event behind
-    // each image. The listener only does a cheap regex peek to extract the request id.
-    private val pending = mutableMapOf<String, CompletableDeferred<String>>()
+    /**
+     * What a completed response hands back to the awaiter.
+     *
+     * [Hex] carries the RAW JSON STRING, not a parsed JsonObject: both JSON parsing AND hex
+     * decoding must happen in the awaiter's coroutine, never on the message-listener
+     * coroutine. For a 2 MB hex-encoded body a full kotlinx.serialization parse is
+     * 100–500 ms; on the listener that would queue every subsequent control-plane RPC and
+     * server event behind each image. The listener only peeks out the request id.
+     *
+     * [Binary] is already decoded — its body arrived as raw bytes, so there is nothing left
+     * to parse and no reason to defer it.
+     */
+    private sealed interface Payload {
+        class Hex(val raw: String) : Payload
+        class Binary(val response: ProxyResponse) : Payload
+    }
+
+    /**
+     * @param onProxyChannel whether the request went out on the dedicated channel. Requests
+     *   sent there die with it, unlike those on `ma-api`, which the server still answers.
+     */
+    private class Pending(
+        val deferred: CompletableDeferred<Payload>,
+        val onProxyChannel: Boolean,
+    )
+
+    /** A binary reply being reassembled on the dedicated channel: its header, then its body. */
+    private class PendingBody(
+        val id: String,
+        val status: Int,
+        val headers: Map<String, String>,
+        val size: Int,
+    ) {
+        val parts = mutableListOf<ByteArray>()
+        var received: Int = 0
+    }
+
+    private val pending = mutableMapOf<String, Pending>()
+
+    // Sends on the dedicated image channel; null whenever there isn't one. Guarded by
+    // `pendingMutex` together with `pending`, so a request cannot register itself as
+    // proxy-channel-bound after detachChannel has already failed that generation.
+    private var proxySender: (suspend (JsonObject) -> Unit)? = null
+
+    // Single slot: the server holds a send lock for header-plus-body on this channel.
+    private var pendingBody: PendingBody? = null
+
     private val concurrencyGate = Semaphore(maxConcurrent)
 
     data class ProxyResponse(
@@ -85,17 +137,30 @@ class WebRTCHttpProxy(
             val permitAcquiredMs = currentTimeMillis()
             val acquireWaitMs = permitAcquiredMs - queuedAtMs
             val id = nextRequestId()
-            val deferred = CompletableDeferred<String>()
-            pendingMutex.withLock { pending[id] = deferred }
+            val deferred = CompletableDeferred<Payload>()
+            // Snapshot the channel and register under one lock, so a detach racing this
+            // cannot leave an entry nobody will ever fail waiting out its full timeout.
+            val send = pendingMutex.withLock {
+                val proxy = proxySender
+                pending[id] = Pending(deferred, onProxyChannel = proxy != null)
+                proxy ?: sender
+            }
             logger.d { "GET $path id=$id acquire_wait_ms=$acquireWaitMs" }
-            val rawJsonString = try {
-                sender(buildRequest(id, path, headers))
+            val payload = try {
+                send(buildRequest(id, path, headers))
                 withTimeout(timeoutMs) { deferred.await() }
             } finally {
-                pendingMutex.withLock { pending.remove(id) }
+                pendingMutex.withLock {
+                    pending.remove(id)
+                    // Stop buffering frames nothing is waiting for any more.
+                    if (pendingBody?.id == id) pendingBody = null
+                }
             }
             val parseStartMs = currentTimeMillis()
-            val response = parseResponse(rawJsonString)
+            val response = when (payload) {
+                is Payload.Binary -> payload.response
+                is Payload.Hex -> parseResponse(payload.raw)
+            }
             val nowMs = currentTimeMillis()
             logger.d {
                 "← id=$id status=${response.status} bytes=${response.body.size} " +
@@ -104,6 +169,33 @@ class WebRTCHttpProxy(
             }
             response
         }
+    }
+
+    /**
+     * Routes subsequent requests onto the dedicated image channel. Requests already in
+     * flight on `ma-api` stay there — the server answers on the channel a request arrived on.
+     */
+    suspend fun attachChannel(send: suspend (JsonObject) -> Unit) {
+        pendingMutex.withLock { proxySender = send }
+    }
+
+    /**
+     * The dedicated channel is gone. Fails everything that went out on it at once, rather
+     * than leaving each caller to wait out its timeout, and drops a half-received body that
+     * can never be completed. Requests in flight on `ma-api` are deliberately left alone.
+     */
+    suspend fun detachChannel(cause: Throwable) {
+        val doomed = pendingMutex.withLock {
+            proxySender = null
+            pendingBody = null
+            val dead = pending.filterValues { it.onProxyChannel }
+            dead.keys.forEach { pending.remove(it) }
+            dead.values.toList()
+        }
+        if (doomed.isNotEmpty()) {
+            logger.w { "http_proxy channel closed with ${doomed.size} request(s) in flight" }
+        }
+        doomed.forEach { it.deferred.completeExceptionally(cause) }
     }
 
     /**
@@ -116,12 +208,99 @@ class WebRTCHttpProxy(
             logger.w { "Dropping http-proxy-response without id" }
             return
         }
-        val deferred = pendingMutex.withLock { pending[id] }
-        if (deferred == null) {
+        val entry = pendingMutex.withLock { pending[id] }
+        if (entry == null) {
             logger.w { "No pending request for id=$id (timed out or cancelled)" }
             return
         }
-        deferred.complete(rawJsonString)
+        entry.deferred.complete(Payload.Hex(rawJsonString))
+    }
+
+    /**
+     * Called with a text frame from the dedicated image channel, which is either a binary
+     * response header or — from a schema-49 server that predates the binary framing — a
+     * whole hex-in-JSON response.
+     */
+    suspend fun dispatchProxyChannelText(rawJsonString: String) {
+        // A header is a few hundred bytes; a hex response is megabytes. Full-parsing only
+        // the small frame keeps `size` from ever being confused with a same-named response
+        // header, and never walks a multi-MB hex body an extra time.
+        if (rawJsonString.length > PROXY_HEADER_MAX_CHARS) {
+            dispatchRawResponse(rawJsonString)
+            return
+        }
+        val frame = runCatching { myJson.decodeFromString<JsonObject>(rawJsonString) }.getOrNull()
+        val size = (frame?.get("size") as? JsonPrimitive)?.intOrNull
+        if (frame == null || size == null) {
+            // No body length: the hex-in-JSON form, which the existing path already handles.
+            dispatchRawResponse(rawJsonString)
+            return
+        }
+        beginBinaryBody(frame, size)
+    }
+
+    /** Called with a raw body frame from the dedicated image channel. */
+    suspend fun dispatchProxyChannelBinary(bytes: ByteArray) {
+        val complete = pendingMutex.withLock {
+            // Frames carry no id, so one arriving with no header open is unattributable.
+            val body = pendingBody ?: return
+            body.parts.add(bytes)
+            body.received += bytes.size
+            body.received >= body.size
+        }
+        if (complete) completeBinaryBody()
+    }
+
+    private suspend fun beginBinaryBody(frame: JsonObject, size: Int) {
+        val id = (frame["id"] as? JsonPrimitive)?.contentOrNull ?: run {
+            logger.w { "Dropping http-proxy-response header without id" }
+            return
+        }
+        if (size !in 0..MAX_BODY_BYTES) {
+            logger.w { "Rejecting http-proxy-response id=$id with implausible size=$size" }
+            return
+        }
+        val status = (frame["status"] as? JsonPrimitive)?.intOrNull ?: 0
+        val headers = frame["headers"]?.jsonObject
+            ?.mapValues { it.value.jsonPrimitive.contentOrNull.orEmpty() }
+            .orEmpty()
+        val waiting = pendingMutex.withLock {
+            // No point buffering a body for a request that already gave up.
+            if (pending[id] == null) {
+                pendingBody = null
+                false
+            } else {
+                pendingBody = PendingBody(id, status, headers, size)
+                true
+            }
+        }
+        if (!waiting) {
+            logger.w { "No pending request for id=$id (timed out or cancelled)" }
+            return
+        }
+        // An empty body is sent as a header on its own, with no frame to follow.
+        if (size == 0) completeBinaryBody()
+    }
+
+    private suspend fun completeBinaryBody() {
+        // Check for a waiting caller before assembling, which for an image copies real bytes.
+        val (body, entry) = pendingMutex.withLock {
+            val b = pendingBody ?: return
+            pendingBody = null
+            b to pending.remove(b.id)
+        }
+        val waiting = entry ?: return
+        val assembled = ByteArray(body.size)
+        var offset = 0
+        for (part in body.parts) {
+            val n = minOf(part.size, body.size - offset)
+            if (n <= 0) break
+            part.copyInto(assembled, destinationOffset = offset, startIndex = 0, endIndex = n)
+            offset += n
+        }
+        waiting.deferred.complete(
+            Payload.Binary(ProxyResponse(body.status, body.headers, assembled)),
+        )
     }
 
     /** Fail every in-flight request. Call on transport disconnect. */
@@ -129,9 +308,11 @@ class WebRTCHttpProxy(
         val snapshot = pendingMutex.withLock {
             val all = pending.values.toList()
             pending.clear()
+            pendingBody = null
+            proxySender = null
             all
         }
-        snapshot.forEach { it.completeExceptionally(cause) }
+        snapshot.forEach { it.deferred.completeExceptionally(cause) }
     }
 
     private fun buildRequest(
@@ -245,6 +426,13 @@ class WebRTCHttpProxy(
         private const val DEFAULT_MAX_CONCURRENT = 6
         private const val DEFAULT_TIMEOUT_MS = 30_000L
         private const val ID_SCAN_WINDOW = 256
+
+        // A binary response header is a few hundred bytes. Anything larger on the dedicated
+        // channel is a hex-in-JSON response, which must not be full-parsed on the listener.
+        private const val PROXY_HEADER_MAX_CHARS = 8 * 1024
+
+        // Upper bound on a single proxied body, mirroring the transport's reassembly guard.
+        private const val MAX_BODY_BYTES = 16 * 1024 * 1024
 
         // Matches both `"id":"..."` and `"id": "..."` (with optional whitespace).
         private val ID_REGEX = Regex("\"id\"\\s*:\\s*\"([^\"]+)\"")

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxy.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxy.kt
@@ -66,13 +66,16 @@ class WebRTCHttpProxy(
         class Binary(val response: ProxyResponse) : Payload
     }
 
+    /** Identifies one lifetime of the dedicated proxy channel. */
+    class ChannelAttachment internal constructor()
+
     /**
-     * @param onProxyChannel whether the request went out on the dedicated channel. Requests
-     *   sent there die with it, unlike those on `ma-api`, which the server still answers.
+     * @param attachment the dedicated channel generation used for this request, or null when
+     *   the request went out on `ma-api`.
      */
     private class Pending(
         val deferred: CompletableDeferred<Payload>,
-        val onProxyChannel: Boolean,
+        val attachment: ChannelAttachment?,
     )
 
     /** A binary reply being reassembled on the dedicated channel: its header, then its body. */
@@ -92,6 +95,7 @@ class WebRTCHttpProxy(
     // `pendingMutex` together with `pending`, so a request cannot register itself as
     // proxy-channel-bound after detachChannel has already failed that generation.
     private var proxySender: (suspend (JsonObject) -> Unit)? = null
+    private var proxyAttachment: ChannelAttachment? = null
 
     // Single slot: the server holds a send lock for header-plus-body on this channel.
     private var pendingBody: PendingBody? = null
@@ -142,7 +146,7 @@ class WebRTCHttpProxy(
             // cannot leave an entry nobody will ever fail waiting out its full timeout.
             val send = pendingMutex.withLock {
                 val proxy = proxySender
-                pending[id] = Pending(deferred, onProxyChannel = proxy != null)
+                pending[id] = Pending(deferred, attachment = proxyAttachment)
                 proxy ?: sender
             }
             logger.d { "GET $path id=$id acquire_wait_ms=$acquireWaitMs" }
@@ -175,20 +179,32 @@ class WebRTCHttpProxy(
      * Routes subsequent requests onto the dedicated image channel. Requests already in
      * flight on `ma-api` stay there — the server answers on the channel a request arrived on.
      */
-    suspend fun attachChannel(send: suspend (JsonObject) -> Unit) {
-        pendingMutex.withLock { proxySender = send }
+    suspend fun attachChannel(send: suspend (JsonObject) -> Unit): ChannelAttachment {
+        val attachment = ChannelAttachment()
+        pendingMutex.withLock {
+            proxySender = send
+            proxyAttachment = attachment
+        }
+        return attachment
     }
 
     /**
      * The dedicated channel is gone. Fails everything that went out on it at once, rather
      * than leaving each caller to wait out its timeout, and drops a half-received body that
      * can never be completed. Requests in flight on `ma-api` are deliberately left alone.
+     *
+     * A stale listener may run after a newer channel has attached. Only clear the shared
+     * sender and reassembly state when [attachment] still owns the current channel.
+     * Requests that were sent through [attachment] are failed in either case.
      */
-    suspend fun detachChannel(cause: Throwable) {
+    suspend fun detachChannel(attachment: ChannelAttachment, cause: Throwable) {
         val doomed = pendingMutex.withLock {
-            proxySender = null
-            pendingBody = null
-            val dead = pending.filterValues { it.onProxyChannel }
+            if (proxyAttachment === attachment) {
+                proxySender = null
+                proxyAttachment = null
+                pendingBody = null
+            }
+            val dead = pending.filterValues { it.attachment === attachment }
             dead.keys.forEach { pending.remove(it) }
             dead.values.toList()
         }
@@ -310,6 +326,7 @@ class WebRTCHttpProxy(
             pending.clear()
             pendingBody = null
             proxySender = null
+            proxyAttachment = null
             all
         }
         snapshot.forEach { it.deferred.completeExceptionally(cause) }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxyChannelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxyChannelTest.kt
@@ -1,0 +1,199 @@
+package io.music_assistant.client.webrtc
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the dedicated `http_proxy` channel framing introduced by
+ * music-assistant/server#5635 and #5643, mirroring the web frontend's own suite
+ * (`tests/plugins/webrtc-transport-http-proxy-channel.test.ts`).
+ *
+ * The two framings must coexist: a schema-49 server that predates the binary framing still
+ * answers in hex on the dedicated channel, and every server answers in hex on `ma-api`.
+ */
+class WebRTCHttpProxyChannelTest {
+    /** Captures outgoing requests so a test can answer the id the proxy actually generated. */
+    private class RecordingChannel {
+        val sent = mutableListOf<JsonObject>()
+        private val firstSend = CompletableDeferred<Unit>()
+
+        val send: suspend (JsonObject) -> Unit = { json ->
+            sent.add(json)
+            firstSend.complete(Unit)
+        }
+
+        suspend fun awaitFirstRequestId(): String {
+            firstSend.await()
+            return (sent.first()["id"] as JsonPrimitive).contentOrNull!!
+        }
+    }
+
+    /** The hex-in-JSON reply, which is what a caller on `ma-api` always receives. */
+    private fun hexResponse(id: String, body: List<Int>): String {
+        val hex = body.joinToString("") { it.toString(16).padStart(2, '0') }
+        return """{"type":"http-proxy-response","id":"$id","status":200,""" +
+            """"headers":{"content-type":"image/png"},"body":"$hex"}"""
+    }
+
+    /** The dedicated channel's framing: a JSON header, then the body as raw binary frames. */
+    private fun binaryHeader(id: String, size: Int): String =
+        """{"type":"http-proxy-response","id":"$id","status":200,""" +
+            """"headers":{"content-type":"image/png"},"size":$size}"""
+
+    private fun frames(body: List<Int>, frameBytes: Int): List<ByteArray> =
+        body.chunked(frameBytes).map { chunk -> ByteArray(chunk.size) { chunk[it].toByte() } }
+
+    @Test
+    fun reassemblesBodyDeliveredInOneFrame() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        val response = async { proxy.get("/imageproxy?p=1") }
+        val id = channel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(binaryHeader(id, 4))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(1, 2, 3, 4))
+
+        val result = response.await()
+        assertEquals(200, result.status)
+        assertContentEquals(byteArrayOf(1, 2, 3, 4), result.body)
+        assertEquals("image/png", result.headers["content-type"])
+    }
+
+    @Test
+    fun reassemblesBodySplitAcrossSeveralFrames() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        val body = listOf(9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+        val response = async { proxy.get("/imageproxy?p=1") }
+        val id = channel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(binaryHeader(id, body.size))
+        // 4/4/2 — the server sizes frames to the channel's negotiated limit, not to the body.
+        frames(body, frameBytes = 4).forEach { proxy.dispatchProxyChannelBinary(it) }
+
+        assertContentEquals(
+            ByteArray(body.size) { body[it].toByte() },
+            response.await().body,
+        )
+    }
+
+    @Test
+    fun resolvesEmptyBodyFromItsHeaderAlone() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        val response = async { proxy.get("/imageproxy?p=1") }
+        val id = channel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(binaryHeader(id, 0))
+
+        val result = response.await()
+        assertEquals(200, result.status)
+        assertEquals(0, result.body.size)
+    }
+
+    @Test
+    fun stillReadsHexResponseOnDedicatedChannel() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        // A server that reports schema 49 but predates the binary framing answers like this.
+        val response = async { proxy.get("/imageproxy?p=1") }
+        val id = channel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(hexResponse(id, listOf(4, 5, 6)))
+
+        assertContentEquals(byteArrayOf(4, 5, 6), response.await().body)
+    }
+
+    @Test
+    fun failsInFlightProxyChannelRequestsWhenChannelCloses() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        // runCatching inside the async: a bare failing async would propagate into the
+        // runTest scope and abort the test before the assertion below could run.
+        val streaming = async { runCatching { proxy.get("/imageproxy?p=1") } }
+        val id = channel.awaitFirstRequestId()
+        // Mid-body: the header landed and one frame arrived, then the channel dropped.
+        proxy.dispatchProxyChannelText(binaryHeader(id, 8))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(1, 2, 3, 4))
+
+        proxy.detachChannel(IllegalStateException("http_proxy channel closed"))
+
+        // Fails now rather than sitting out the 30 s request timeout.
+        assertTrue(streaming.await().exceptionOrNull() is IllegalStateException)
+    }
+
+    @Test
+    fun leavesApiChannelRequestsAloneWhenProxyChannelCloses() = runTest {
+        val apiChannel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = apiChannel.send)
+
+        // Goes out before the dedicated channel exists, so it must survive that channel's close.
+        val viaApi = async { proxy.get("/imageproxy?p=1") }
+        val id = apiChannel.awaitFirstRequestId()
+
+        proxy.attachChannel { error("must not be used by an already-sent request") }
+        proxy.detachChannel(IllegalStateException("http_proxy channel closed"))
+
+        // The server still answers on the channel the request arrived on.
+        proxy.dispatchRawResponse(hexResponse(id, listOf(7, 7)))
+        assertContentEquals(byteArrayOf(7, 7), viaApi.await().body)
+    }
+
+    @Test
+    fun dropsBodyForRequestThatAlreadyGaveUp() = runTest {
+        val channel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+        proxy.attachChannel(channel.send)
+
+        // Nothing is pending, so the header must not open a reassembly slot. A later frame
+        // then has no body to append to and is discarded rather than corrupting the next reply.
+        proxy.dispatchProxyChannelText(binaryHeader("req_never_sent", 4))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(1, 2, 3, 4))
+
+        val response = async { proxy.get("/imageproxy?p=1") }
+        val id = channel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(binaryHeader(id, 2))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(8, 9))
+
+        assertContentEquals(byteArrayOf(8, 9), response.await().body)
+    }
+
+    @Test
+    fun routesToDedicatedChannelOnceAttachedAndBackToApiAfterDetach() = runTest {
+        val apiChannel = RecordingChannel()
+        val proxyChannel = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = apiChannel.send)
+
+        proxy.attachChannel(proxyChannel.send)
+        val onProxy = async { proxy.get("/imageproxy?p=1") }
+        val proxyId = proxyChannel.awaitFirstRequestId()
+        proxy.dispatchProxyChannelText(binaryHeader(proxyId, 1))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(1))
+        onProxy.await()
+
+        proxy.detachChannel(IllegalStateException("closed"))
+
+        val onApi = async { proxy.get("/imageproxy?p=2") }
+        val apiId = apiChannel.awaitFirstRequestId()
+        proxy.dispatchRawResponse(hexResponse(apiId, listOf(2)))
+        onApi.await()
+
+        assertEquals(1, proxyChannel.sent.size)
+        assertEquals(1, apiChannel.sent.size)
+        assertTrue(proxyId != apiId)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxyChannelTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/webrtc/WebRTCHttpProxyChannelTest.kt
@@ -120,7 +120,7 @@ class WebRTCHttpProxyChannelTest {
     fun failsInFlightProxyChannelRequestsWhenChannelCloses() = runTest {
         val channel = RecordingChannel()
         val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
-        proxy.attachChannel(channel.send)
+        val attachment = proxy.attachChannel(channel.send)
 
         // runCatching inside the async: a bare failing async would propagate into the
         // runTest scope and abort the test before the assertion below could run.
@@ -130,7 +130,7 @@ class WebRTCHttpProxyChannelTest {
         proxy.dispatchProxyChannelText(binaryHeader(id, 8))
         proxy.dispatchProxyChannelBinary(byteArrayOf(1, 2, 3, 4))
 
-        proxy.detachChannel(IllegalStateException("http_proxy channel closed"))
+        proxy.detachChannel(attachment, IllegalStateException("http_proxy channel closed"))
 
         // Fails now rather than sitting out the 30 s request timeout.
         assertTrue(streaming.await().exceptionOrNull() is IllegalStateException)
@@ -145,8 +145,8 @@ class WebRTCHttpProxyChannelTest {
         val viaApi = async { proxy.get("/imageproxy?p=1") }
         val id = apiChannel.awaitFirstRequestId()
 
-        proxy.attachChannel { error("must not be used by an already-sent request") }
-        proxy.detachChannel(IllegalStateException("http_proxy channel closed"))
+        val attachment = proxy.attachChannel { error("must not be used by an already-sent request") }
+        proxy.detachChannel(attachment, IllegalStateException("http_proxy channel closed"))
 
         // The server still answers on the channel the request arrived on.
         proxy.dispatchRawResponse(hexResponse(id, listOf(7, 7)))
@@ -178,14 +178,14 @@ class WebRTCHttpProxyChannelTest {
         val proxyChannel = RecordingChannel()
         val proxy = WebRTCHttpProxy(sender = apiChannel.send)
 
-        proxy.attachChannel(proxyChannel.send)
+        val attachment = proxy.attachChannel(proxyChannel.send)
         val onProxy = async { proxy.get("/imageproxy?p=1") }
         val proxyId = proxyChannel.awaitFirstRequestId()
         proxy.dispatchProxyChannelText(binaryHeader(proxyId, 1))
         proxy.dispatchProxyChannelBinary(byteArrayOf(1))
         onProxy.await()
 
-        proxy.detachChannel(IllegalStateException("closed"))
+        proxy.detachChannel(attachment, IllegalStateException("closed"))
 
         val onApi = async { proxy.get("/imageproxy?p=2") }
         val apiId = apiChannel.awaitFirstRequestId()
@@ -195,5 +195,38 @@ class WebRTCHttpProxyChannelTest {
         assertEquals(1, proxyChannel.sent.size)
         assertEquals(1, apiChannel.sent.size)
         assertTrue(proxyId != apiId)
+    }
+
+    @Test
+    fun staleDetachDoesNotTearDownNewlyAttachedChannel() = runTest {
+        val channelA = RecordingChannel()
+        val channelB = RecordingChannel()
+        val proxy = WebRTCHttpProxy(sender = { error("must not use ma-api") })
+
+        // A reconnect can attach B before the cancelled listener for A reaches its finally block.
+        val attachmentA = proxy.attachChannel(channelA.send)
+        val responseA = async { runCatching { proxy.get("/imageproxy?p=1") } }
+        channelA.awaitFirstRequestId()
+
+        proxy.attachChannel(channelB.send)
+        val responseB = async { runCatching { proxy.get("/imageproxy?p=2") } }
+        val idB = channelB.awaitFirstRequestId()
+
+        // This represents the stale A listener's detach after B has become current.
+        val cause = IllegalStateException("channel A closed")
+        proxy.detachChannel(attachmentA, cause)
+
+        // A's request is failed promptly, while B remains usable.
+        val failureA = responseA.await().exceptionOrNull()
+        assertTrue(failureA is IllegalStateException)
+        assertEquals(cause.message, failureA.message)
+        proxy.dispatchProxyChannelText(binaryHeader(idB, 2))
+        proxy.dispatchProxyChannelBinary(byteArrayOf(8, 9))
+
+        val resultB = responseB.await()
+        assertTrue(resultB.isSuccess, "stale channel A detach failed channel B: ${resultB.exceptionOrNull()}")
+        assertContentEquals(byteArrayOf(8, 9), resultB.getOrThrow().body)
+        assertEquals(1, channelA.sent.size)
+        assertEquals(1, channelB.sent.size)
     }
 }


### PR DESCRIPTION
Servers on schema 49+ route proxied HTTP on an `http_proxy` data channel and answer there with a JSON header plus raw binary body frames, instead of hex-in-JSON on `ma-api`. That drops ~2.7x wire overhead to ~1x and stops images queueing ahead of API traffic.

Feature-gated on server_info.schema_version: a pre-49 server mistakes an unknown channel label for the API channel and drops the whole session, so the channel is opened only after the server proves it can route the label.
