### PR TITLE
fix: replace currentColor stroke in hallway icon with hex literal

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/shared-icons/README.md
+++ b/shared-icons/README.md
@@ -13,3 +13,4 @@ to Vector Assets for use with `SharedIcons`. To do the latter (as of Android Stu
 2. Choose "Local file" and then select the SVG file for the new/updated icon and create the XML
 3. Correct any problems with the generated XML so that the preview looks correct
    - Some Vector Assets end up referencing `currentColor` for the fill or stroke color. This should usually be changed to `#ffffffff`.
+   - `DrawableColorsTest` fails the build on any color value that is not a hex literal.

--- a/shared-icons/src/androidHostTest/kotlin/io/music_assistant/client/sharedicons/DrawableColorsTest.kt
+++ b/shared-icons/src/androidHostTest/kotlin/io/music_assistant/client/sharedicons/DrawableColorsTest.kt
@@ -1,0 +1,46 @@
+package io.music_assistant.client.sharedicons
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Guards the drawables against SVG-isms that survive an Android Studio "Vector Asset" import.
+ *
+ * The Compose Resources vector parser accepts only `#`-hex color literals. A leftover
+ * `currentColor` compiles and lints fine, then throws `IllegalArgumentException` the moment
+ * `painterResource` loads the drawable at runtime. This test turns that crash into a build
+ * failure. See the shared-icons README for the import procedure.
+ */
+class DrawableColorsTest {
+
+    @Test
+    fun `every drawable color is a hex literal`() {
+        val files = drawableDir().listFiles { file -> file.extension == "xml" }?.sorted().orEmpty()
+        assertTrue(files.isNotEmpty(), "No drawables found in ${drawableDir().absolutePath}")
+
+        val offenders = files.flatMap { file ->
+            COLOR_ATTRIBUTE.findAll(file.readText())
+                .map { it.groupValues[1] }
+                .filterNot { it.matches(HEX_COLOR) }
+                .map { "${file.name}: $it" }
+        }
+        assertTrue(
+            offenders.isEmpty(),
+            "Non-hex color values (Compose Resources cannot parse these):\n" +
+                offenders.joinToString("\n"),
+        )
+    }
+
+    private fun drawableDir(): File =
+        listOf(DRAWABLE_PATH, "shared-icons/$DRAWABLE_PATH")
+            .map { File(it) }
+            .firstOrNull { it.isDirectory }
+            ?: File(DRAWABLE_PATH)
+
+    private companion object {
+        const val DRAWABLE_PATH = "src/commonMain/composeResources/drawable"
+        val COLOR_ATTRIBUTE = Regex("""android:\w*Color="([^"]*)"""")
+        val HEX_COLOR = Regex("#[0-9a-fA-F]{6,8}")
+    }
+}

--- a/shared-icons/src/androidHostTest/kotlin/io/music_assistant/client/sharedicons/DrawableColorsTest.kt
+++ b/shared-icons/src/androidHostTest/kotlin/io/music_assistant/client/sharedicons/DrawableColorsTest.kt
@@ -13,9 +13,8 @@ import kotlin.test.assertTrue
  * failure. See the shared-icons README for the import procedure.
  */
 class DrawableColorsTest {
-
     @Test
-    fun `every drawable color is a hex literal`() {
+    fun everyDrawableColorIsHexLiteral() {
         val files = drawableDir().listFiles { file -> file.extension == "xml" }?.sorted().orEmpty()
         assertTrue(files.isNotEmpty(), "No drawables found in ${drawableDir().absolutePath}")
 

--- a/shared-icons/src/commonMain/composeResources/drawable/hallway.xml
+++ b/shared-icons/src/commonMain/composeResources/drawable/hallway.xml
@@ -22,7 +22,7 @@
       android:strokeLineJoin="round"
       android:strokeWidth="2"
       android:fillColor="#00000000"
-      android:strokeColor="currentColor"
+      android:strokeColor="#ffffffff"
       android:strokeLineCap="round"/>
   <path
       android:pathData="M14,12h0.01"


### PR DESCRIPTION
Fixes crash from non-existing icon color.