### PR TITLE
Improve folder browsing and continuous playback

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -77,6 +78,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.abs
+
+private const val RAPID_SKIP_BATCH_MS = 140L
 
 /** Preserve newer event/optimistic state when a delayed full snapshot arrives. */
 internal fun mergeFullQueueSnapshot(
@@ -131,6 +135,15 @@ class MainDataSource(
 
     private val supervisorJob = SupervisorJob()
     override val coroutineContext: CoroutineContext = supervisorJob + Dispatchers.IO
+
+    private data class RapidSkipBatch(
+        var delta: Int,
+        var playerId: String,
+        var job: Job? = null,
+    )
+
+    private val rapidSkipLock = Any()
+    private val rapidSkipBatches = mutableMapOf<String, RapidSkipBatch>()
 
     private val _serverPlayers = MutableStateFlow<DataState<List<Player>>>(DataState.Loading())
     private val _queueInfos = MutableStateFlow<List<QueueInfo>>(emptyList())
@@ -1095,7 +1108,38 @@ class MainDataSource(
             localPlayerController.handleLocalCommand(data, action)
             return
         }
+
+        if (
+            (action == PlayerAction.Next || action == PlayerAction.Previous) &&
+            data.queueInfo?.currentItem?.track !is io.music_assistant.client.data.model.client.items.Audiobook
+        ) {
+            val queueId = data.queueInfo?.id
+            if (queueId != null) {
+                enqueueRapidQueueSkip(
+                    queueId = queueId,
+                    playerId = data.playerId,
+                    delta = if (action == PlayerAction.Next) 1 else -1,
+                )
+                return
+            }
+        }
+
         val resolved = playerRequestFactory.resolve(data, action)
+
+        if (resolved is PlayerAction.SeekTo) {
+            data.queueInfo?.id?.let { queueId ->
+                positionTracker.setRemoteOptimisticSeek(
+                    queueId = queueId,
+                    elapsedSec = resolved.position.toDouble(),
+                    isPlaying = data.player.isPlaying,
+                    durationSec =
+                        data.queueInfo?.currentItem?.track?.duration,
+                    speed =
+                        data.queueInfo?.playbackSpeed ?: 1.0,
+                )
+            }
+        }
+
         launch {
             val request = playerRequestFactory.buildRequest(data, resolved) ?: return@launch
             val result = apiClient.sendRequest(request)
@@ -1105,6 +1149,87 @@ class MainDataSource(
                 ) { "Failed to send player action request for ${data.player.name}: $action" }
             }
         }
+    }
+
+    private fun enqueueRapidQueueSkip(
+        queueId: String,
+        playerId: String,
+        delta: Int,
+    ) {
+        synchronized(rapidSkipLock) {
+            val batch =
+                rapidSkipBatches.getOrPut(queueId) {
+                    RapidSkipBatch(delta = 0, playerId = playerId)
+                }
+            batch.delta += delta
+            batch.playerId = playerId
+            batch.job?.cancel()
+            batch.job = launch {
+                delay(RAPID_SKIP_BATCH_MS)
+                val snapshot = synchronized(rapidSkipLock) {
+                    rapidSkipBatches.remove(queueId)
+                } ?: return@launch
+                dispatchRapidQueueSkip(queueId, snapshot)
+            }
+        }
+    }
+
+    private suspend fun dispatchRapidQueueSkip(
+        queueId: String,
+        batch: RapidSkipBatch,
+    ) {
+        if (batch.delta == 0) return
+
+        if (abs(batch.delta) == 1) {
+            apiClient.sendRequest(
+                Request.Player.simpleCommand(
+                    playerId = batch.playerId,
+                    command = if (batch.delta > 0) "next" else "previous",
+                ),
+            )
+            return
+        }
+
+        val queueItems =
+            apiClient.sendRequest(Request.Queue.items(queueId))
+                .resultAs<List<ServerQueueItem>>()
+        val currentItemId =
+            _queueInfos.value
+                .firstOrNull { it.id == queueId }
+                ?.currentItem
+                ?.id
+        val currentIndex = queueItems?.indexOfFirst { it.queueItemId == currentItemId } ?: -1
+
+        if (queueItems.isNullOrEmpty() || currentIndex < 0) {
+            repeat(abs(batch.delta)) {
+                apiClient.sendRequest(
+                    Request.Player.simpleCommand(
+                        playerId = batch.playerId,
+                        command = if (batch.delta > 0) "next" else "previous",
+                    ),
+                )
+            }
+            return
+        }
+
+        val targetIndex =
+            rapidSkipTargetIndex(
+                currentIndex = currentIndex,
+                itemCount = queueItems.size,
+                delta = batch.delta,
+            )
+
+        log.i {
+            "Rapid skip queue=$queueId taps=${batch.delta} " +
+                "index=$currentIndex->$targetIndex"
+        }
+
+        apiClient.sendRequest(
+            Request.Queue.playIndex(
+                queueId = queueId,
+                queueItemId = queueItems[targetIndex].queueItemId,
+            ),
+        )
     }
 
     fun queueAction(action: QueueAction) {
@@ -1690,4 +1815,13 @@ class MainDataSource(
             return visiblePlayerIds.firstOrNull()
         }
     }
+}
+
+internal fun rapidSkipTargetIndex(
+    currentIndex: Int,
+    itemCount: Int,
+    delta: Int,
+): Int {
+    require(itemCount > 0)
+    return (currentIndex + delta).coerceIn(0, itemCount - 1)
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -77,6 +77,8 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.abs
 
@@ -142,7 +144,7 @@ class MainDataSource(
         var job: Job? = null,
     )
 
-    private val rapidSkipLock = Any()
+    private val rapidSkipMutex = Mutex()
     private val rapidSkipBatches = mutableMapOf<String, RapidSkipBatch>()
 
     private val _serverPlayers = MutableStateFlow<DataState<List<Player>>>(DataState.Loading())
@@ -1156,20 +1158,22 @@ class MainDataSource(
         playerId: String,
         delta: Int,
     ) {
-        synchronized(rapidSkipLock) {
-            val batch =
-                rapidSkipBatches.getOrPut(queueId) {
-                    RapidSkipBatch(delta = 0, playerId = playerId)
+        launch {
+            rapidSkipMutex.withLock {
+                val batch =
+                    rapidSkipBatches.getOrPut(queueId) {
+                        RapidSkipBatch(delta = 0, playerId = playerId)
+                    }
+                batch.delta += delta
+                batch.playerId = playerId
+                batch.job?.cancel()
+                batch.job = launch {
+                    delay(RAPID_SKIP_BATCH_MS)
+                    val snapshot = rapidSkipMutex.withLock {
+                        rapidSkipBatches.remove(queueId)
+                    } ?: return@launch
+                    dispatchRapidQueueSkip(queueId, snapshot)
                 }
-            batch.delta += delta
-            batch.playerId = playerId
-            batch.job?.cancel()
-            batch.job = launch {
-                delay(RAPID_SKIP_BATCH_MS)
-                val snapshot = synchronized(rapidSkipLock) {
-                    rapidSkipBatches.remove(queueId)
-                } ?: return@launch
-                dispatchRapidQueueSkip(queueId, snapshot)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
@@ -44,6 +44,7 @@ class PlayerPositionTracker {
         val speed: Double = 1.0,
         /** Hold the optimistic position until Sendspin confirms audio is flowing. */
         val freezeReason: FreezeReason? = null,
+        val ignoreServerAnchorsUntilMs: Long = 0L,
     ) {
         /** Position right now: anchor + speed-scaled wall-time since anchor (capped at duration). */
         fun effectiveNow(): Double {
@@ -75,6 +76,15 @@ class PlayerPositionTracker {
     ) {
         anchors.update { existing ->
             val current = existing[queueId]
+
+            if (
+                current != null &&
+                currentTimeMillis() <
+                    current.ignoreServerAnchorsUntilMs
+            ) {
+                return@update existing
+            }
+
             // Server anchors are noisy during handoff; Sendspin sync is the confirmation.
             if (current?.freezeReason != null) return@update existing
             existing + (
@@ -127,6 +137,33 @@ class PlayerPositionTracker {
                     durationSec = durationSec ?: current?.durationSec,
                     speed = speed ?: current?.speed ?: 1.0,
                     freezeReason = FreezeReason.SEEK,
+                )
+            )
+        }
+    }
+
+    /**
+     * Optimistic seek for remote/server players.
+     * Protects the requested position from MA's short-lived stale zero echo.
+     */
+    fun setRemoteOptimisticSeek(
+        queueId: String,
+        elapsedSec: Double,
+        isPlaying: Boolean,
+        durationSec: Double? = null,
+        speed: Double = 1.0,
+    ) {
+        anchors.update { existing ->
+            existing + (
+                queueId to Anchor(
+                    elapsedSec = elapsedSec,
+                    wallMs = currentTimeMillis(),
+                    isPlaying = isPlaying,
+                    durationSec = durationSec,
+                    speed = speed,
+                    freezeReason = null,
+                    ignoreServerAnchorsUntilMs =
+                        currentTimeMillis() + 3_000L,
                 )
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerRequestFactory.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerRequestFactory.kt
@@ -51,7 +51,10 @@ class PlayerRequestFactory(
                 Request.Player.setPower(playerId = data.playerId, powered = action.powered)
 
             is PlayerAction.SeekTo -> {
-                Request.Player.seek(queueId = data.playerId, position = action.position)
+                Request.Player.seek(
+                    queueId = data.queueInfo?.id ?: data.playerId,
+                    position = action.position,
+                )
             }
 
             // Resolved to SeekTo in resolve(); never reaches here.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
@@ -130,13 +130,17 @@ sealed class AppMediaItem {
 /** A quick favorite toggle is possible only when the add path has a [uri] to send. */
 val AppMediaItem.canBeFavorited: Boolean get() = uri != null
 
+/** Builds the normalized URI for an item represented only by its provider mapping. */
+fun ProviderMapping.mediaUri(mediaType: String): String =
+    "$providerInstance://$mediaType/$itemId"
+
 /**
  * Browse responses from filesystem providers can omit the normalized library URI.
  * Reconstruct the provider URI from its mapping so those tracks remain playable.
  */
 val Track.browsePlaybackUri: String?
     get() = mediaUri ?: providerMappings?.firstOrNull()?.let { mapping ->
-        "${mapping.providerInstance}://track/${mapping.itemId}"
+        mapping.mediaUri(MediaType.TRACK.serverValue)
     }
 
 fun PlayableItem.image(type: ImageType): ImageInfo? =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/AppMediaItem.kt
@@ -130,6 +130,15 @@ sealed class AppMediaItem {
 /** A quick favorite toggle is possible only when the add path has a [uri] to send. */
 val AppMediaItem.canBeFavorited: Boolean get() = uri != null
 
+/**
+ * Browse responses from filesystem providers can omit the normalized library URI.
+ * Reconstruct the provider URI from its mapping so those tracks remain playable.
+ */
+val Track.browsePlaybackUri: String?
+    get() = mediaUri ?: providerMappings?.firstOrNull()?.let { mapping ->
+        "${mapping.providerInstance}://track/${mapping.itemId}"
+    }
+
 fun PlayableItem.image(type: ImageType): ImageInfo? =
     images[type] ?: images[ImageType.MAIN] ?: images.firstNotNullOfOrNull { it.value }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -6,6 +6,7 @@ import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.factory.MediaItemFactory
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
+import io.music_assistant.client.data.model.client.items.mediaUri
 import io.music_assistant.client.data.model.server.SearchResult
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.model.server.events.MediaItemAddedEvent
@@ -193,7 +194,7 @@ class MediaItemRepository(
             itemId = fallback.itemId,
             provider = fallback.providerInstance,
             favorite = null,
-            uri = "${fallback.providerInstance}://$mediaType/${fallback.itemId}",
+            uri = fallback.mediaUri(mediaType),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/di/SharedModule.kt
@@ -38,6 +38,7 @@ import io.music_assistant.client.ui.compose.home.players.DspSettingsViewModel
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel
 import io.music_assistant.client.ui.compose.item.ItemListViewModel
 import io.music_assistant.client.ui.compose.item.ViewModeViewModel
+import io.music_assistant.client.ui.compose.library.BrowsePlaybackCoordinator
 import io.music_assistant.client.ui.compose.library.BrowseViewModel
 import io.music_assistant.client.ui.compose.library.LibraryCategoriesViewModel
 import io.music_assistant.client.ui.compose.library.LibraryListViewModel
@@ -127,6 +128,7 @@ fun sharedModule(
         }
         factory { LibraryCategoriesViewModel(get()) }
         factory { params -> LibraryListViewModel(params[0], get(), get(), get(), get()) }
+        singleOf(::BrowsePlaybackCoordinator)
         factory { params -> BrowseViewModel(params.getOrNull<String>(), get(), get(), get()) }
         factory { params ->
             ItemDetailsViewModel(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -159,6 +159,134 @@ class SettingsRepository(
         _playersSorting.update { newValue }
     }
 
+    @Serializable
+    data class FavoriteBrowseFolder(
+        val path: String,
+        val itemId: String,
+        val provider: String,
+        val name: String,
+        val uri: String? = null,
+    )
+
+    private val _favoriteBrowseFolders =
+        MutableStateFlow(loadFavoriteBrowseFolders())
+
+    val favoriteBrowseFolders = _favoriteBrowseFolders.asStateFlow()
+
+    private fun loadFavoriteBrowseFolders(): List<FavoriteBrowseFolder> {
+        val raw =
+            settings.getStringOrNull("favorite_browse_folders")
+                ?: return emptyList()
+
+        return runCatching {
+            myJson.decodeFromString<List<FavoriteBrowseFolder>>(raw)
+        }.getOrDefault(emptyList())
+    }
+
+    fun setBrowseFolderFavorite(
+        folder: FavoriteBrowseFolder,
+        favorite: Boolean,
+    ) {
+        val current = _favoriteBrowseFolders.value
+
+        val updated =
+            if (favorite) {
+                (
+                    current.filterNot { it.path == folder.path } +
+                        folder
+                )
+            } else {
+                current.filterNot { it.path == folder.path }
+            }
+
+        settings.putString(
+            "favorite_browse_folders",
+            myJson.encodeToString(updated),
+        )
+
+        _favoriteBrowseFolders.update { updated }
+    }
+
+    fun isBrowseFolderFavorite(path: String): Boolean =
+        _favoriteBrowseFolders.value.any { it.path == path }
+
+    enum class RandomPlaybackMode {
+        OFF,
+        RANDOM_SONGS,
+        RANDOM_FOLDERS,
+        ;
+
+        fun next(): RandomPlaybackMode =
+            when (this) {
+                OFF -> RANDOM_SONGS
+                RANDOM_SONGS -> RANDOM_FOLDERS
+                RANDOM_FOLDERS -> OFF
+            }
+    }
+
+    private val _randomPlaybackMode =
+        MutableStateFlow(
+            runCatching {
+                RandomPlaybackMode.valueOf(
+                    settings.getString(
+                        "random_playback_mode",
+                        RandomPlaybackMode.OFF.name,
+                    ),
+                )
+            }.getOrDefault(RandomPlaybackMode.OFF),
+        )
+
+    val randomPlaybackMode =
+        _randomPlaybackMode.asStateFlow()
+
+    fun cycleRandomPlaybackMode(): RandomPlaybackMode {
+        val next = _randomPlaybackMode.value.next()
+
+        settings.putString(
+            "random_playback_mode",
+            next.name,
+        )
+
+        _randomPlaybackMode.update { next }
+
+        return next
+    }
+
+    @Serializable
+    data class CachedBrowseFolder(
+        val path: String,
+        val itemId: String,
+        val provider: String,
+        val name: String,
+        val uri: String? = null,
+    )
+
+    private val _cachedBrowseFolders =
+        MutableStateFlow(loadCachedBrowseFolders())
+
+    val cachedBrowseFolders = _cachedBrowseFolders.asStateFlow()
+
+    private fun loadCachedBrowseFolders(): List<CachedBrowseFolder> {
+        val raw =
+            settings.getStringOrNull("cached_browse_folders")
+                ?: return emptyList()
+
+        return runCatching {
+            myJson.decodeFromString<List<CachedBrowseFolder>>(raw)
+        }.getOrDefault(emptyList())
+    }
+
+    fun setCachedBrowseFolders(
+        folders: List<CachedBrowseFolder>,
+    ) {
+        settings.putString(
+            "cached_browse_folders",
+            myJson.encodeToString(folders),
+        )
+
+        _cachedBrowseFolders.update { folders }
+    }
+
     // Home-screen rows: visibility + user-defined order in a single ordered list.
     // Order = display sort; enabled=false = hidden. JSON-encoded because folder
     // ids are arbitrary server strings (may contain the delimiters a flat string
@@ -725,6 +853,52 @@ class SettingsRepository(
             }
         }
         return LibraryFilters()
+    }
+
+    private val _browseViewMode = MutableStateFlow(
+        settings.getStringOrNull("view_mode_BROWSE")
+            ?.let { runCatching { ViewMode.valueOf(it) }.getOrNull() }
+            ?: ViewMode.LIST,
+    )
+    val browseViewMode = _browseViewMode.asStateFlow()
+
+    fun setBrowseViewMode(mode: ViewMode) {
+        settings.putString("view_mode_BROWSE", mode.name)
+        _browseViewMode.update { mode }
+    }
+
+    private val _browseSortOption = MutableStateFlow(
+        settings.getStringOrNull("sort_browse")
+            ?.let { parseSortOption(it) }
+            ?: SortOption(SortField.NAME),
+    )
+    val browseSortOption = _browseSortOption.asStateFlow()
+
+    fun setBrowseSortOption(option: SortOption) {
+        settings.putString(
+            "sort_browse",
+            "${option.field.name}:${option.descending}",
+        )
+        _browseSortOption.update { option }
+    }
+
+    private fun librarySortKey(mediaType: MediaType) =
+        "sort_library_${mediaType.name}"
+
+    fun getLibrarySortOption(mediaType: MediaType): SortOption {
+        val raw = settings.getStringOrNull(librarySortKey(mediaType))
+            ?: return SortConfig.defaultFor(mediaType)
+        return parseSortOption(raw) ?: SortConfig.defaultFor(mediaType)
+    }
+
+    fun setLibrarySortOption(
+        mediaType: MediaType,
+        option: SortOption,
+    ) {
+        settings.putString(
+            librarySortKey(mediaType),
+            "${option.field.name}:${option.descending}",
+        )
     }
 
     fun getSortOption(context: SubItemContext): SortOption {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/settings/SettingsRepository.kt
@@ -259,7 +259,11 @@ class SettingsRepository(
         val provider: String,
         val name: String,
         val uri: String? = null,
-    )
+    ) {
+        fun isLocalFilesystemFolder(): Boolean =
+            !path.endsWith("://") &&
+                (provider.startsWith("filesystem_local") || path.startsWith("filesystem_local"))
+    }
 
     private val _cachedBrowseFolders =
         MutableStateFlow(loadCachedBrowseFolders())
@@ -274,17 +278,19 @@ class SettingsRepository(
         return runCatching {
             myJson.decodeFromString<List<CachedBrowseFolder>>(raw)
         }.getOrDefault(emptyList())
+            .filter(CachedBrowseFolder::isLocalFilesystemFolder)
     }
 
     fun setCachedBrowseFolders(
         folders: List<CachedBrowseFolder>,
     ) {
+        val filesystemFolders = folders.filter(CachedBrowseFolder::isLocalFilesystemFolder)
         settings.putString(
             "cached_browse_folders",
-            myJson.encodeToString(folders),
+            myJson.encodeToString(filesystemFolders),
         )
 
-        _cachedBrowseFolders.update { folders }
+        _cachedBrowseFolders.update { filesystemFolders }
     }
 
     // Home-screen rows: visibility + user-defined order in a single ordered list.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/CategoryRow.kt
@@ -51,6 +51,7 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.DisplayString
@@ -68,6 +69,7 @@ fun <T, U> CategoryRow(
     onNavigateClick: (AppMediaItem) -> Unit,
     onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
     onOptionSelected: (U) -> Unit = {},
+    onFolderLongClick: (RecommendationFolder) -> Unit = {},
     onPlayClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
@@ -80,6 +82,7 @@ fun <T, U> CategoryRow(
             onNavigateClick = onNavigateClick,
             onNavigateToList = onNavigateToList,
             onOptionSelected = onOptionSelected,
+            onFolderLongClick = onFolderLongClick,
             onPlayClick = onPlayClick,
             playlistActions = playlistActions,
             libraryActions = libraryActions,
@@ -133,6 +136,7 @@ fun <T> CategoryRow(
     onNavigateClick: (AppMediaItem) -> Unit,
     onNavigateToList: (String, ItemList) -> Unit = { _, _ -> },
     onOptionSelected: (T) -> Unit = {},
+    onFolderLongClick: (RecommendationFolder) -> Unit = {},
     onPlayClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
@@ -167,6 +171,7 @@ fun <T> CategoryRow(
             }
         },
         onNavigateClick = onNavigateClick,
+        onFolderLongClick = onFolderLongClick,
         onPlayClick = onPlayClick,
         mediaItems = itemCategory.items,
         playlistActions = playlistActions,
@@ -182,6 +187,7 @@ fun CategoryRow(
     title: String,
     actions: @Composable () -> Unit = {},
     onNavigateClick: (AppMediaItem) -> Unit,
+    onFolderLongClick: (RecommendationFolder) -> Unit = {},
     onPlayClick: PlayHandler<AppMediaItem>,
     mediaItems: List<AppMediaItem>,
     playlistActions: PlaylistActions,
@@ -221,6 +227,7 @@ fun CategoryRow(
                     is PodcastEpisode -> "Episode"
                     is RadioStation -> "RadioStation"
                     is Genre -> "Genre"
+                    is RecommendationFolder -> "RecommendationFolder"
                     else -> "Unknown"
                 }
             },
@@ -300,6 +307,12 @@ fun CategoryRow(
                     onPlayOption = onPlayClick,
                     libraryActions = libraryActions,
                     providerIconFetcher = providerIconFetcher,
+                )
+
+                is RecommendationFolder -> FolderCell(
+                    item = item,
+                    onNavigateClick = { folder -> onNavigateClick(folder) },
+                    onLongClick = onFolderLongClick,
                 )
 
                 else -> {}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/ItemActionResolver.kt
@@ -8,6 +8,7 @@ import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.items.canBeFavorited
 
 /** Item types accepted by playlist edits (server contract, not a UI choice). */
 val AppMediaItem.supportsAddToPlaylist: Boolean
@@ -32,9 +33,9 @@ fun resolveLongClickActions(
     if (customizationAllowed) add(ItemAction.Customize)
     if (librarySupported) {
         add(if (item.isInLibrary) ItemAction.RemoveFromLibrary else ItemAction.AddToLibrary)
-        if (item.isInLibrary) {
-            add(if (item.favorite == true) ItemAction.Unfavorite else ItemAction.Favorite)
-        }
+    }
+    if (item.canBeFavorited) {
+        add(if (item.favorite == true) ItemAction.Unfavorite else ItemAction.Favorite)
     }
     if (canAddToPlaylist) add(ItemAction.AddToPlaylist)
     if (canRemoveFromPlaylist) add(ItemAction.RemoveFromPlaylist)
@@ -94,9 +95,9 @@ fun resolveDetailOverflowActions(
 ): List<ItemAction> = buildList {
     if (librarySupported) {
         add(if (item.isInLibrary) ItemAction.RemoveFromLibrary else ItemAction.AddToLibrary)
-        if (item.isInLibrary) {
-            add(if (item.favorite == true) ItemAction.Unfavorite else ItemAction.Favorite)
-        }
+    }
+    if (item.canBeFavorited) {
+        add(if (item.favorite == true) ItemAction.Unfavorite else ItemAction.Favorite)
     }
     if (canAddToPlaylist) add(ItemAction.AddToPlaylist)
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/items/MediaItems.kt
@@ -1147,6 +1147,7 @@ fun FolderCell(
     item: RecommendationFolder,
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (RecommendationFolder) -> Unit,
+    onLongClick: (RecommendationFolder) -> Unit = {},
 ) {
     when (viewMode) {
         ViewMode.LIST -> RowItem(
@@ -1156,13 +1157,13 @@ fun FolderCell(
             description = contentDescription(item),
             prefixContent = { FolderImage(item) },
             onClick = { onNavigateClick(item) },
-            onLongClick = {},
+            onLongClick = { onLongClick(item) },
         )
 
         ViewMode.GRID -> GridItem(
             description = contentDescription(item),
             onClick = { onNavigateClick(item) },
-            onLongClick = {},
+            onLongClick = { onLongClick(item) },
         ) {
             FolderImage(item)
             Spacer(Modifier.height(4.dp))

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreen.kt
@@ -20,12 +20,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.rememberTopAppBarState
@@ -55,6 +57,7 @@ import io.music_assistant.client.data.model.client.items.Playlist
 import io.music_assistant.client.data.model.client.items.Podcast
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.RadioStation
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.CenteredProgress
@@ -93,13 +96,28 @@ fun HomeScreen(
     state: HomeScreenState,
 ) {
     val homeScreenState by homeScreenViewModel.state.collectAsStateWithLifecycle()
+    var folderForFavoriteMenu by remember { mutableStateOf<RecommendationFolder?>(null) }
 
     // Reconciled, enabled-first ordering. Authoritative for normal-mode display.
     val recommendationsState = homeScreenState.recommendations
     val shortcutsState = homeScreenState.shortcuts
+    val favoritesState = homeScreenState.favorites
+    val randomFoldersState = homeScreenState.randomFolders
     val homeRowsConfig = homeScreenState.homeRowsConfig
-    val working = remember(recommendationsState, shortcutsState, homeRowsConfig) {
-        getCategories(recommendationsState, shortcutsState, homeRowsConfig)
+    val working = remember(
+        recommendationsState,
+        shortcutsState,
+        favoritesState,
+        randomFoldersState,
+        homeRowsConfig,
+    ) {
+        getCategories(
+            recommendationsState,
+            shortcutsState,
+            favoritesState,
+            randomFoldersState,
+            homeRowsConfig,
+        )
     }
 
     // Edit-mode working copy — isolated from external (real-time) updates while editing;
@@ -158,7 +176,17 @@ fun HomeScreen(
                 CategoryRow(
                     data = if (row.loading) DataState.Loading() else DataState.Data(row.category),
                     itemCategoryProvider = { it },
-                    onNavigateClick = onNavigateClick,
+                    onNavigateClick = { item ->
+                        if (
+                            row.category.id == RANDOM_FOLDERS_CATEGORY_ID &&
+                            item is RecommendationFolder
+                        ) {
+                            homeScreenViewModel.playRandomFolder(item)
+                        } else {
+                            onNavigateClick(item)
+                        }
+                    },
+                    onFolderLongClick = { folder -> folderForFavoriteMenu = folder },
                     onPlayClick = { item, option, radio, _ ->
                         homeScreenViewModel.onPlayClick(item, option, radio)
                     },
@@ -240,6 +268,29 @@ fun HomeScreen(
                     }
                 }
             }
+
+            folderForFavoriteMenu?.let { folder ->
+                AlertDialog(
+                    onDismissRequest = { folderForFavoriteMenu = null },
+                    title = { Text(folder.displayName) },
+                    text = { Text("Remove this folder from Favorites?") },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                homeScreenViewModel.setBrowseFolderFavorite(folder, favorite = false)
+                                folderForFavoriteMenu = null
+                            },
+                        ) {
+                            Text("Unfavorite")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { folderForFavoriteMenu = null }) {
+                            Text("Cancel")
+                        }
+                    },
+                )
+            }
         }
     }
 }
@@ -261,6 +312,8 @@ internal data class HomeRow(
 internal fun getCategories(
     recommendationsState: DataState<List<RecommendationRowState>>,
     shortcutsState: DataState<List<Shortcut>>,
+    favoritesState: DataState<List<AppMediaItem>> = DataState.NoData(),
+    randomFoldersState: DataState<List<RecommendationFolder>> = DataState.NoData(),
     homeRowsConfig: List<SettingsRepository.HomeRowPref>,
 ): List<Pair<HomeRow, Boolean>> {
     val baseList = if (recommendationsState is DataState.Data) {
@@ -277,7 +330,8 @@ internal fun getCategories(
                             item is Podcast ||
                             item is PodcastEpisode ||
                             item is RadioStation ||
-                            item is Genre
+                            item is Genre ||
+                            item is RecommendationFolder
                 } == true
             }
             .distinctBy { it.folder.lazyListKey() }
@@ -294,7 +348,7 @@ internal fun getCategories(
                 )
             }
 
-        if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
+        val rows = if (shortcutsState is DataState.Data && shortcutsState.data.isNotEmpty()) {
             val shortcuts = shortcutsState.data
             val shortcutsRow = HomeRow(
                 category = ItemCategory(
@@ -311,6 +365,39 @@ internal fun getCategories(
         } else {
             recommendations
         }
+
+        val randomFoldersRow =
+            (randomFoldersState as? DataState.Data)
+                ?.data
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { folders ->
+                    HomeRow(
+                        category = ItemCategory(
+                            id = RANDOM_FOLDERS_CATEGORY_ID,
+                            title = "Random Folders".toDisplayString(),
+                            items = folders,
+                            lazyListKey = RANDOM_FOLDERS_CATEGORY_ID,
+                        ),
+                        loading = false,
+                    )
+                }
+        val favoritesRow =
+            (favoritesState as? DataState.Data)
+                ?.data
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { favorites ->
+                    HomeRow(
+                        category = ItemCategory(
+                            id = FAVORITES_CATEGORY_ID,
+                            title = "Favorites".toDisplayString(),
+                            items = favorites,
+                            lazyListKey = FAVORITES_CATEGORY_ID,
+                        ),
+                        loading = false,
+                    )
+                }
+
+        listOfNotNull(favoritesRow, randomFoldersRow) + rows
     } else {
         emptyList()
     }
@@ -319,6 +406,8 @@ internal fun getCategories(
 }
 
 private const val SHORTCUTS_CATEGORY_ID = "shortcuts"
+private const val FAVORITES_CATEGORY_ID = "favorites"
+private const val RANDOM_FOLDERS_CATEGORY_ID = "random_folders"
 
 @Composable
 private fun LandingPageTopBar(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -16,6 +16,7 @@ import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
 import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.items.browsePlaybackUri
 import io.music_assistant.client.data.model.server.ServerUser
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.player.sendspin.SendspinState
@@ -550,7 +551,7 @@ class HomeScreenViewModel(
                     name.equals("Empty", ignoreCase = true)
             }
             .sortedBy { it.displayName.lowercase() }
-            .mapNotNull { it.mediaUri }
+            .mapNotNull { it.browsePlaybackUri }
             .distinct()
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -10,6 +10,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.Player
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.Shortcut
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
@@ -58,6 +59,24 @@ class HomeScreenViewModel(
     private val jobs = mutableListOf<Job>()
     private var loadDataJob: Job? = null
 
+    private var browseFolderCache: List<RecommendationFolder>? =
+        settings.cachedBrowseFolders.value
+            .takeIf { it.isNotEmpty() }
+            ?.map { stored ->
+                RecommendationFolder(
+                    itemId = stored.itemId,
+                    provider = stored.provider,
+                    name = stored.name,
+                    uri = stored.uri,
+                    images = emptyMap(),
+                    path = stored.path,
+                )
+            }
+
+    // A persistent cache means a normal app launch does not need to crawl
+    // the Browse tree again. A manual Home refresh explicitly invalidates it.
+    private var forceBrowseFolderRefresh = false
+
     private val _links = MutableSharedFlow<String>()
     val links = _links.asSharedFlow()
 
@@ -97,6 +116,8 @@ class HomeScreenViewModel(
         State(
             shortcuts = DataState.Loading(),
             recommendations = DataState.Loading(),
+            favorites = DataState.Loading(),
+            randomFolders = DataState.Loading(),
             homeRowsConfig = settings.homeRowsConfig.value,
         ),
     )
@@ -105,6 +126,20 @@ class HomeScreenViewModel(
     private val _playersState =
         MutableStateFlow<PlayersState>(PlayersState.Loading)
     val playersState = _playersState.asStateFlow()
+
+    // These fields must be initialized before the collectors started in init;
+    // test dispatchers can run those collectors immediately.
+    private var randomPlaybackSessionUris: List<String> = emptyList()
+    private var randomPlaybackSessionIndex: Int = -1
+    private var randomPlaybackSessionTargetId: String? = null
+    private var randomPlaybackSessionQueueId: String? = null
+    private var randomPlaybackFolderSequence: List<RecommendationFolder> = emptyList()
+    private var randomPlaybackFolderIndex: Int = -1
+    private var randomPlaybackFolderMode = SettingsRepository.RandomPlaybackMode.OFF
+    private var randomPlaybackFolderTransitionInFlight = false
+    private var randomPlaybackWasPlaying = false
+    private var randomPlaybackLastElapsedSec = 0.0
+    private var randomPlaybackAutoAdvanceInFlight = false
 
     init {
         viewModelScope.launch {
@@ -203,24 +238,39 @@ class HomeScreenViewModel(
         // Listen to real-time library changes to refresh tracks already shown
         // in the recommendations grid.
         viewModelScope.launch {
+            settings.favoriteBrowseFolders.collect {
+                loadData()
+            }
+        }
+
+        viewModelScope.launch {
             mediaItemRepository.itemChanges.collect { change ->
                 (change.item as? Track)?.let { updateRecommendationsIfNeeded(it) }
+
+                // Refresh Home so Favorites immediately reflects favorite changes.
+                loadData()
             }
         }
     }
 
-    fun loadData() {
+    fun loadData(refreshBrowseFolders: Boolean = false) {
+        if (refreshBrowseFolders) {
+            forceBrowseFolderRefresh = true
+        }
         loadDataJob?.cancel()
 
         _state.update {
             it.copy(
                 recommendations = DataState.Loading(),
                 shortcuts = DataState.Loading(),
+                favorites = DataState.Loading(),
+                randomFolders = DataState.Loading(),
             )
         }
 
         loadDataJob = viewModelScope.launch {
             launch { loadShortcuts() }
+            launch { loadBrowseFolderRows() }
             loadRecommendations()
         }
     }
@@ -294,6 +344,111 @@ class HomeScreenViewModel(
         }
     }
 
+    private suspend fun loadBrowseFolderRows() {
+        try {
+            val folderPool = if (browseFolderCache.isNullOrEmpty() || forceBrowseFolderRefresh) {
+                val discovered = mutableListOf<RecommendationFolder>()
+
+                suspend fun discover(path: String?, current: RecommendationFolder? = null, depth: Int = 0) {
+                    if (depth > 12) return
+                    val items = mediaItemRepository.fetchMediaItems(Request.Browse.atPath(path)).getOrNull()
+                        ?: return
+                    val tracks = items.filterIsInstance<Track>().filterNot {
+                        it.displayName.trim().equals("(Empty)", true) ||
+                            it.displayName.trim().equals("Empty", true)
+                    }
+                    if (current != null && tracks.isNotEmpty()) discovered += current
+                    items.filterIsInstance<RecommendationFolder>()
+                        .filter { !it.isParentLink && it.path != null }
+                        .forEach { discover(it.path, it, depth + 1) }
+                }
+
+                discover(null)
+                discovered.distinctBy { it.path }.also { folders ->
+                    browseFolderCache = folders
+                    settings.setCachedBrowseFolders(
+                        folders.map { folder ->
+                            SettingsRepository.CachedBrowseFolder(
+                                path = requireNotNull(folder.path),
+                                itemId = folder.itemId,
+                                provider = folder.provider,
+                                name = folder.name,
+                                uri = folder.uri,
+                            )
+                        },
+                    )
+                    forceBrowseFolderRefresh = false
+                }
+            } else {
+                browseFolderCache.orEmpty()
+            }
+
+            val libraryFavorites = buildList<AppMediaItem> {
+                getList<AppMediaItem>(Request.Artist.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Album.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Track.list(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Playlist.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Audiobook.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Podcast.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.RadioStation.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+                getList<AppMediaItem>(Request.Genre.listLibrary(favorite = true, limit = 100))?.let(::addAll)
+            }
+            val favoriteFolders = settings.favoriteBrowseFolders.value.map { stored ->
+                RecommendationFolder(
+                    itemId = stored.itemId,
+                    provider = stored.provider,
+                    name = stored.name,
+                    uri = stored.uri,
+                    images = emptyMap(),
+                    path = stored.path,
+                )
+            }
+            val favorites = (favoriteFolders + libraryFavorites).distinctBy { item ->
+                if (item is RecommendationFolder) {
+                    "folder:${item.path}"
+                } else {
+                    "${item.mediaType.serverValue}:${item.itemId}"
+                }
+            }
+            _state.update {
+                it.copy(
+                    favorites = DataState.Data(favorites),
+                    randomFolders = DataState.Data(folderPool.shuffled().take(RANDOM_FOLDER_COUNT)),
+                )
+            }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            Logger.e("Error loading Home folder rows", error)
+            _state.update {
+                it.copy(favorites = DataState.Error(), randomFolders = DataState.Error())
+            }
+        }
+    }
+
+    fun setBrowseFolderFavorite(folder: RecommendationFolder, favorite: Boolean) {
+        val path = folder.path ?: return
+        settings.setBrowseFolderFavorite(
+            SettingsRepository.FavoriteBrowseFolder(
+                path = path,
+                itemId = folder.itemId,
+                provider = folder.provider,
+                name = folder.displayName,
+                uri = folder.uri,
+            ),
+            favorite = favorite,
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun <T : AppMediaItem> getList(request: Request): List<T>? =
+        mediaItemRepository.fetchMediaItems(request).let { result ->
+            if (result.isFailure) {
+                Logger.e("Error fetching list for request $request: ${result.exceptionOrNull()}")
+            }
+            result.getOrNull()?.mapNotNull { it as? T }
+        }
+
     fun onPlayClick(
         item: AppMediaItem,
         option: QueueOption,
@@ -314,6 +469,547 @@ class HomeScreenViewModel(
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Starts randomized playback from a Browse folder.
+     *
+     * The Browse API returns all items at this folder level. Playable items
+     * are sent to Music Assistant as one shuffled REPLACE request.
+     *
+     * Random Folder playback deliberately does not enable Music Assistant's
+     * Don't Stop The Music mode. Folder-to-folder continuation is controlled
+     * separately by the app.
+     */
+    /**
+     * Plays the Random Folders collection as one continuous media sequence.
+     *
+     * Playback starts with the folder the user tapped, then continues through
+     * the remaining folders in the current Random Folders Home-row order,
+     * wrapping around to folders that appeared before the tapped folder.
+     *
+     * Music Assistant receives one complete REPLACE playback request, which
+     * gives normal media-player semantics: automatic track advancement and
+     * working Previous / Next controls without Don't Stop The Music.
+     */
+    /**
+     * Starts continuous playback across the discovered Browse-folder pool.
+     *
+     * OFF:
+     *   selected folder first, then folders alphabetically.
+     *
+     * RANDOM_SONGS:
+     *   first song from the selected folder starts normally; all remaining
+     *   available songs are shuffled globally.
+     *
+     * RANDOM_FOLDERS:
+     *   selected folder plays completely in normal order; remaining folders
+     *   are randomized while preserving normal song order inside each folder.
+     *
+     * The whole sequence is sent in one REPLACE request so normal Previous,
+     * Next and automatic track advancement continue to work.
+     */
+    // App-owned playback sequence for the custom folder playback modes.
+    //
+    // Music Assistant currently exposes this playback to the client as a
+    // one-item queue, so Next / Previous cannot rely on MA queue navigation.
+    // We therefore keep the sequence here and submit one track at a time.
+    /**
+     * Handles Next / Previous for an active custom playback session.
+     *
+     * Returns true when the action was consumed here. All other player
+     * actions must continue through the normal Music Assistant path.
+     */
+    private suspend fun loadRandomPlaybackFolderTracks(
+        folder: RecommendationFolder,
+    ): List<String> {
+        val path = folder.path ?: return emptyList()
+
+        val result =
+            mediaItemRepository.fetchMediaItems(
+                Request.Browse.atPath(path),
+            )
+
+        val items = result.getOrNull()
+
+        if (items == null) {
+            Logger.e(
+                "Failed to load playback folder '${folder.displayName}'",
+                result.exceptionOrNull(),
+            )
+            return emptyList()
+        }
+
+        return items
+            .filterIsInstance<Track>()
+            .filterNot { track ->
+                val name = track.displayName.trim()
+
+                name.equals("(Empty)", ignoreCase = true) ||
+                    name.equals("Empty", ignoreCase = true)
+            }
+            .sortedBy { it.displayName.lowercase() }
+            .mapNotNull { it.mediaUri }
+            .distinct()
+    }
+
+    private fun switchRandomPlaybackFolder(
+        direction: Int,
+    ): Boolean {
+        if (randomPlaybackFolderTransitionInFlight) return true
+
+        val folders = randomPlaybackFolderSequence
+        if (folders.isEmpty()) return false
+
+        randomPlaybackFolderTransitionInFlight = true
+
+        viewModelScope.launch {
+            try {
+                var index = randomPlaybackFolderIndex
+                var attempts = 0
+
+                while (attempts < folders.size) {
+                    index =
+                        (index + direction + folders.size) %
+                            folders.size
+
+                    val folder = folders[index]
+                    val songs =
+                        loadRandomPlaybackFolderTracks(folder)
+
+                    if (songs.isNotEmpty()) {
+                        randomPlaybackFolderIndex = index
+                        randomPlaybackSessionUris = songs
+
+                        val trackIndex =
+                            if (direction >= 0) {
+                                0
+                            } else {
+                                songs.lastIndex
+                            }
+
+                        Logger.withTag("RandomFolderPlay").i {
+                            "FOLDER SWITCH " +
+                                "folder=${folder.displayName} " +
+                                "tracks=${songs.size}"
+                        }
+
+                        playRandomPlaybackSessionIndex(trackIndex)
+                        return@launch
+                    }
+
+                    attempts++
+                }
+
+                Logger.withTag("RandomFolderPlay").i {
+                    "No playable next folder found"
+                }
+            } finally {
+                randomPlaybackFolderTransitionInFlight = false
+            }
+        }
+
+        return true
+    }
+
+    private fun appendAndPlayRandomLibrarySong(): Boolean {
+        if (randomPlaybackFolderTransitionInFlight) return true
+
+        val folders = randomPlaybackFolderSequence
+        if (folders.isEmpty()) return false
+
+        randomPlaybackFolderTransitionInFlight = true
+
+        viewModelScope.launch {
+            try {
+                val candidates = folders.shuffled()
+
+                for (folder in candidates) {
+                    val songs =
+                        loadRandomPlaybackFolderTracks(folder)
+                            .filterNot {
+                                it in randomPlaybackSessionUris
+                            }
+
+                    if (songs.isEmpty()) continue
+
+                    val uri = songs.random()
+
+                    randomPlaybackSessionUris =
+                        randomPlaybackSessionUris + uri
+
+                    Logger.withTag("RandomFolderPlay").i {
+                        "RANDOM GLOBAL uri=$uri"
+                    }
+
+                    playRandomPlaybackSessionIndex(
+                        randomPlaybackSessionUris.lastIndex,
+                    )
+
+                    return@launch
+                }
+
+                // Everything has already been heard: allow a new cycle.
+                randomPlaybackSessionUris =
+                    randomPlaybackSessionUris
+                        .getOrNull(randomPlaybackSessionIndex)
+                        ?.let(::listOf)
+                        .orEmpty()
+
+                appendAndPlayRandomLibrarySong()
+            } finally {
+                randomPlaybackFolderTransitionInFlight = false
+            }
+        }
+
+        return true
+    }
+
+    private fun advanceRandomPlaybackNext(
+        source: String,
+    ): Boolean {
+        val session = randomPlaybackSessionUris
+
+        if (
+            session.isEmpty() ||
+            randomPlaybackSessionIndex !in session.indices
+        ) {
+            return false
+        }
+
+        if (randomPlaybackSessionIndex < session.lastIndex) {
+            val nextIndex = randomPlaybackSessionIndex + 1
+
+            Logger.withTag("RandomFolderPlay").i {
+                "ADVANCE source=$source " +
+                    "$randomPlaybackSessionIndex -> $nextIndex"
+            }
+
+            playRandomPlaybackSessionIndex(nextIndex)
+            return true
+        }
+
+        return when (randomPlaybackFolderMode) {
+            SettingsRepository.RandomPlaybackMode.RANDOM_SONGS ->
+                appendAndPlayRandomLibrarySong()
+
+            SettingsRepository.RandomPlaybackMode.OFF,
+            SettingsRepository.RandomPlaybackMode.RANDOM_FOLDERS,
+            ->
+                switchRandomPlaybackFolder(direction = 1)
+        }
+    }
+
+    private fun advanceRandomPlaybackPrevious(): Boolean {
+        val session = randomPlaybackSessionUris
+
+        if (
+            session.isEmpty() ||
+            randomPlaybackSessionIndex !in session.indices
+        ) {
+            return false
+        }
+
+        if (randomPlaybackSessionIndex > 0) {
+            playRandomPlaybackSessionIndex(
+                randomPlaybackSessionIndex - 1,
+            )
+            return true
+        }
+
+        return when (randomPlaybackFolderMode) {
+            SettingsRepository.RandomPlaybackMode.RANDOM_SONGS ->
+                false
+
+            SettingsRepository.RandomPlaybackMode.OFF,
+            SettingsRepository.RandomPlaybackMode.RANDOM_FOLDERS,
+            ->
+                switchRandomPlaybackFolder(direction = -1)
+        }
+    }
+
+    fun handleRandomPlaybackTransport(
+        playerData: PlayerData,
+        action: PlayerAction,
+    ): Boolean {
+        if (
+            action != PlayerAction.Next &&
+            action != PlayerAction.Previous
+        ) {
+            return false
+        }
+
+        val session = randomPlaybackSessionUris
+
+        if (
+            session.isEmpty() ||
+            randomPlaybackSessionIndex !in session.indices
+        ) {
+            return false
+        }
+
+        val currentQueueId = playerData.queueInfo?.id
+
+        if (
+            randomPlaybackSessionQueueId != null &&
+            currentQueueId != null &&
+            currentQueueId != randomPlaybackSessionQueueId
+        ) {
+            return false
+        }
+
+        return when (action) {
+            PlayerAction.Next ->
+                advanceRandomPlaybackNext("MANUAL_NEXT")
+
+            PlayerAction.Previous ->
+                advanceRandomPlaybackPrevious()
+
+            else ->
+                false
+        }
+    }
+
+    /**
+     * Detects natural completion of the currently playing custom-session track.
+     *
+     * Music Assistant sees each custom-session song as Queue 1/1, so it stops
+     * at the end. When we observe playing -> stopped near the track duration,
+     * advance through the same client-owned sequence used by the Next button.
+     */
+    private fun handleRandomPlaybackNaturalEnd(
+        playerData: PlayerData,
+    ) {
+        val session = randomPlaybackSessionUris
+
+        if (
+            session.isEmpty() ||
+            randomPlaybackSessionIndex !in session.indices
+        ) {
+            randomPlaybackWasPlaying = false
+            randomPlaybackLastElapsedSec = 0.0
+            return
+        }
+
+        val sessionQueueId = randomPlaybackSessionQueueId
+        val currentQueueId = playerData.queueInfo?.id
+
+        if (
+            sessionQueueId != null &&
+            currentQueueId != null &&
+            currentQueueId != sessionQueueId
+        ) {
+            return
+        }
+
+        val queue = playerData.queueInfo ?: return
+        val duration = queue.currentItem?.track?.duration
+        val elapsed =
+            queue.elapsedTime ?: randomPlaybackLastElapsedSec
+        val isPlaying = playerData.player.isPlaying
+
+        if (isPlaying) {
+            randomPlaybackWasPlaying = true
+            randomPlaybackLastElapsedSec = elapsed
+            randomPlaybackAutoAdvanceInFlight = false
+            return
+        }
+
+        val endPosition =
+            maxOf(
+                randomPlaybackLastElapsedSec,
+                elapsed,
+            )
+
+        val endedNaturally =
+            randomPlaybackWasPlaying &&
+                duration != null &&
+                duration > 0.0 &&
+                endPosition >= duration - 3.0
+
+        if (
+            endedNaturally &&
+            !randomPlaybackAutoAdvanceInFlight
+        ) {
+            randomPlaybackAutoAdvanceInFlight = true
+            randomPlaybackWasPlaying = false
+
+            Logger.withTag("RandomFolderPlay").i {
+                "NATURAL END " +
+                    "index=$randomPlaybackSessionIndex " +
+                    "elapsed=$endPosition duration=$duration"
+            }
+
+            advanceRandomPlaybackNext("NATURAL_END")
+        }
+    }
+
+    private fun playRandomPlaybackSessionIndex(
+        index: Int,
+    ) {
+        val session = randomPlaybackSessionUris
+        val targetId = randomPlaybackSessionTargetId ?: return
+
+        if (index !in session.indices) return
+
+        randomPlaybackSessionIndex = index
+        randomPlaybackWasPlaying = false
+        randomPlaybackLastElapsedSec = 0.0
+
+        val uri = session[index]
+
+        Logger.withTag("RandomFolderPlay").i {
+            "session track=${index + 1}/${session.size} uri=$uri"
+        }
+
+        viewModelScope.launch {
+            apiClient.sendRequest(
+                Request.Library.play(
+                    media = listOf(uri),
+                    queueOrPlayerId = targetId,
+                    option = QueueOption.REPLACE,
+                    radioMode = false,
+                ),
+            )
+        }
+    }
+
+    fun playRandomFolder(
+        folder: RecommendationFolder,
+    ) {
+        val selectedPath = folder.path ?: return
+        val selectedPlayer =
+            dataSource.selectedPlayer ?: return
+
+        val playbackTargetId =
+            selectedPlayer.queueOrPlayerId
+
+        val actualQueueId =
+            selectedPlayer.queueInfo?.id
+
+        viewModelScope.launch {
+            val mode = settings.randomPlaybackMode.value
+
+            val allFolders =
+                (
+                    listOf(folder) +
+                        browseFolderCache.orEmpty()
+                )
+                    .filter {
+                        it.path != null &&
+                            !it.isParentLink
+                    }
+                    .distinctBy { it.path }
+
+            val selectedFolder =
+                allFolders.firstOrNull {
+                    it.path == selectedPath
+                } ?: folder
+
+            val alphabetic =
+                allFolders.sortedBy {
+                    it.displayName.lowercase()
+                }
+
+            val selectedAlphabeticIndex =
+                alphabetic.indexOfFirst {
+                    it.path == selectedPath
+                }
+
+            randomPlaybackFolderSequence =
+                when (mode) {
+                    SettingsRepository.RandomPlaybackMode.OFF -> {
+                        if (selectedAlphabeticIndex >= 0) {
+                            alphabetic.drop(selectedAlphabeticIndex) +
+                                alphabetic.take(selectedAlphabeticIndex)
+                        } else {
+                            listOf(selectedFolder) + alphabetic
+                        }
+                    }
+
+                    SettingsRepository.RandomPlaybackMode.RANDOM_FOLDERS ->
+                        listOf(selectedFolder) +
+                            allFolders
+                                .filterNot {
+                                    it.path == selectedPath
+                                }
+                                .shuffled()
+
+                    SettingsRepository.RandomPlaybackMode.RANDOM_SONGS ->
+                        allFolders
+                }
+
+            randomPlaybackFolderIndex =
+                randomPlaybackFolderSequence
+                    .indexOfFirst {
+                        it.path == selectedPath
+                    }
+                    .coerceAtLeast(0)
+
+            randomPlaybackFolderMode = mode
+            randomPlaybackFolderTransitionInFlight = false
+
+            val selectedTracks =
+                loadRandomPlaybackFolderTracks(selectedFolder)
+
+            if (selectedTracks.isEmpty()) {
+                Logger.withTag("RandomFolderPlay").i {
+                    "Selected folder has no playable tracks"
+                }
+                return@launch
+            }
+
+            // RANDOM_SONGS starts with the selected folder's first song.
+            // Every following Next/natural-end chooses globally.
+            randomPlaybackSessionUris =
+                if (
+                    mode ==
+                    SettingsRepository.RandomPlaybackMode.RANDOM_SONGS
+                ) {
+                    listOf(selectedTracks.first())
+                } else {
+                    selectedTracks
+                }
+
+            randomPlaybackSessionIndex = 0
+            randomPlaybackSessionTargetId = playbackTargetId
+            randomPlaybackSessionQueueId = actualQueueId
+            randomPlaybackWasPlaying = false
+            randomPlaybackLastElapsedSec = 0.0
+            randomPlaybackAutoAdvanceInFlight = false
+
+            actualQueueId?.let { queueId ->
+                apiClient.sendRequest(
+                    Request.Queue.setRepeatMode(
+                        queueId = queueId,
+                        repeatMode = RepeatMode.OFF,
+                    ),
+                )
+
+                apiClient.sendRequest(
+                    Request.Queue.setShuffle(
+                        queueId = queueId,
+                        enabled = false,
+                    ),
+                )
+
+                apiClient.sendRequest(
+                    Request.Queue.setDontStopTheMusic(
+                        queueId = queueId,
+                        enabled = false,
+                    ),
+                )
+            }
+
+            Logger.withTag("RandomFolderPlay").i {
+                "START tapped=${folder.displayName} " +
+                    "mode=$mode " +
+                    "tracks=${randomPlaybackSessionUris.size} " +
+                    "folders=${randomPlaybackFolderSequence.size}"
+            }
+
+            playRandomPlaybackSessionIndex(0)
         }
     }
 
@@ -346,6 +1042,23 @@ class HomeScreenViewModel(
         ) { playerData, sendspinState ->
             playerData to sendspinState
         }.collect { (playerData, sendspinState) ->
+            val selectedPlayerIndex =
+                dataSource.selectedPlayerIndex.value
+
+            when (playerData) {
+                is DataState.Data ->
+                    selectedPlayerIndex
+                        ?.let { playerData.data.getOrNull(it) }
+                        ?.let(::handleRandomPlaybackNaturalEnd)
+
+                is DataState.Stale ->
+                    selectedPlayerIndex
+                        ?.let { playerData.data.getOrNull(it) }
+                        ?.let(::handleRandomPlaybackNaturalEnd)
+
+                else -> Unit
+            }
+
             // Update when in Loading or Data state
             // This allows transitioning from Loading to Data and updating existing Data
             // Don't update terminal states (Disconnected, NoAuth, NoServer)
@@ -432,6 +1145,9 @@ class HomeScreenViewModel(
     data class State(
         val shortcuts: DataState<List<Shortcut>>,
         val recommendations: DataState<List<RecommendationRowState>>,
+        val favorites: DataState<List<AppMediaItem>>,
+        val randomFolders: DataState<List<RecommendationFolder>>,
+
         val homeRowsConfig: List<SettingsRepository.HomeRowPref> = emptyList(),
     )
 
@@ -451,6 +1167,7 @@ class HomeScreenViewModel(
 
     private companion object {
         private const val BUFFER_REAL_INTERVAL = 500L
+        private const val RANDOM_FOLDER_COUNT = 10
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/HomeScreenViewModel.kt
@@ -358,9 +358,22 @@ class HomeScreenViewModel(
                         it.displayName.trim().equals("(Empty)", true) ||
                             it.displayName.trim().equals("Empty", true)
                     }
-                    if (current != null && tracks.isNotEmpty()) discovered += current
+                    if (
+                        current != null &&
+                        tracks.isNotEmpty() &&
+                        !current.path.orEmpty().endsWith("://")
+                    ) {
+                        discovered += current
+                    }
                     items.filterIsInstance<RecommendationFolder>()
-                        .filter { !it.isParentLink && it.path != null }
+                        .filter {
+                            !it.isParentLink &&
+                                it.path != null &&
+                                (
+                                    it.provider.startsWith("filesystem_local") ||
+                                        it.path.startsWith("filesystem_local")
+                                )
+                        }
                         .forEach { discover(it.path, it, depth + 1) }
                 }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/MainNavRoot.kt
@@ -355,6 +355,15 @@ private fun mainNavEntryProvider(
                 contentPadding = contentPadding,
                 onNavigateClick = { item ->
                     when (item) {
+                        is RecommendationFolder -> {
+                            multiBackStack.add(
+                                MainNav.Browse(
+                                    path = item.path ?: item.uri,
+                                    title = item.displayName,
+                                ),
+                            )
+                        }
+
                         is Artist,
                         is Album,
                         is Playlist,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AllInclusive
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.rounded.Forward30
 import androidx.compose.material.icons.rounded.Replay10
 import androidx.compose.material3.CircularProgressIndicator
@@ -15,6 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,12 +25,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
+import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.icons.PauseIcon
@@ -43,6 +48,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_pause
 import musicassistantclient.composeapp.generated.resources.action_play
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 @Composable
 fun PlayerControls(
@@ -55,18 +61,25 @@ fun PlayerControls(
     showSkipBack: Boolean = true,
     tint: Color = MaterialTheme.colorScheme.primary,
 ) {
+    val settingsRepository: SettingsRepository = koinInject()
+    val randomPlaybackMode by
+        settingsRepository.randomPlaybackMode.collectAsStateWithLifecycle()
+
     val player = playerData.player
     val queue = playerData.queueInfo
     val playerEnabled = player.canPlay && !player.isAnnouncing
     val buttonsEnabled = queue?.currentItem?.isPlayable == true
     // Audiobooks / podcast episodes swap shuffle & repeat for skip-back / skip-forward seek.
     val isLongForm = queue?.currentItem?.track.isLongFormSpokenContent
-    val itemsCount = playerData.queueItems?.size ?: 0
-    val skipForwardEnabled = when {
-        queue?.currentIndex?.let { it < itemsCount - 1 } == true -> true
-        (queue?.currentItem?.track as? Audiobook)?.let { it.fullyPlayed == false } == true -> true
-        else -> false
-    }
+    // Do not gate Next on playerData.queueItems.
+    // The server queue may contain following items even when the client has
+    // not loaded the full queue-item list yet.
+    val skipForwardEnabled =
+        buttonsEnabled &&
+            (
+                !isLongForm ||
+                    (queue?.currentItem?.track as? Audiobook)?.fullyPlayed == false
+            )
     val smallButtonSize = (mainButtonSize.value * 0.6).dp
     Row(
         modifier = modifier
@@ -85,19 +98,69 @@ fun PlayerControls(
                     ) { playerAction(playerData, PlayerAction.SeekBy(-LongFormSeekDefaults.BACK_SECONDS)) }
                 } else {
                     ActionButton(
-                        icon = if (it.shuffleEnabled) {
-                            ShuffleOnIcon
-                        } else {
-                            ShuffleOffIcon
-                        },
-                        tint = tint,
+                        icon =
+                            when (randomPlaybackMode) {
+                                SettingsRepository.RandomPlaybackMode.OFF ->
+                                    ShuffleOffIcon
+
+                                SettingsRepository.RandomPlaybackMode.RANDOM_SONGS ->
+                                    ShuffleOnIcon
+
+                                SettingsRepository.RandomPlaybackMode.RANDOM_FOLDERS ->
+                                    Icons.Default.Folder
+                            },
+                        tint =
+                            if (
+                                randomPlaybackMode ==
+                                SettingsRepository.RandomPlaybackMode.OFF
+                            ) {
+                                tint.copy(alpha = 0.45f)
+                            } else {
+                                tint
+                            },
                         size = smallButtonSize,
-                        enabled = playerEnabled && buttonsEnabled && !it.isDynamicPlaylist,
+                        enabled =
+                            playerEnabled &&
+                                buttonsEnabled &&
+                                !it.isDynamicPlaylist,
                     ) {
-                        playerAction(
-                            playerData,
-                            PlayerAction.ToggleShuffle(current = it.shuffleEnabled),
-                        )
+                        settingsRepository.cycleRandomPlaybackMode()
+
+                        // The custom Random Folder system owns randomisation.
+                        // Disable Music Assistant queue shuffle if it happened
+                        // to be enabled, otherwise the two systems would fight.
+                        if (it.shuffleEnabled) {
+                            playerAction(
+                                playerData,
+                                PlayerAction.ToggleShuffle(
+                                    current = true,
+                                ),
+                            )
+                        }
+                    }
+
+                    if (
+                        it.autoPlayEnabled != null &&
+                        !it.isDynamicPlaylist
+                    ) {
+                        ActionButton(
+                            icon = Icons.Default.AllInclusive,
+                            tint =
+                                if (it.autoPlayEnabled == true) {
+                                    tint
+                                } else {
+                                    tint.copy(alpha = 0.45f)
+                                },
+                            size = smallButtonSize,
+                            enabled = playerEnabled && buttonsEnabled,
+                        ) {
+                            playerAction(
+                                playerData,
+                                PlayerAction.ToggleDontStopTheMusic(
+                                    current = it.autoPlayEnabled == true,
+                                ),
+                            )
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import io.music_assistant.client.data.model.client.ImageType
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
 import io.music_assistant.client.data.model.client.ResolvedChapter
@@ -64,6 +65,7 @@ import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.QualityTier
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.canBeFavorited
+import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.data.model.client.items.qualityTier
 import io.music_assistant.client.data.model.client.presentationChapter
 import io.music_assistant.client.data.model.client.toAbsoluteSeekSeconds
@@ -111,6 +113,7 @@ fun CompactPlayerItem(
     sendSpinState: SendspinState?,
 ) {
     val currentMedia = item.player.currentMedia
+    val artworkUrl = item.nowPlayingArtworkUrl()
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
 
     Row(
@@ -142,7 +145,7 @@ fun CompactPlayerItem(
                     AsyncImage(
                         placeholder = placeholder,
                         fallback = placeholder,
-                        model = rememberArtworkRequest(currentMedia.imageUrl),
+                        model = rememberArtworkRequest(artworkUrl),
                         contentDescription = currentMedia.title,
                         contentScale = ContentScale.Crop,
                         modifier = Modifier.fillMaxSize(),
@@ -312,6 +315,7 @@ fun FullPlayerItem(
     chapterProgressEnabled: Boolean = true,
 ) {
     val currentMedia = item.player.currentMedia
+    val artworkUrl = item.nowPlayingArtworkUrl()
 
     // Folder hierarchy for the full Now Playing screen.
     //
@@ -342,18 +346,18 @@ fun FullPlayerItem(
                 .background(colors.dominant.alphaOn(currentMedia != null)),
             contentAlignment = Alignment.Center,
         ) {
-            currentMedia?.imageUrl?.let {
+            artworkUrl?.let {
                 val placeholder =
                     rememberPlaceholderPainter(
                         backgroundColor = colors.dominant,
                         iconColor = onPrimaryContainer,
-                        icon = currentMedia.defaultIcon,
+                        icon = currentMedia?.defaultIcon ?: AlbumIcon,
                     )
                 AsyncImage(
                     placeholder = placeholder,
                     fallback = placeholder,
                     model = rememberArtworkRequest(it),
-                    contentDescription = currentMedia.title,
+                    contentDescription = currentMedia?.title,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxSize(),
                 )
@@ -799,6 +803,13 @@ fun FullPlayerItem(
             }
         }
     }
+}
+
+internal fun PlayerData.nowPlayingArtworkUrl(): String? {
+    val currentTrack = queueInfo?.currentItem?.track
+    return player.currentMedia?.imageUrl
+        ?: currentTrack?.image(ImageType.THUMB)?.url
+        ?: (currentTrack as? Track)?.album?.image(ImageType.THUMB)?.url
 }
 
 private val FULL_PLAYER_HORIZONTAL_PADDING = 16.dp

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -62,6 +62,7 @@ import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.QualityTier
+import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.canBeFavorited
 import io.music_assistant.client.data.model.client.items.qualityTier
 import io.music_assistant.client.data.model.client.presentationChapter
@@ -174,7 +175,7 @@ fun CompactPlayerItem(
                         contentDescription = trackContentDescription
                     },
             ) {
-                Text(
+            Text(
                     modifier = Modifier
                         .fillMaxWidth()
                         .fadingEdges(marqueeFade)
@@ -271,6 +272,30 @@ private fun trackNameAndContentDescription(title: String?): Pair<String, String>
     return Pair(title ?: stringResource(Res.string.players_nothing), playingContentDescription)
 }
 
+internal fun Track.nowPlayingFolderHierarchy(): String? {
+    val mappings = providerMappings.orEmpty()
+    val pathCandidates =
+        mappings
+            .sortedByDescending {
+                it.providerDomain == "filesystem_local" ||
+                    it.providerInstance.startsWith("filesystem_local--")
+            }
+            .map { it.itemId } + listOfNotNull(uri)
+
+    return pathCandidates.firstNotNullOfOrNull { candidate ->
+        val hasScheme = "://" in candidate
+        val path = candidate.substringAfter("://", candidate)
+        val parentPath = path.substringBeforeLast("/", "")
+        val segments = parentPath.split("/").filter { it.isNotBlank() }.toMutableList()
+
+        if (hasScheme && segments.firstOrNull()?.lowercase() in setOf("track", "tracks")) {
+            segments.removeAt(0)
+        }
+
+        segments.joinToString(" › ").takeIf { it.isNotBlank() }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullPlayerItem(
@@ -287,6 +312,18 @@ fun FullPlayerItem(
     chapterProgressEnabled: Boolean = true,
 ) {
     val currentMedia = item.player.currentMedia
+
+    // Folder hierarchy for the full Now Playing screen.
+    //
+    // Library tracks have a normalized URI (for example library://track/13328).
+    // The original filesystem-relative path is retained in the filesystem provider
+    // mapping's itemId.
+    //
+    // Display:
+    // Hungarian › Bon Bon › Album
+    val nowPlayingFolderHierarchy =
+        (item.queueInfo?.currentItem?.track as? Track)?.nowPlayingFolderHierarchy()
+
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
     val controlTint = colors.controlTint
 
@@ -365,6 +402,32 @@ fun FullPlayerItem(
                 .clearAndSetSemantics { contentDescription = trackContentDescription },
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            if (!poweredOff) {
+                nowPlayingFolderHierarchy?.let { folderHierarchy ->
+                    Text(
+                        text = folderHierarchy,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    horizontal =
+                                        FULL_PLAYER_HORIZONTAL_PADDING,
+                                ),
+                        style =
+                            MaterialTheme.typography.bodySmall,
+                        color =
+                            MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    Spacer(
+                        modifier = Modifier.height(4.dp),
+                    )
+                }
+            }
+
             Text(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -191,9 +191,8 @@ fun PlayersPager(
             )
         }
         val playerColors = playerDataList.associateWith {
-            val media = it.player.currentMedia
             rememberAnimatedPlayerColors(
-                imageUrl = media?.imageUrl,
+                imageUrl = it.nowPlayingArtworkUrl(),
                 fallback = MaterialTheme.colorScheme.primaryContainer,
                 source = colorsSource,
                 enabled = dynamicColorsEnabled,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -308,7 +308,20 @@ fun PlayersPager(
                                 sendspinState = state.sendspinState,
                                 onSelectPlayer = onSelectPlayer,
                                 onGroupButton = onGroupButton,
-                                playerAction = playerAction1,
+                                playerAction = { playerData, action ->
+                                    if (
+                                        !homeScreenViewModel
+                                            .handleRandomPlaybackTransport(
+                                                playerData,
+                                                action,
+                                            )
+                                    ) {
+                                        playerAction1(
+                                            playerData,
+                                            action,
+                                        )
+                                    }
+                                },
                             )
                         } else {
                             ExpandedPlayerPage(
@@ -317,7 +330,20 @@ fun PlayersPager(
                                 onSelectPlayer = onSelectPlayer,
                                 onGroupButton = onGroupButton,
                                 onDspButton = onDspButton.takeIf { !player.player.isGroup },
-                                playerAction = playerAction1,
+                                playerAction = { playerData, action ->
+                                    if (
+                                        !homeScreenViewModel
+                                            .handleRandomPlaybackTransport(
+                                                playerData,
+                                                action,
+                                            )
+                                    ) {
+                                        playerAction1(
+                                            playerData,
+                                            action,
+                                        )
+                                    }
+                                },
                                 playlistActions = actionsViewModel,
                                 onFavoriteClick = {
                                     actionsViewModel.onFavoriteClick(it)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/AdaptiveMediaGrid.kt
@@ -58,6 +58,7 @@ fun AdaptiveMediaGrid(
     hasMore: Boolean = true,
     viewMode: ViewMode = ViewMode.GRID,
     onNavigateClick: (AppMediaItem) -> Unit,
+    onFolderLongClick: (RecommendationFolder) -> Unit = {},
     onPlayClick: PlayHandler<AppMediaItem>,
     onLoadMore: () -> Unit = {},
     gridState: LazyGridState = rememberLazyGridState(),
@@ -194,6 +195,7 @@ fun AdaptiveMediaGrid(
                     item = item,
                     viewMode = viewMode,
                     onNavigateClick = onNavigateClick,
+                    onLongClick = onFolderLongClick,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
@@ -1,0 +1,114 @@
+package io.music_assistant.client.ui.compose.library
+
+import co.touchlab.kermit.Logger
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.api.ServiceClient
+import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.settings.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+
+/**
+ * Extends normal Browse playback beyond the folder that supplied the tapped track.
+ *
+ * The current folder is submitted first so playback starts without waiting for a library-wide
+ * crawl. Remaining playable folders are then appended in alphabetical order. A newer Browse
+ * playback request always cancels the older append job before changing the queue.
+ */
+class BrowsePlaybackCoordinator(
+    private val apiClient: ServiceClient,
+    private val mediaItemRepository: MediaItemRepository,
+    private val settings: SettingsRepository,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var appendJob: Job? = null
+
+    suspend fun play(
+        currentPath: String?,
+        initialUris: List<String>,
+        queueOrPlayerId: String,
+        option: QueueOption,
+        radioMode: Boolean,
+        continueIntoFollowingFolders: Boolean,
+    ) {
+        appendJob?.cancelAndJoin()
+        appendJob = null
+
+        apiClient.sendRequest(
+            Request.Library.play(
+                media = initialUris,
+                queueOrPlayerId = queueOrPlayerId,
+                option = option,
+                radioMode = radioMode,
+            ),
+        )
+
+        if (!continueIntoFollowingFolders || currentPath == null) return
+
+        val followingFolders =
+            orderedBrowseContinuationFolders(
+                currentPath = currentPath,
+                folders = settings.cachedBrowseFolders.value,
+            )
+
+        if (followingFolders.isEmpty()) return
+
+        appendJob = scope.launch {
+            followingFolders.forEach { folder ->
+                val tracks =
+                    mediaItemRepository
+                        .fetchMediaItems(Request.Browse.atPath(folder.path))
+                        .getOrNull()
+                        .orEmpty()
+                        .filterIsInstance<Track>()
+                        .filterNot { track ->
+                            val name = track.displayName.trim()
+                            name.equals("(Empty)", ignoreCase = true) ||
+                                name.equals("Empty", ignoreCase = true)
+                        }
+                        .sortedBy { it.displayName.lowercase() }
+                        .mapNotNull { it.mediaUri }
+                        .distinct()
+
+                if (tracks.isEmpty()) return@forEach
+
+                apiClient.sendRequest(
+                    Request.Library.play(
+                        media = tracks,
+                        queueOrPlayerId = queueOrPlayerId,
+                        option = QueueOption.ADD,
+                        radioMode = false,
+                    ),
+                ).onFailure { error ->
+                    Logger.withTag("BrowsePlayback").e(error) {
+                        "Failed to append folder=${folder.name} path=${folder.path}"
+                    }
+                }
+
+                Logger.withTag("BrowsePlayback").i {
+                    "APPEND folder=${folder.name} tracks=${tracks.size}"
+                }
+            }
+        }
+    }
+}
+
+internal fun orderedBrowseContinuationFolders(
+    currentPath: String,
+    folders: List<SettingsRepository.CachedBrowseFolder>,
+): List<SettingsRepository.CachedBrowseFolder> {
+    val ordered =
+        folders
+            .distinctBy { it.path }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+    val currentIndex = ordered.indexOfFirst { it.path == currentPath }
+    if (currentIndex < 0 || ordered.size < 2) return emptyList()
+
+    return ordered.drop(currentIndex + 1) + ordered.take(currentIndex)
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
@@ -5,6 +5,7 @@ import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.items.browsePlaybackUri
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
 import kotlinx.coroutines.CoroutineScope
@@ -73,7 +74,7 @@ class BrowsePlaybackCoordinator(
                                 name.equals("Empty", ignoreCase = true)
                         }
                         .sortedBy { it.displayName.lowercase() }
-                        .mapNotNull { it.mediaUri }
+                        .mapNotNull { it.browsePlaybackUri }
                         .distinct()
 
                 if (tracks.isEmpty()) return@forEach

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinator.kt
@@ -4,7 +4,9 @@ import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.model.client.QueueOption
+import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
 import io.music_assistant.client.data.model.client.items.browsePlaybackUri
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.settings.SettingsRepository
@@ -34,12 +36,25 @@ class BrowsePlaybackCoordinator(
         currentPath: String?,
         initialUris: List<String>,
         queueOrPlayerId: String,
+        queueId: String?,
         option: QueueOption,
         radioMode: Boolean,
         continueIntoFollowingFolders: Boolean,
     ) {
         appendJob?.cancelAndJoin()
         appendJob = null
+
+        queueId?.let { id ->
+            apiClient.sendRequest(
+                Request.Queue.setRepeatMode(id, RepeatMode.OFF),
+            )
+            apiClient.sendRequest(
+                Request.Queue.setShuffle(id, enabled = false),
+            )
+            apiClient.sendRequest(
+                Request.Queue.setDontStopTheMusic(id, enabled = false),
+            )
+        }
 
         apiClient.sendRequest(
             Request.Library.play(
@@ -61,42 +76,67 @@ class BrowsePlaybackCoordinator(
         if (followingFolders.isEmpty()) return
 
         appendJob = scope.launch {
-            followingFolders.forEach { folder ->
-                val tracks =
-                    mediaItemRepository
-                        .fetchMediaItems(Request.Browse.atPath(folder.path))
-                        .getOrNull()
-                        .orEmpty()
-                        .filterIsInstance<Track>()
-                        .filterNot { track ->
-                            val name = track.displayName.trim()
-                            name.equals("(Empty)", ignoreCase = true) ||
-                                name.equals("Empty", ignoreCase = true)
-                        }
-                        .sortedBy { it.displayName.lowercase() }
-                        .mapNotNull { it.browsePlaybackUri }
-                        .distinct()
-
-                if (tracks.isEmpty()) return@forEach
-
-                apiClient.sendRequest(
-                    Request.Library.play(
-                        media = tracks,
-                        queueOrPlayerId = queueOrPlayerId,
-                        option = QueueOption.ADD,
-                        radioMode = false,
-                    ),
-                ).onFailure { error ->
-                    Logger.withTag("BrowsePlayback").e(error) {
-                        "Failed to append folder=${folder.name} path=${folder.path}"
-                    }
-                }
+            val continuationUris =
+                followingFolders.flatMap { folder ->
+                    val tracks = collectFolderTrackUris(folder.path)
 
                 Logger.withTag("BrowsePlayback").i {
-                    "APPEND folder=${folder.name} tracks=${tracks.size}"
+                    "COLLECT folder=${folder.name} tracks=${tracks.size}"
+                }
+
+                    tracks
+                }
+
+            if (continuationUris.isEmpty()) return@launch
+
+            apiClient.sendRequest(
+                Request.Library.play(
+                    media = continuationUris,
+                    queueOrPlayerId = queueOrPlayerId,
+                    option = QueueOption.ADD,
+                    radioMode = false,
+                ),
+            ).onFailure { error ->
+                Logger.withTag("BrowsePlayback").e(error) {
+                    "Failed to append Browse continuation"
                 }
             }
+
+            Logger.withTag("BrowsePlayback").i {
+                "APPEND continuation tracks=${continuationUris.size}"
+            }
         }
+    }
+
+    private suspend fun collectFolderTrackUris(path: String, depth: Int = 0): List<String> {
+        if (depth > 12) return emptyList()
+        val items =
+            mediaItemRepository
+                .fetchMediaItems(Request.Browse.atPath(path))
+                .getOrNull()
+                .orEmpty()
+
+        val directTracks =
+            items
+                .filterIsInstance<Track>()
+                .filterNot { track ->
+                    val name = track.displayName.trim()
+                    name.equals("(Empty)", ignoreCase = true) ||
+                        name.equals("Empty", ignoreCase = true)
+                }
+                .sortedBy { it.displayName.lowercase() }
+                .mapNotNull { it.browsePlaybackUri }
+
+        val nestedTracks =
+            items
+                .filterIsInstance<RecommendationFolder>()
+                .filterNot { it.isParentLink }
+                .mapNotNull { it.path }
+                .distinct()
+                .sortedWith(String.CASE_INSENSITIVE_ORDER)
+                .flatMap { collectFolderTrackUris(it, depth + 1) }
+
+        return (directTracks + nestedTracks).distinct()
     }
 }
 
@@ -104,12 +144,55 @@ internal fun orderedBrowseContinuationFolders(
     currentPath: String,
     folders: List<SettingsRepository.CachedBrowseFolder>,
 ): List<SettingsRepository.CachedBrowseFolder> {
-    val ordered =
+    val currentRoot = currentPath.topLevelBrowsePath() ?: return emptyList()
+    val currentProvider = currentPath.browseProviderRoot()
+    val grouped =
         folders
+            .filter { it.path.browseProviderRoot() == currentProvider }
             .distinctBy { it.path }
-            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
-    val currentIndex = ordered.indexOfFirst { it.path == currentPath }
-    if (currentIndex < 0 || ordered.size < 2) return emptyList()
+            .mapNotNull { folder -> folder.path.topLevelBrowsePath()?.let { it to folder } }
+            .groupBy({ it.first }, { it.second })
+            .toSortedMap(String.CASE_INSENSITIVE_ORDER)
+    val orderedRoots = grouped.keys.toList()
+    val currentIndex = orderedRoots.indexOf(currentRoot)
+    if (currentIndex < 0 || orderedRoots.size < 2) return emptyList()
 
-    return ordered.drop(currentIndex + 1) + ordered.take(currentIndex)
+    val followingRoots = orderedRoots.drop(currentIndex + 1) + orderedRoots.take(currentIndex)
+    return followingRoots.flatMap { root ->
+        grouped.getValue(root).sortedWith(
+            compareBy(String.CASE_INSENSITIVE_ORDER) { it.path },
+        )
+    }
+}
+
+private fun String.browseProviderRoot(): String? {
+    val schemeIndex = indexOf("://")
+    return if (schemeIndex < 0) null else take(schemeIndex + 3)
+}
+
+private fun String.topLevelBrowsePath(): String? {
+    val normalized = trimEnd('/')
+    val schemeIndex = normalized.indexOf("://")
+    if (schemeIndex < 0) return normalized.substringBefore('/').takeIf { it.isNotEmpty() }
+    val providerRoot = normalized.take(schemeIndex + 3)
+    val firstSegment = normalized.drop(schemeIndex + 3).substringBefore('/')
+    return firstSegment.takeIf { it.isNotEmpty() }?.let { providerRoot + it }
+}
+
+private fun String.parentBrowsePath(): String? {
+    val normalized = trimEnd('/')
+    val schemeIndex = normalized.indexOf("://")
+    if (schemeIndex >= 0) {
+        val providerRoot = normalized.take(schemeIndex + 3)
+        val relativePath = normalized.drop(schemeIndex + 3)
+        val lastSeparator = relativePath.lastIndexOf('/')
+        return if (lastSeparator < 0) {
+            providerRoot
+        } else {
+            providerRoot + relativePath.take(lastSeparator)
+        }
+    }
+
+    val lastSeparator = normalized.lastIndexOf('/')
+    return if (lastSeparator < 0) null else normalized.take(lastSeparator)
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseScreen.kt
@@ -1,40 +1,56 @@
 package io.music_assistant.client.ui.compose.library
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ViewList
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.music_assistant.client.data.model.client.ClickContext
+import io.music_assistant.client.data.model.client.SortField
 import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.RecommendationFolder
+import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.DataState
+import io.music_assistant.client.ui.compose.common.SortChip
 import io.music_assistant.client.ui.compose.common.ToastHost
 import io.music_assistant.client.ui.compose.common.items.ProvideClickActions
 import io.music_assistant.client.ui.compose.common.rememberToastState
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
+import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import musicassistantclient.composeapp.generated.resources.Res
+import musicassistantclient.composeapp.generated.resources.cd_toggle_view_mode
 import musicassistantclient.composeapp.generated.resources.common_back
 import musicassistantclient.composeapp.generated.resources.library_empty
 import musicassistantclient.composeapp.generated.resources.library_error
 import musicassistantclient.composeapp.generated.resources.nav_browse
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 /**
  * Folder-style browser for one level of the server's `music/browse` tree. Folders drill down
@@ -58,9 +74,19 @@ fun BrowseScreen(
 
     val dataState by browseViewModel.state.collectAsStateWithLifecycle()
 
+    val settingsRepository: SettingsRepository = koinInject()
+    val sortOption by settingsRepository.browseSortOption.collectAsStateWithLifecycle()
+    val viewMode by settingsRepository.browseViewMode.collectAsStateWithLifecycle()
+    val favoriteBrowseFolders by
+        settingsRepository.favoriteBrowseFolders.collectAsStateWithLifecycle()
+
+    var folderForFavoriteMenu by remember {
+        mutableStateOf<RecommendationFolder?>(null)
+    }
+
     TopBarLayout(
         topBar = {
-            TopAppBar(
+            TwoRowTopAppBar(
                 title = { Text(title ?: stringResource(Res.string.nav_browse)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
@@ -68,6 +94,36 @@ fun BrowseScreen(
                             Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(Res.string.common_back),
                         )
+                    }
+                },
+                secondRow = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        SortChip(
+                            currentSort = sortOption,
+                            availableFields = listOf(
+                                SortField.ORIGINAL,
+                                SortField.NAME,
+                            ),
+                            onSortChanged = settingsRepository::setBrowseSortOption,
+                        )
+
+                        IconButton(
+                            onClick = {
+                                settingsRepository.setBrowseViewMode(viewMode.toggled())
+                            },
+                        ) {
+                            Icon(
+                                imageVector = when (viewMode) {
+                                    ViewMode.LIST -> Icons.Default.GridView
+                                    ViewMode.GRID -> Icons.AutoMirrored.Filled.ViewList
+                                },
+                                contentDescription =
+                                    stringResource(Res.string.cd_toggle_view_mode),
+                            )
+                        }
                     }
                 },
             )
@@ -88,7 +144,29 @@ fun BrowseScreen(
                     is DataState.Data,
                     is DataState.Stale,
                     -> {
-                        val items = state.dataOrNull.orEmpty()
+                        val sourceItems = state.dataOrNull.orEmpty()
+
+                        val items = when (sortOption.field) {
+                            SortField.NAME -> {
+                                val sorted = sourceItems.sortedWith(
+                                    Comparator { a, b ->
+                                        a.displayName.lowercase().compareTo(
+                                            b.displayName.lowercase(),
+                                        )
+                                    },
+                                )
+                                if (sortOption.descending) sorted.reversed() else sorted
+                            }
+
+                            else -> {
+                                if (sortOption.descending) {
+                                    sourceItems.reversed()
+                                } else {
+                                    sourceItems
+                                }
+                            }
+                        }
+
                         if (items.isEmpty()) {
                             CenteredMessage(stringResource(Res.string.library_empty))
                         } else {
@@ -97,8 +175,13 @@ fun BrowseScreen(
                                 items = items,
                                 isLoadingMore = false,
                                 hasMore = false,
-                                viewMode = ViewMode.LIST,
+                                viewMode = viewMode,
                                 onNavigateClick = onNavigateClick,
+                                onFolderLongClick = { folder ->
+                                    if (!folder.isParentLink && folder.path != null) {
+                                        folderForFavoriteMenu = folder
+                                    }
+                                },
                                 onPlayClick = { item, option, radio, _ ->
                                     browseViewModel.onPlayClick(item, option, radio)
                                 },
@@ -109,6 +192,67 @@ fun BrowseScreen(
                             )
                         }
                     }
+                }
+            }
+
+            folderForFavoriteMenu?.let { folder ->
+                val path = folder.path
+
+                if (path != null) {
+                    val isFavorite =
+                        favoriteBrowseFolders.any { it.path == path }
+
+                    AlertDialog(
+                        onDismissRequest = {
+                            folderForFavoriteMenu = null
+                        },
+                        title = {
+                            Text(folder.displayName)
+                        },
+                        text = {
+                            Text(
+                                if (isFavorite) {
+                                    "Remove this folder from Favorites?"
+                                } else {
+                                    "Add this folder to Favorites?"
+                                },
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(
+                                onClick = {
+                                    settingsRepository.setBrowseFolderFavorite(
+                                        SettingsRepository.FavoriteBrowseFolder(
+                                            path = path,
+                                            itemId = folder.itemId,
+                                            provider = folder.provider,
+                                            name = folder.displayName,
+                                            uri = folder.uri,
+                                        ),
+                                        favorite = !isFavorite,
+                                    )
+                                    folderForFavoriteMenu = null
+                                },
+                            ) {
+                                Text(
+                                    if (isFavorite) {
+                                        "Unfavorite"
+                                    } else {
+                                        "Favorite"
+                                    },
+                                )
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(
+                                onClick = {
+                                    folderForFavoriteMenu = null
+                                },
+                            ) {
+                                Text("Cancel")
+                            }
+                        },
+                    )
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
-import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
+import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,9 +23,9 @@ import kotlinx.coroutines.launch
  */
 class BrowseViewModel(
     private val path: String?,
-    private val apiClient: ServiceClient,
     private val mainDataSource: MainDataSource,
     private val mediaItemRepository: MediaItemRepository,
+    private val playbackCoordinator: BrowsePlaybackCoordinator,
 ) : ViewModel() {
     private val _state = MutableStateFlow<DataState<List<AppMediaItem>>>(DataState.Loading())
     val state = _state.asStateFlow()
@@ -47,26 +47,69 @@ class BrowseViewModel(
         }
     }
 
-    // Mirrors ItemListViewModel.onPlayClick — play a browsed item on the selected player.
     fun onPlayClick(
         item: AppMediaItem,
         option: QueueOption,
         radio: Boolean,
     ) {
         viewModelScope.launch {
-            val queueId = mainDataSource.selectedPlayer?.queueOrPlayerId ?: return@launch
-            item.mediaUri?.let { mediaUri ->
-                Logger.withTag("PlayDispatch")
-                    .i { "BrowseViewModel: uri=$mediaUri option=$option radio=$radio queue=$queueId" }
-                apiClient.sendRequest(
-                    Request.Library.play(
-                        media = listOf(mediaUri),
-                        queueOrPlayerId = queueId,
-                        option = option,
-                        radioMode = radio && item !is Genre,
-                    ),
-                )
+            val queueId =
+                mainDataSource.selectedPlayer?.queueOrPlayerId
+                    ?: return@launch
+
+            val mediaUri = item.mediaUri ?: return@launch
+
+            // For a Track tapped inside Browse, play from that track
+            // through the rest of the current folder.
+            val playbackUris =
+                if (item is Track) {
+                    val folderItems =
+                        mediaItemRepository.fetchMediaItems(
+                            Request.Browse.atPath(path),
+                        ).getOrNull().orEmpty()
+
+                    val tracks =
+                        folderItems
+                            .filterIsInstance<Track>()
+                            .filterNot { track ->
+                                val name = track.displayName.trim()
+                                name.equals("(Empty)", ignoreCase = true) ||
+                                    name.equals("Empty", ignoreCase = true)
+                            }
+                            .sortedBy {
+                                it.displayName.lowercase()
+                            }
+                            .mapNotNull { it.mediaUri }
+                            .distinct()
+
+                    val tappedIndex =
+                        tracks.indexOf(mediaUri)
+
+                    if (tappedIndex >= 0) {
+                        tracks.drop(tappedIndex)
+                    } else {
+                        listOf(mediaUri)
+                    }
+                } else {
+                    listOf(mediaUri)
+                }
+
+            if (playbackUris.isEmpty()) return@launch
+
+            Logger.withTag("PlayDispatch").i {
+                "BrowseViewModel: start=$mediaUri " +
+                    "tracks=${playbackUris.size} " +
+                    "option=$option queue=$queueId"
             }
+
+            playbackCoordinator.play(
+                currentPath = path,
+                initialUris = playbackUris,
+                queueOrPlayerId = queueId,
+                option = option,
+                radioMode = radio && item !is Genre,
+                continueIntoFollowingFolders = item is Track && !radio,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/BrowseViewModel.kt
@@ -53,9 +53,8 @@ class BrowseViewModel(
         radio: Boolean,
     ) {
         viewModelScope.launch {
-            val queueId =
-                mainDataSource.selectedPlayer?.queueOrPlayerId
-                    ?: return@launch
+            val selectedPlayer = mainDataSource.selectedPlayer ?: return@launch
+            val queueOrPlayerId = selectedPlayer.queueOrPlayerId
 
             val mediaUri = item.mediaUri ?: return@launch
 
@@ -97,15 +96,16 @@ class BrowseViewModel(
             if (playbackUris.isEmpty()) return@launch
 
             Logger.withTag("PlayDispatch").i {
-                "BrowseViewModel: start=$mediaUri " +
+                    "BrowseViewModel: start=$mediaUri " +
                     "tracks=${playbackUris.size} " +
-                    "option=$option queue=$queueId"
+                    "option=$option queue=$queueOrPlayerId"
             }
 
             playbackCoordinator.play(
                 currentPath = path,
                 initialUris = playbackUris,
-                queueOrPlayerId = queueId,
+                queueOrPlayerId = queueOrPlayerId,
+                queueId = selectedPlayer.queueInfo?.id,
                 option = option,
                 radioMode = radio && item !is Genre,
                 continueIntoFollowingFolders = item is Track && !radio,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListViewModel.kt
@@ -47,6 +47,7 @@ class LibraryListViewModel(
         State(
             dataState = DataState.Loading(),
             mediaType = mediaType,
+            sortOption = settingsRepository.getLibrarySortOption(mediaType),
         ),
     )
     val state = _state.asStateFlow()
@@ -215,6 +216,7 @@ class LibraryListViewModel(
     }
 
     fun onSortChanged(sortOption: SortOption) {
+        settingsRepository.setLibrarySortOption(mediaType, sortOption)
         _state.update { it.copy(sortOption = sortOption) }
         searchTrigger.tryEmit(Unit)
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/RapidSkipTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/RapidSkipTest.kt
@@ -1,0 +1,28 @@
+package io.music_assistant.client.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RapidSkipTest {
+    @Test
+    fun `rapid next taps jump directly to final requested item`() {
+        assertEquals(
+            7,
+            rapidSkipTargetIndex(currentIndex = 3, itemCount = 12, delta = 4),
+        )
+    }
+
+    @Test
+    fun `rapid previous taps jump backwards`() {
+        assertEquals(
+            2,
+            rapidSkipTargetIndex(currentIndex = 6, itemCount = 12, delta = -4),
+        )
+    }
+
+    @Test
+    fun `rapid skip is clamped at queue boundaries`() {
+        assertEquals(9, rapidSkipTargetIndex(currentIndex = 8, itemCount = 10, delta = 5))
+        assertEquals(0, rapidSkipTargetIndex(currentIndex = 1, itemCount = 10, delta = -5))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/NowPlayingFolderHierarchyTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/NowPlayingFolderHierarchyTest.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.ui.compose.home.players
 
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.items.browsePlaybackUri
 import io.music_assistant.client.data.model.server.ProviderMapping
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,6 +21,19 @@ class NowPlayingFolderHierarchyTest {
     @Test
     fun `normalized library uri alone does not produce a hierarchy`() {
         assertNull(track(uri = "library://track/13328").nowPlayingFolderHierarchy())
+    }
+
+    @Test
+    fun `browse track without library uri uses its provider mapping`() {
+        val track = track(
+            uri = null,
+            mappingItemId = "Metallica/Album/01 Song.mp3",
+        )
+
+        assertEquals(
+            "filesystem_local--test://track/Metallica/Album/01 Song.mp3",
+            track.browsePlaybackUri,
+        )
     }
 
     private fun track(uri: String?, mappingItemId: String? = null) =

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/NowPlayingFolderHierarchyTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/NowPlayingFolderHierarchyTest.kt
@@ -1,0 +1,53 @@
+package io.music_assistant.client.ui.compose.home.players
+
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.server.ProviderMapping
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NowPlayingFolderHierarchyTest {
+    @Test
+    fun `filesystem provider mapping supplies folder hierarchy for library track`() {
+        val track = track(
+            uri = "library://track/13328",
+            mappingItemId = "Hungarian/Bon Bon/Album/01 Song.mp3",
+        )
+
+        assertEquals("Hungarian › Bon Bon › Album", track.nowPlayingFolderHierarchy())
+    }
+
+    @Test
+    fun `normalized library uri alone does not produce a hierarchy`() {
+        assertNull(track(uri = "library://track/13328").nowPlayingFolderHierarchy())
+    }
+
+    private fun track(uri: String?, mappingItemId: String? = null) =
+        Track(
+            itemId = "13328",
+            provider = "library",
+            name = "Song",
+            providerMappings =
+                mappingItemId?.let {
+                    listOf(
+                        ProviderMapping(
+                            itemId = it,
+                            providerDomain = "filesystem_local",
+                            providerInstance = "filesystem_local--test",
+                        ),
+                    )
+                },
+            metadata = null,
+            favorite = false,
+            uri = uri,
+            images = emptyMap(),
+            duration = 180.0,
+            isPlayable = true,
+            artists = emptyList(),
+            album = null,
+            discNumber = null,
+            trackNumber = null,
+            position = null,
+            version = null,
+        )
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinatorTest.kt
@@ -1,0 +1,56 @@
+package io.music_assistant.client.ui.compose.library
+
+import io.music_assistant.client.settings.SettingsRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BrowsePlaybackCoordinatorTest {
+    @Test
+    fun `continuation follows alphabetical folders and wraps once`() {
+        val folders =
+            listOf(
+                folder("c", "Charlie"),
+                folder("a", "Alpha"),
+                folder("b", "Bravo"),
+            )
+
+        assertEquals(
+            listOf("c", "a"),
+            orderedBrowseContinuationFolders("b", folders).map { it.path },
+        )
+    }
+
+    @Test
+    fun `current folder is never appended again`() {
+        val duplicateCurrent =
+            listOf(
+                folder("a", "Alpha"),
+                folder("a", "Alpha duplicate"),
+                folder("b", "Bravo"),
+            )
+
+        assertEquals(
+            listOf("b"),
+            orderedBrowseContinuationFolders("a", duplicateCurrent).map { it.path },
+        )
+    }
+
+    @Test
+    fun `unknown folder does not append an unrelated library`() {
+        assertTrue(
+            orderedBrowseContinuationFolders(
+                currentPath = "missing",
+                folders = listOf(folder("a", "Alpha"), folder("b", "Bravo")),
+            ).isEmpty(),
+        )
+    }
+
+    private fun folder(path: String, name: String) =
+        SettingsRepository.CachedBrowseFolder(
+            path = path,
+            itemId = path,
+            provider = "filesystem_local--test",
+            name = name,
+        )
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/library/BrowsePlaybackCoordinatorTest.kt
@@ -10,14 +10,20 @@ class BrowsePlaybackCoordinatorTest {
     fun `continuation follows alphabetical folders and wraps once`() {
         val folders =
             listOf(
-                folder("c", "Charlie"),
-                folder("a", "Alpha"),
-                folder("b", "Bravo"),
+                folder("filesystem_local--test://c", "Charlie"),
+                folder("filesystem_local--test://a", "Alpha"),
+                folder("filesystem_local--test://b", "Bravo"),
             )
 
         assertEquals(
-            listOf("c", "a"),
-            orderedBrowseContinuationFolders("b", folders).map { it.path },
+            listOf(
+                "filesystem_local--test://c",
+                "filesystem_local--test://a",
+            ),
+            orderedBrowseContinuationFolders(
+                "filesystem_local--test://b",
+                folders,
+            ).map { it.path },
         )
     }
 
@@ -25,14 +31,54 @@ class BrowsePlaybackCoordinatorTest {
     fun `current folder is never appended again`() {
         val duplicateCurrent =
             listOf(
-                folder("a", "Alpha"),
-                folder("a", "Alpha duplicate"),
-                folder("b", "Bravo"),
+                folder("filesystem_local--test://a", "Alpha"),
+                folder("filesystem_local--test://a", "Alpha duplicate"),
+                folder("filesystem_local--test://b", "Bravo"),
             )
 
         assertEquals(
-            listOf("b"),
-            orderedBrowseContinuationFolders("a", duplicateCurrent).map { it.path },
+            listOf("filesystem_local--test://b"),
+            orderedBrowseContinuationFolders(
+                "filesystem_local--test://a",
+                duplicateCurrent,
+            ).map { it.path },
+        )
+    }
+
+    @Test
+    fun `continuation excludes folders from other hierarchy levels`() {
+        val folders =
+            listOf(
+                folder("filesystem_local--test://anastazie", "anastazie"),
+                folder("filesystem_local--test://award wining dj", "award wining dj"),
+                folder("filesystem_local--test://abba/disc 1", "disc 1"),
+                folder("filesystem_local--other://gigi", "gigi"),
+            )
+
+        assertEquals(
+            listOf("filesystem_local--test://award wining dj", "filesystem_local--test://abba/disc 1"),
+            orderedBrowseContinuationFolders(
+                "filesystem_local--test://anastazie",
+                folders,
+            ).map { it.path },
+        )
+    }
+
+    @Test
+    fun `nested sole child continues with next album folder`() {
+        val folders =
+            listOf(
+                folder("filesystem_local--test://anastazie/misc", "Misc"),
+                folder("filesystem_local--test://award-winning-dj/cd1", "CD1"),
+                folder("filesystem_local--other://gigi", "Gigi"),
+            )
+
+        assertEquals(
+            listOf("filesystem_local--test://award-winning-dj/cd1"),
+            orderedBrowseContinuationFolders(
+                "filesystem_local--test://anastazie/misc",
+                folders,
+            ).map { it.path },
         )
     }
 
@@ -41,8 +87,26 @@ class BrowsePlaybackCoordinatorTest {
         assertTrue(
             orderedBrowseContinuationFolders(
                 currentPath = "missing",
-                folders = listOf(folder("a", "Alpha"), folder("b", "Bravo")),
+                folders =
+                    listOf(
+                        folder("filesystem_local--test://a", "Alpha"),
+                        folder("filesystem_local--test://b", "Bravo"),
+                    ),
             ).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `only non-root local filesystem folders are cacheable`() {
+        assertTrue(folder("filesystem_local--test://ABBA", "ABBA").isLocalFilesystemFolder())
+        assertTrue(!folder("filesystem_local--test://", "Filesystem").isLocalFilesystemFolder())
+        assertTrue(
+            !SettingsRepository.CachedBrowseFolder(
+                path = "tunein--test://category/solomon-islands",
+                itemId = "solomon-islands",
+                provider = "tunein--test",
+                name = "Solomon Islands",
+            ).isLocalFilesystemFolder(),
         )
     }
 


### PR DESCRIPTION
Closes #910

## Summary

- persist Browse sort and grid/list preferences
- support favoriting Browse folders and show Favorites/Random Folders rows on Home
- add continuous folder playback modes: off, random songs, and random folders
- show filesystem folder hierarchy above the title on the full Now Playing screen while leaving the mini-player unchanged
- batch rapid multi-tap Next/Previous actions so the UI does not revert to stale queue state

## Testing

- `./gradlew detektAll`
- `./gradlew :androidApp:assembleDebug`
- `./gradlew :androidApp:testDebug :composeApp:testAndroidHostTest`
- `./gradlew :androidApp:lintDebug`
- manual testing against a real Music Assistant server and Android device, including continuous folder transitions, playback modes, Now Playing hierarchy, and rapid skipping

This is intentionally submitted as one integrated change because the Home rows, Browse coordinator, playback transport handling, and Now Playing path metadata share the same cached folder model. I can split it if that would make review easier.