### PR TITLE
Add chapter next/prev button for audiobooks in CarPlay

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -209,7 +209,13 @@ class MainDataSource(
      */
     val nowPlayingTrack: StateFlow<NowPlayingTrack?> =
         localPlayerPresentation
-            .map { buildNowPlayingTrack(it.value, it.chapter) }
+            .map {
+                buildNowPlayingTrack(
+                    playerData = it.value,
+                    currentChapter = it.chapter,
+                    chapterNavigationEnabled = userPreferences.isChapterProgressEnabled,
+                )
+            }
             .distinctUntilChanged()
             .stateIn(this, SharingStarted.Eagerly, null)
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -6,10 +6,10 @@ import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.QueueTrack
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.ResolvedChapter
-import io.music_assistant.client.data.model.client.navigationChapters
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
+import io.music_assistant.client.data.model.client.navigationChapters
 import io.music_assistant.client.utils.monotonicMs
 import kotlin.math.abs
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -6,6 +6,7 @@ import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.QueueTrack
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.ResolvedChapter
+import io.music_assistant.client.data.model.client.navigationChapters
 import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
@@ -27,6 +28,8 @@ data class NowPlayingTrack(
     val artworkUrl: String?,
     val duration: Double?,
     val isLongFormContent: Boolean,
+    // Pref-gated: remote next/previous will chapter-jump for this content.
+    val hasChapterNavigation: Boolean = false,
 )
 
 /**
@@ -86,18 +89,23 @@ internal object NowPlayingChannelChangeDetection {
 }
 
 /**
- * Maps local state to metadata; [currentChapter] switches duration and album
- * to the resolved chapter presentation.
+ * [currentChapter] switches duration/album to the chapter presentation.
+ * [NowPlayingTrack.hasChapterNavigation] is only true when
+ * [chapterNavigationEnabled] (the `audiobook_chapter_progress` preference) is set.
  */
 internal fun buildNowPlayingTrack(
     playerData: PlayerData?,
     currentChapter: ResolvedChapter? = null,
+    chapterNavigationEnabled: Boolean = false,
 ): NowPlayingTrack? {
     val currentItem = playerData?.queueInfo?.currentItem ?: return null
     val base = withRadioStreamMetadata(
         base = currentItem.track.toNowPlayingTrack(),
         playerData = playerData,
         currentItem = currentItem,
+    ).copy(
+        hasChapterNavigation = chapterNavigationEnabled &&
+            currentItem.track.navigationChapters() != null,
     )
     if (currentChapter == null) return base
     return base.copy(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerControls.kt
@@ -28,6 +28,7 @@ import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.data.model.client.items.Audiobook
 import io.music_assistant.client.data.model.client.items.LongFormSeekDefaults
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
+import io.music_assistant.client.data.model.client.navigationChapters
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.ui.compose.common.icons.PauseIcon
@@ -54,6 +55,8 @@ fun PlayerControls(
     showSkip: Boolean = true,
     showSkipBack: Boolean = true,
     tint: Color = MaterialTheme.colorScheme.primary,
+    // Server audiobook_chapter_progress pref; gates chapter-based Next enablement.
+    chapterProgressEnabled: Boolean = true,
 ) {
     val player = playerData.player
     val queue = playerData.queueInfo
@@ -62,8 +65,15 @@ fun PlayerControls(
     // Audiobooks / podcast episodes swap shuffle & repeat for skip-back / skip-forward seek.
     val isLongForm = queue?.currentItem?.track.isLongFormSpokenContent
     val itemsCount = playerData.queueItems?.size ?: 0
+    // Next is a chapter jump when navigation applies (PlayerRequestFactory), so it stays
+    // enabled while a chapter starts after the (event-driven, close-enough) position.
+    val elapsedSec = queue?.elapsedTime ?: 0.0
+    val hasUpcomingChapter = chapterProgressEnabled &&
+        queue?.currentItem?.track.navigationChapters()?.any { it.start > elapsedSec } == true
     val skipForwardEnabled = when {
         queue?.currentIndex?.let { it < itemsCount - 1 } == true -> true
+        hasUpcomingChapter -> true
+        // Chapterless/last-chapter fallback: an in-progress audiobook still takes a plain next.
         (queue?.currentItem?.track as? Audiobook)?.let { it.fullyPlayed == false } == true -> true
         else -> false
     }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -108,6 +108,8 @@ fun CompactPlayerItem(
     onGroupButton: (() -> Unit)? = null,
     showAdditionalControls: Boolean = false,
     sendSpinState: SendspinState?,
+    // Server preference gate for chapter-based Next enablement.
+    chapterProgressEnabled: Boolean = true,
 ) {
     val currentMedia = item.player.currentMedia
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
@@ -239,6 +241,7 @@ fun CompactPlayerItem(
                 showSkip = true,
                 showSkipBack = onSelectPlayer != null,
                 tint = colors.controlTint,
+                chapterProgressEnabled = chapterProgressEnabled,
             )
         }
 
@@ -717,6 +720,7 @@ fun FullPlayerItem(
                 playerAction = playerAction,
                 mainButtonSize = 60.dp,
                 tint = controlTint,
+                chapterProgressEnabled = chapterProgressEnabled,
             )
             // Mirrors the heart slot: lyrics button when available, else a spacer
             // so the transport controls stay centered.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -309,6 +309,7 @@ fun PlayersPager(
                                 onSelectPlayer = onSelectPlayer,
                                 onGroupButton = onGroupButton,
                                 playerAction = playerAction1,
+                                chapterProgressEnabled = chapterProgressEnabled,
                             )
                         } else {
                             ExpandedPlayerPage(
@@ -520,6 +521,7 @@ private fun ExpandedPlayerPage(
                     onGroupButton = if (isExpandedScreen && !isQueueExpanded) onGroupButton else null,
                     showAdditionalControls = isExpandedScreen,
                     sendSpinState = sendspinState,
+                    chapterProgressEnabled = chapterProgressEnabled,
                 )
             }
         }
@@ -966,6 +968,8 @@ private fun CollapsedPlayerPage(
     onSelectPlayer: () -> Unit,
     onGroupButton: () -> Unit,
     playerAction: (PlayerData, PlayerAction) -> Unit,
+    // Server preference gate for chapter-based Next enablement.
+    chapterProgressEnabled: Boolean = true,
 ) {
     if (!isExpandedScreen) {
         Row(
@@ -990,6 +994,7 @@ private fun CollapsedPlayerPage(
         onSelectPlayer = if (isExpandedScreen) onSelectPlayer else null,
         onGroupButton = if (isExpandedScreen) onGroupButton else null,
         sendSpinState = sendspinState,
+        chapterProgressEnabled = chapterProgressEnabled,
     )
 }
 

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -35,24 +35,31 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     // per connect (see didConnect). Always set before any template is built.
     private var strings: CarPlayStrings?
 
-    // MARK: - Now Playing buttons (shuffle/repeat)
+    // MARK: - Now Playing buttons (shuffle/repeat, chapter prev/next)
     //
     // Created once per connection and NEVER rebuilt — installing fresh button
     // instances on state changes is the flicker/lock-up class this design
     // exists to avoid. State flows one way per concern:
-    //   - Track channel: profile flips (music ↔ long-form) swap which retained
-    //     instances are installed; long-form content gets no shuffle/repeat.
-    //   - Modes channel: enablement only.
+    //   - Track channel: profile flips swap which retained instances are
+    //     installed. Music gets shuffle/repeat; long-form content with
+    //     navigable chapters gets chapter prev/next (the transport row keeps
+    //     the ±N skips); other long-form content gets nothing.
+    //   - Modes channel: shuffle/repeat enablement only.
     // Selected state is never written here: CarPlay renders it from
     // MPRemoteCommandCenter's currentShuffleType/currentRepeatType, whose sole
     // writer is NowPlayingCoordinator's modes handler.
+    /// `empty` (not `none`) so the case never collides with `Optional.none`
+    /// when the stored profile below is compared or switched over.
+    private enum NowPlayingButtonProfile { case music, chapters, empty }
     private var shuffleButton: CPNowPlayingShuffleButton?
     private var repeatButton: CPNowPlayingRepeatButton?
+    private var chapterBackButton: CPNowPlayingImageButton?
+    private var chapterForwardButton: CPNowPlayingImageButton?
     private var trackSubscription: Cancellable?
     private var modesSubscription: Cancellable?
     /// nil = nothing applied yet this connection, so the first emission
     /// always installs.
-    private var nowPlayingButtonsInstalled: Bool?
+    private var nowPlayingButtonProfile: NowPlayingButtonProfile?
     /// Last enablement pushed to the buttons; nil until the first modes
     /// emission so the initial value always applies.
     private var nowPlayingButtonsEnabled: Bool?
@@ -133,7 +140,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         CPNowPlayingTemplate.shared.updateNowPlayingButtons([])
         shuffleButton = nil
         repeatButton = nil
-        nowPlayingButtonsInstalled = nil
+        chapterBackButton = nil
+        chapterForwardButton = nil
+        nowPlayingButtonProfile = nil
         nowPlayingButtonsEnabled = nil
         libraryTemplate = nil
         libraryBrowseSection = nil
@@ -219,20 +228,40 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         repeatButton = CPNowPlayingRepeatButton { _ in
             NowPlayingCoordinator.shared.dispatchCarCommand("toggle_repeat")
         }
-        // Fresh CPNowPlayingButtons default to enabled. Start disabled so the
-        // track replay can't install enabled-looking buttons for the runloop
-        // gap before the modes replay delivers the real enablement.
+        // Same next/previous command path as the lock screen; installed only
+        // while chapters apply, so always enabled — Kotlin handles the edges
+        // (previous restarts the chapter; next past the last is a plain next).
+        chapterBackButton = CPNowPlayingImageButton(
+            image: Self.chapterButtonImage(symbol: "backward.end.fill")
+        ) { _ in
+            NowPlayingCoordinator.shared.dispatchCarCommand("previous")
+        }
+        chapterForwardButton = CPNowPlayingImageButton(
+            image: Self.chapterButtonImage(symbol: "forward.end.fill")
+        ) { _ in
+            NowPlayingCoordinator.shared.dispatchCarCommand("next")
+        }
+        // Fresh CPNowPlayingButtons default to enabled; start disabled so the
+        // runloop gap before the modes replay can't show enabled-looking
+        // buttons before real enablement arrives.
         shuffleButton?.isEnabled = false
         repeatButton?.isEnabled = false
-        nowPlayingButtonsInstalled = nil
+        nowPlayingButtonProfile = nil
         nowPlayingButtonsEnabled = nil
 
         trackSubscription = KmpHelper.shared.observeNowPlayingTrack { [weak self] track in
-            // Long-form content swaps prev/next for ±N skips in the command
-            // center; its CarPlay surface likewise drops shuffle/repeat.
-            // A nil track keeps the music profile (buttons present, and the
-            // modes channel's nil disables them).
-            self?.applyNowPlayingButtons(installed: track?.isLongFormContent != true)
+            // Bottom bar shows chapter prev/next only when the long-form
+            // content has navigable chapters, otherwise nothing. A nil track
+            // keeps the music profile; the modes channel's nil disables it.
+            let profile: NowPlayingButtonProfile
+            if track?.isLongFormContent != true {
+                profile = .music
+            } else if track?.hasChapterNavigation == true {
+                profile = .chapters
+            } else {
+                profile = .empty
+            }
+            self?.applyNowPlayingButtons(profile: profile)
         }
         modesSubscription = KmpHelper.shared.observeNowPlayingModes { [weak self] modes in
             guard let self else { return }
@@ -244,36 +273,51 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
             // CarPlay snapshots button state at presentation: a property write
             // on an already-installed instance does not re-render. Re-present
             // the SAME retained instances (not new ones) to publish the change.
-            if self.nowPlayingButtonsInstalled == true {
+            if self.nowPlayingButtonProfile == .music {
                 self.presentNowPlayingButtons()
             }
         }
     }
 
-    /// Installs or removes the retained button instances, only on profile
+    /// SF-symbol template image for the chapter buttons; CarPlay applies its
+    /// own tint to template-rendered images.
+    private static func chapterButtonImage(symbol: String) -> UIImage {
+        UIImage(
+            systemName: symbol,
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 24, weight: .semibold)
+        )!
+    }
+
+    /// Installs the retained button instances for a profile, only on profile
     /// change — never rebuilding them.
-    private func applyNowPlayingButtons(installed: Bool) {
+    private func applyNowPlayingButtons(profile: NowPlayingButtonProfile) {
         dispatchPrecondition(condition: .onQueue(.main))
-        guard nowPlayingButtonsInstalled != installed else { return }
-        let hadApplied = nowPlayingButtonsInstalled != nil
-        nowPlayingButtonsInstalled = installed
-        // First emission of the long-form profile: the template is already
-        // empty (didDisconnect teardown / fresh process), so there is nothing
-        // to remove — record the state without a misleading "removed" log or
-        // a no-op empty update.
-        guard installed || hadApplied else { return }
-        os_log("CP: now-playing buttons %{public}@",
-               log: cpLog, type: .default, installed ? "installed" : "removed")
+        guard nowPlayingButtonProfile != profile else { return }
+        let hadApplied = nowPlayingButtonProfile != nil
+        nowPlayingButtonProfile = profile
+        // First emission of the empty profile: the template is already empty
+        // (didDisconnect teardown / fresh process), so there is nothing to
+        // remove — record the state without a no-op empty update.
+        guard profile != .empty || hadApplied else { return }
+        os_log("CP: now-playing buttons profile %{public}@",
+               log: cpLog, type: .default, String(describing: profile))
         presentNowPlayingButtons()
     }
 
-    /// Pushes the current retained instances (or none) to the template.
-    /// The sole `updateNowPlayingButtons` caller besides disconnect teardown.
+    /// Pushes the current profile's retained instances (or none) to the
+    /// template. The sole `updateNowPlayingButtons` caller besides disconnect
+    /// teardown.
     private func presentNowPlayingButtons() {
         dispatchPrecondition(condition: .onQueue(.main))
-        let buttons: [CPNowPlayingButton] = nowPlayingButtonsInstalled == true
-            ? [shuffleButton, repeatButton].compactMap { $0 }
-            : []
+        let buttons: [CPNowPlayingButton]
+        switch nowPlayingButtonProfile {
+        case .music:
+            buttons = [shuffleButton, repeatButton].compactMap { $0 }
+        case .chapters:
+            buttons = [chapterBackButton, chapterForwardButton].compactMap { $0 }
+        case .empty, nil:
+            buttons = []
+        }
         CPNowPlayingTemplate.shared.updateNowPlayingButtons(buttons)
     }
 


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

This keeps the 10 second back / 30 second forward buttons while adding the chapter prev/next, if the size of the UI allows.

Also fix a bug where the 'next' button was disabled if there was no other items in the queue, even if you're listening to an audiobook or podcast with chapters and weren't on the last chapter.

<img width="754" height="449" alt="Screenshot 2026-08-25 at 3 22 36 PM" src="https://github.com/user-attachments/assets/426ec139-0e5b-40bf-94d8-3d66b6cc0fc5" />

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

