### PR TITLE
Wait for home load errors

### DIFF
--- a/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/support/pages/HomePage.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.support.pages
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -57,7 +58,9 @@ class HomePage(composeTestRule: ComposeTestRule) : ComposePage(composeTestRule) 
     }
 
     fun assertErrorLoadingData(): HomePage {
-        composeTestRule.onNodeWithText(Res.string.library_error.get()).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText(Res.string.library_error.get()).isDisplayed()
+        }
         return this
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/session/SendspinProtocolSession.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/session/SendspinProtocolSession.kt
@@ -56,7 +56,7 @@ sealed interface SessionEvent {
     /** An in-band re-handshake completed and new session keys are in place. */
     data object RehandshakeCompleted : SessionEvent
 
-    /** The session failed. [permanent] mirrors the transport's judgment. */
+    /** The session failed after best-effort transport cleanup; [permanent] mirrors the transport's judgment. */
     data class Failed(val cause: Throwable, val permanent: Boolean) : SessionEvent
 }
 
@@ -211,12 +211,13 @@ internal abstract class AbstractSendspinSession(
 
     /** Epoch establishment failed with [cause]; close the connection silently. */
     protected open suspend fun onEpochFailed(cause: Exception) {
-        emitEvent(SessionEvent.Failed(cause, permanent = false))
         try {
             transport.disconnect()
         } catch (_: Exception) {
             // Best-effort close; the socket may already be gone.
         }
+        // Publish failure after cleanup so consumers can safely react to it.
+        emitEvent(SessionEvent.Failed(cause, permanent = false))
     }
 
     /** One step of an epoch: a frame of this epoch, or the ending control event. */


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Wait for the asynchronous refresh failure state before asserting the error message. This avoids racing the Home screen recomposition in the Robolectric test.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll :composeApp:testAndroidHostTest :androidApp:testDebug`

