### PR TITLE
Improve how iOS handles audio interruptions

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerController.kt
@@ -29,6 +29,7 @@ import io.music_assistant.client.settings.SettingsRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import io.music_assistant.client.utils.SessionState
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -140,6 +141,8 @@ class LocalPlayerController(
 
     private data class QueuedEntry(val action: PlayerAction, val request: Request)
 
+    private val deferredPausedSeek = atomic<DeferredPausedSeek?>(null)
+
     init {
         // Reset clock sync on foreground unless playback held CPU awake through
         // the background — otherwise doze-paused CLOCK_MONOTONIC strands the offset.
@@ -167,6 +170,39 @@ class LocalPlayerController(
      */
     fun handleLocalCommand(data: PlayerData, action: PlayerAction) {
         val resolved = playerRequestFactory.resolve(data, action)
+        val commandReady = apiClient.isReadyForCommands.value
+
+        if (resolved is PlayerAction.SeekTo && !data.player.isPlaying) {
+            deferPausedSeek(data, resolved)
+            return
+        }
+        if (!shouldSendLocalActionImmediately(resolved, data.player.isPlaying, commandReady)) {
+            log.w { "Ignoring live seek while command transport is unavailable" }
+            return
+        }
+        if (resolved is PlayerAction.SeekTo) {
+            deferredPausedSeek.value = null
+        } else {
+            invalidateDeferredPausedSeekUnless(data.queueInfo)
+        }
+
+        val resumesPausedPlayback = resolved == PlayerAction.Play ||
+            (resolved == PlayerAction.TogglePlayPause && !data.player.isPlaying)
+        val deferredSeek = deferredPausedSeek.value?.takeIf { it.matches(data) }
+        if (resumesPausedPlayback && deferredSeek != null) {
+            if (deferredSeek.consuming) return
+            if (!commandReady || _sendspinState.value == null) {
+                log.i { "Deferring play until the selected paused position can be sent safely" }
+                if (_sendspinState.value == null && settings.sendspinEnabled.value) launch { start() }
+                return
+            }
+            val consumed = consumeDeferredPausedSeek(data) ?: return
+            applyOptimisticUpdate(data, resolved)
+            applyOptimisticUpdate(data, PlayerAction.SeekTo(consumed.position))
+            launch { sendDeferredSeekAsPlay(data, consumed) }
+            return
+        }
+
         applyOptimisticUpdate(data, resolved)
         launch {
             val request = playerRequestFactory.buildRequest(data, resolved) ?: return@launch
@@ -206,6 +242,67 @@ class LocalPlayerController(
     private fun cancelPendingPlayTimeout() {
         pendingPlayTimeoutJob?.cancel()
         pendingPlayTimeoutJob = null
+    }
+
+    private fun deferPausedSeek(data: PlayerData, action: PlayerAction.SeekTo) {
+        val queueInfo = data.queueInfo ?: return
+        val currentItem = queueInfo.currentItem ?: return
+        deferredPausedSeek.value = DeferredPausedSeek(queueInfo.id, currentItem.id, action.position)
+        updateOptimisticQueueInfo { it.copy(elapsedTime = action.position.toDouble()) }
+        positionTracker.setPausedPosition(
+            queueId = queueInfo.id,
+            elapsedSec = action.position.toDouble(),
+            durationSec = currentItem.track.duration,
+            speed = queueInfo.playbackSpeed,
+        )
+    }
+
+    private fun consumeDeferredPausedSeek(data: PlayerData): DeferredPausedSeek? {
+        while (true) {
+            val pending = deferredPausedSeek.value ?: return null
+            if (!pending.matches(data)) {
+                if (deferredPausedSeek.compareAndSet(pending, null)) return null
+                continue
+            }
+            if (pending.consuming) return null
+            val consuming = pending.copy(consuming = true)
+            if (deferredPausedSeek.compareAndSet(pending, consuming)) return consuming
+        }
+    }
+
+    private fun invalidateDeferredPausedSeekUnless(queueInfo: QueueInfo?) {
+        val pending = deferredPausedSeek.value ?: return
+        if (pending.queueId != queueInfo?.id || pending.queueItemId != queueInfo.currentItem?.id) {
+            deferredPausedSeek.compareAndSet(pending, null)
+        }
+    }
+
+    private suspend fun sendDeferredSeekAsPlay(data: PlayerData, consumed: DeferredPausedSeek) {
+        val request = playerRequestFactory.buildRequest(
+            data,
+            PlayerAction.SeekTo(consumed.position),
+        ) ?: run {
+            deferredPausedSeek.compareAndSet(consumed, consumed.copy(consuming = false))
+            return
+        }
+        if (apiClient.sendRequest(request).isSuccess) {
+            deferredPausedSeek.compareAndSet(consumed, null)
+            return
+        }
+
+        // The command was never accepted: retain the user's media-scoped target for a retry,
+        // and roll the local sink/UI back to paused rather than pretending playback started.
+        if (consumed.matches(localPlayerData.value ?: data) &&
+            deferredPausedSeek.compareAndSet(consumed, consumed.copy(consuming = false))
+        ) {
+            cancelPendingPlayTimeout()
+            mediaPlayerController.pauseSink()
+            _localPlayerData.update { current -> current?.copy(pendingPlay = false) }
+            positionTracker.setPausedPosition(
+                queueId = consumed.queueId,
+                elapsedSec = consumed.position.toDouble(),
+            )
+        }
     }
 
     private fun applyOptimisticUpdate(data: PlayerData, action: PlayerAction) {
@@ -290,6 +387,7 @@ class LocalPlayerController(
             PlayerAction.Next,
             PlayerAction.Previous,
             -> {
+                deferredPausedSeek.value = null
                 // Queue events for the next track can arrive before its audio; keep the
                 // boundary frozen until Sendspin confirms the new stream.
                 data.queueInfo?.id?.let { queueId ->
@@ -314,10 +412,12 @@ class LocalPlayerController(
         // The Result.isFailure fallback closes the TOCTOU window where the state
         // flips between the check and the send.
         if (!apiClient.isReadyForCommands.value) {
-            enqueue(action, request)
+            if (shouldQueueLocalAction(action)) enqueue(action, request)
             return
         }
-        if (apiClient.sendRequest(request).isFailure) enqueue(action, request)
+        if (apiClient.sendRequest(request).isFailure && shouldQueueLocalAction(action)) {
+            enqueue(action, request)
+        }
     }
 
     fun drainCommandQueue() {
@@ -337,7 +437,10 @@ class LocalPlayerController(
     // --- Server event reconciliation ---
 
     fun onServerPlayerUpdate(player: Player) {
-        if (player.isPlaying) cancelPendingPlayTimeout()
+        if (player.isPlaying) {
+            cancelPendingPlayTimeout()
+            deferredPausedSeek.value = null
+        }
         _localPlayerData.update { current ->
             if (current == null) {
                 if (!settings.sendspinEnabled.value) return@update null
@@ -366,6 +469,7 @@ class LocalPlayerController(
     }
 
     fun onServerQueueUpdate(queueInfo: QueueInfo) {
+        invalidateDeferredPausedSeekUnless(queueInfo)
         // Staleness gating happens upstream in [MainDataSource.gateOrSkip]
         // before we're called, so this just absorbs the admitted event.
         _localPlayerData.update { current ->
@@ -382,6 +486,7 @@ class LocalPlayerController(
     }
 
     fun onQueueItemsLoaded(queueInfo: QueueInfo, items: List<QueueTrack>) {
+        invalidateDeferredPausedSeekUnless(queueInfo)
         _localPlayerData.update { current ->
             current?.let {
                 // Preserve the authoritative `info` (shuffle/repeat/elapsed are
@@ -745,6 +850,7 @@ class LocalPlayerController(
      *  preserves both so [drainCommandQueue] can replay a queued resume once the
      *  transport returns. */
     fun clearState() {
+        deferredPausedSeek.value = null
         _localPlayerData.update { null }
         launch { commandQueueMutex.withLock { commandQueue.clear() } }
     }
@@ -835,9 +941,7 @@ class LocalPlayerController(
                 }
 
                 is PlayerAction.SeekTo -> {
-                    Logger.e("SeekTo: ${action.position}")
-                    commandQueue.removeAll { it.action is PlayerAction.SeekTo }
-                    commandQueue.add(entry)
+                    log.w { "Dropping seek instead of replaying it after reconnect" }
                 }
 
                 else -> commandQueue.add(entry)
@@ -878,6 +982,27 @@ class LocalPlayerController(
  * from [queueInfo], defaulting to off when no queue exists. Returns null for
  * unrecognized commands and malformed seek payloads.
  */
+internal data class DeferredPausedSeek(
+    val queueId: String,
+    val queueItemId: String,
+    val position: Long,
+    val consuming: Boolean = false,
+) {
+    fun matches(data: PlayerData): Boolean {
+        val queueInfo = data.queueInfo ?: return false
+        return queueId == queueInfo.id && queueItemId == queueInfo.currentItem?.id
+    }
+}
+
+internal fun shouldSendLocalActionImmediately(
+    action: PlayerAction,
+    isPlaying: Boolean,
+    commandReady: Boolean,
+): Boolean = action !is PlayerAction.SeekTo || (isPlaying && commandReady)
+
+/** Absolute seek starts a paused MA queue, so stale seek intent must never survive offline. */
+internal fun shouldQueueLocalAction(action: PlayerAction): Boolean = action !is PlayerAction.SeekTo
+
 internal fun remoteCommandToPlayerAction(command: String, queueInfo: QueueInfo?): PlayerAction? = when {
     command == "play" -> PlayerAction.Play
     command == "pause" -> PlayerAction.Pause

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/PlayerPositionTracker.kt
@@ -42,7 +42,7 @@ class PlayerPositionTracker {
          * interpolated delta to match, or the slider drifts then snaps each anchor.
          */
         val speed: Double = 1.0,
-        /** Hold the optimistic position until Sendspin confirms audio is flowing. */
+        /** Hold local user intent against stale server echoes until it is consumed/confirmed. */
         val freezeReason: FreezeReason? = null,
     ) {
         /** Position right now: anchor + speed-scaled wall-time since anchor (capped at duration). */
@@ -57,7 +57,7 @@ class PlayerPositionTracker {
      * Optimistic anchors wait for [confirmPlaying], not server queue echoes: MA can
      * report the seek target or next-track position before Sendspin has audio.
      */
-    enum class FreezeReason { SEEK, TRACK_CHANGE }
+    enum class FreezeReason { PAUSED_SEEK, SEEK, TRACK_CHANGE }
 
     private val anchors = MutableStateFlow<Map<String, Anchor>>(emptyMap())
 
@@ -105,6 +105,28 @@ class PlayerPositionTracker {
                     elapsedSec = current.effectiveNow(),
                     wallMs = currentTimeMillis(),
                     isPlaying = isPlaying,
+                )
+            )
+        }
+    }
+
+    /** Sets a paused position without implying a server seek; Play later promotes it to a seek. */
+    fun setPausedPosition(
+        queueId: String,
+        elapsedSec: Double,
+        durationSec: Double? = null,
+        speed: Double? = null,
+    ) {
+        anchors.update { existing ->
+            val current = existing[queueId]
+            existing + (
+                queueId to Anchor(
+                    elapsedSec = elapsedSec,
+                    wallMs = currentTimeMillis(),
+                    isPlaying = false,
+                    durationSec = durationSec ?: current?.durationSec,
+                    speed = speed ?: current?.speed ?: 1.0,
+                    freezeReason = FreezeReason.PAUSED_SEEK,
                 )
             )
         }
@@ -173,7 +195,7 @@ class PlayerPositionTracker {
     /** O(1) read of latest interpolated position. */
     fun effectiveSec(queueId: String): Double? = anchors.value[queueId]?.effectiveNow()
 
-    /** True while an optimistic seek or track-change is waiting for confirmation. */
+    /** True while paused seek intent or an optimistic playback handoff is protected. */
     fun isFrozenUntilConfirmed(queueId: String): Boolean =
         anchors.value[queueId]?.freezeReason != null
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/connection/SendspinWsHandler.kt
@@ -118,8 +118,6 @@ class SendspinWsHandler(
     private fun startListening(wsSession: DefaultClientWebSocketSession, listenerEpoch: Int) {
         listenerJob?.cancel()
         listenerJob = launch {
-            var reconnecting = false
-            var disconnectEmitted = false
             try {
                 for (frame in wsSession.incoming) {
                     when (frame) {
@@ -137,12 +135,6 @@ class SendspinWsHandler(
 
                         is Frame.Close -> {
                             logger.i { "WebSocket closed: ${frame.readReason()}" }
-                            // The incoming loop also ends after a Close frame;
-                            // emit the epoch's Disconnected exactly once.
-                            if (!disconnectEmitted) {
-                                disconnectEmitted = true
-                                handleDisconnection(listenerEpoch)
-                            }
                         }
 
                         is Frame.Ping, is Frame.Pong -> {
@@ -155,21 +147,22 @@ class SendspinWsHandler(
             } catch (e: Exception) {
                 if (explicitDisconnect) {
                     logger.i { "Explicit disconnect, not reconnecting" }
-                    if (!disconnectEmitted) {
-                        disconnectEmitted = true
-                        handleDisconnection(listenerEpoch)
-                    }
-                    return@launch
+                } else {
+                    logger.e(e) { "WS error - will auto-reconnect" }
                 }
-
-                // Network error - auto-reconnect!
-                logger.e(e) { "WS error - will auto-reconnect" }
-                reconnecting = true
-                emitEvent(InboundTransportEvent.Reconnecting(listenerEpoch, 0))
-                attemptReconnect(listenerEpoch)
             } finally {
-                if (!explicitDisconnect && !reconnecting && !disconnectEmitted) {
-                    handleDisconnection(listenerEpoch)
+                if (
+                    shouldReconnectAfterListenerExit(
+                        explicitDisconnect = explicitDisconnect,
+                        listenerIsCurrent = listenerEpoch == epoch,
+                    )
+                ) {
+                    // Close frames, exceptions, and a normally exhausted incoming channel all
+                    // converge here so exactly one reconnect loop can be launched per listener.
+                    // A listener cancelled after its replacement advanced the epoch is stale.
+                    logger.w { "WebSocket listener ended unexpectedly — reconnecting" }
+                    emitEvent(InboundTransportEvent.Reconnecting(listenerEpoch, 0))
+                    attemptReconnect(listenerEpoch)
                 }
             }
         }
@@ -218,12 +211,6 @@ class SendspinWsHandler(
         session = null
 
         emitEvent(InboundTransportEvent.Disconnected(epoch))
-    }
-
-    private fun handleDisconnection(listenerEpoch: Int) {
-        logger.i { "WebSocket disconnected" }
-        session = null
-        emitEvent(InboundTransportEvent.Disconnected(listenerEpoch))
     }
 
     private fun attemptReconnect(previousEpoch: Int) {
@@ -278,3 +265,8 @@ class SendspinWsHandler(
         client.close()
     }
 }
+
+internal fun shouldReconnectAfterListenerExit(
+    explicitDisconnect: Boolean,
+    listenerIsCurrent: Boolean,
+): Boolean = !explicitDisconnect && listenerIsCurrent

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/PlayerPositionTrackerTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/PlayerPositionTrackerTest.kt
@@ -6,6 +6,23 @@ import kotlin.test.assertTrue
 
 class PlayerPositionTrackerTest {
     @Test
+    fun pausedPositionRemainsFixedAndRejectsStaleServerEchoes() {
+        val tracker = PlayerPositionTracker()
+        val queueId = "queue"
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 25.0, isPlaying = false)
+        tracker.setPausedPosition(queueId = queueId, elapsedSec = 90.0)
+
+        assertEquals(90.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+
+        tracker.setAnchor(queueId = queueId, elapsedSec = 25.5, isPlaying = false)
+
+        assertEquals(90.0, tracker.effectiveSec(queueId))
+        assertTrue(tracker.isFrozenUntilConfirmed(queueId))
+    }
+
+    @Test
     fun optimisticSeekIgnoresStaleServerAnchorFarFromSeekTarget() {
         val tracker = PlayerPositionTracker()
         val queueId = "queue"

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/RemoteCommandMappingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/RemoteCommandMappingTest.kt
@@ -1,11 +1,17 @@
 package io.music_assistant.client.data
 
+import io.music_assistant.client.data.model.client.AppMediaItemFixtures.track
+import io.music_assistant.client.data.model.client.PlayerDataFixtures
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueue
 import io.music_assistant.client.data.model.client.QueueInfo
+import io.music_assistant.client.data.model.client.QueueTrack
 import io.music_assistant.client.data.model.client.RepeatMode
 import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Pins the remote-command-string contract shared by the lock screen, Control
@@ -77,6 +83,57 @@ class RemoteCommandMappingTest {
         assertEquals(PlayerAction.SeekBy(30), remoteCommandToPlayerAction("seek_by:30", null))
         assertNull(remoteCommandToPlayerAction("seek:not-a-number", null))
         assertNull(remoteCommandToPlayerAction("seek_by:not-a-number", null))
+    }
+
+    @Test
+    fun seekIsSentImmediatelyOnlyDuringActiveOnlinePlayback() {
+        val seek = PlayerAction.SeekTo(42)
+
+        assertTrue(shouldSendLocalActionImmediately(seek, isPlaying = true, commandReady = true))
+        assertFalse(shouldSendLocalActionImmediately(seek, isPlaying = false, commandReady = true))
+        assertFalse(shouldSendLocalActionImmediately(seek, isPlaying = true, commandReady = false))
+        assertFalse(shouldSendLocalActionImmediately(seek, isPlaying = false, commandReady = false))
+    }
+
+    @Test
+    fun deferredPausedSeekIsScopedToItsExactQueueItem() {
+        val first = QueueTrack(
+            id = "item-1",
+            track = track(),
+            isPlayable = true,
+            format = null,
+            dsp = null,
+            provider = null,
+        )
+        val second = first.copy(id = "item-2")
+        val firstData = PlayerDataFixtures.playerData(listOf(first).toQueue())
+        val firstQueue = (firstData.queue as io.music_assistant.client.ui.compose.common.DataState.Data).data
+        val sameQueueOtherItem = firstData.copy(
+            queue = io.music_assistant.client.ui.compose.common.DataState.Data(
+                firstQueue.copy(info = firstQueue.info.copy(currentItem = second)),
+            ),
+        )
+        val pending = DeferredPausedSeek(firstData.queueInfo!!.id, first.id, position = 42)
+
+        assertTrue(pending.matches(firstData))
+        assertFalse(pending.matches(sameQueueOtherItem))
+    }
+
+    @Test
+    fun absoluteSeekIsNeverPreservedForReplay() {
+        assertFalse(shouldQueueLocalAction(PlayerAction.SeekTo(42)))
+        assertTrue(shouldQueueLocalAction(PlayerAction.Play))
+    }
+
+    @Test
+    fun nonSeekActionsKeepTheirExistingOfflineDispatchBehavior() {
+        assertTrue(
+            shouldSendLocalActionImmediately(
+                PlayerAction.Play,
+                isPlaying = false,
+                commandReady = false,
+            ),
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
@@ -1,5 +1,6 @@
 package io.music_assistant.client.player.sendspin.transport
 
+import io.music_assistant.client.player.sendspin.connection.shouldReconnectAfterListenerExit
 import io.music_assistant.client.webrtc.DataChannelInbound
 import io.music_assistant.client.webrtc.DataChannelReceiveSource
 import io.music_assistant.client.webrtc.DataChannelState
@@ -14,7 +15,9 @@ import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 /**
  * The channel-closed signal must be produced by the same coroutine that pumps
@@ -28,6 +31,28 @@ class WebRTCTransportCloseOrderingTest {
 
         override suspend fun receive(): DataChannelInbound =
             script.receiveCatching().getOrNull() ?: throw CancellationException("source closed")
+    }
+
+    @Test
+    fun onlyUnexpectedExitFromTheCurrentListenerReconnects() {
+        assertTrue(
+            shouldReconnectAfterListenerExit(
+                explicitDisconnect = false,
+                listenerIsCurrent = true,
+            ),
+        )
+        assertFalse(
+            shouldReconnectAfterListenerExit(
+                explicitDisconnect = true,
+                listenerIsCurrent = true,
+            ),
+        )
+        assertFalse(
+            shouldReconnectAfterListenerExit(
+                explicitDisconnect = false,
+                listenerIsCurrent = false,
+            ),
+        )
     }
 
     @Test

--- a/iosApp/AudioQueueLifecycle.swift
+++ b/iosApp/AudioQueueLifecycle.swift
@@ -1,0 +1,121 @@
+import Foundation
+import AudioToolbox
+
+/// Serializes AudioQueue ownership across the audio consumer, interruption
+/// callbacks, and remote commands. Queue construction runs outside the lock;
+/// a generation token prevents stale publication after pause or stop.
+final class AudioQueueLifecycle {
+    struct StartToken: Equatable {
+        fileprivate let generation: UInt64
+    }
+
+    private let lock = NSLock()
+    private var generation: UInt64 = 0
+    private var shouldPlay = true
+    private var streamStarted = false
+    private var queue: AudioQueueRef?
+    private var playing = false
+
+    var isRenderingAudio: Bool {
+        lock.withLock { streamStarted || playing }
+    }
+
+    func prepareToPlay() {
+        lock.withLock {
+            generation &+= 1
+            shouldPlay = true
+            streamStarted = false
+        }
+    }
+
+    func resume(start: (AudioQueueRef) -> Bool) {
+        lock.withLock {
+            shouldPlay = true
+            if let queue {
+                streamStarted = true
+                playing = start(queue)
+            } else {
+                generation &+= 1
+                streamStarted = false
+                playing = false
+            }
+        }
+    }
+
+    func beginStartIfNeeded() -> StartToken? {
+        lock.withLock {
+            guard shouldPlay, !streamStarted else { return nil }
+            streamStarted = true
+            return StartToken(generation: generation)
+        }
+    }
+
+    func acceptsAudio() -> Bool {
+        lock.withLock { shouldPlay }
+    }
+
+    var hasStartedStream: Bool {
+        lock.withLock { streamStarted }
+    }
+
+    var isPlaying: Bool {
+        lock.withLock { playing }
+    }
+
+    func cancelStart(_ token: StartToken) {
+        lock.withLock {
+            guard generation == token.generation, queue == nil else { return }
+            streamStarted = false
+            playing = false
+        }
+    }
+
+    /// Publishes and starts `newQueue` only if `token` remains current.
+    /// `start` runs under the lock to prevent concurrent disposal; failure
+    /// clears the reservation so the next packet can retry.
+    func installIfCurrent(
+        _ newQueue: AudioQueueRef,
+        token: StartToken,
+        start: (AudioQueueRef) -> Bool
+    ) -> Bool {
+        lock.withLock {
+            guard shouldPlay, streamStarted, generation == token.generation else { return false }
+            guard start(newQueue) else {
+                streamStarted = false
+                playing = false
+                return false
+            }
+            queue = newQueue
+            playing = true
+            return true
+        }
+    }
+
+    func withQueue(_ body: (AudioQueueRef) -> Void) {
+        lock.withLock {
+            guard let queue else { return }
+            body(queue)
+        }
+    }
+
+    /// Detaches under the lock but disposes afterward, avoiding lock inversion
+    /// with an AudioQueue callback being drained by synchronous disposal.
+    func detachQueue(allowFutureStart: Bool) -> AudioQueueRef? {
+        lock.withLock {
+            generation &+= 1
+            shouldPlay = allowFutureStart
+            streamStarted = false
+            playing = false
+            defer { queue = nil }
+            return queue
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -8,7 +8,7 @@ import ComposeApp
 class NativeAudioController: NSObject, PlatformAudioPlayer {
 
     // MARK: - AudioQueue
-    private var audioQueue: AudioQueueRef?
+    private let queueLifecycle = AudioQueueLifecycle()
     private var audioFormat: AudioStreamBasicDescription = AudioStreamBasicDescription()
 
     // MARK: - Audio Buffer
@@ -31,14 +31,8 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     private var codecHeader: Data?
 
     // MARK: - State
-    private var isPlaying = false
     /// True while local playback owns or is claiming the shared audio session.
-    var isRenderingAudio: Bool { streamStarted || isPlaying }
-    private var streamStarted = false
-    // Play-intent gate (mirrors Android's shouldPlayAudio). While false — paused or
-    // interrupted — incoming audio is dropped instead of (re)starting the queue, so
-    // a packet still in the consumer pipeline can't undo an optimistic pause.
-    private var shouldPlay = true
+    var isRenderingAudio: Bool { queueLifecycle.isRenderingAudio }
     // True only while we hold a server pause issued in response to an audio-session
     // interruption (phone call, Siri). On .ended we auto-resume the server only if
     // this is set — so we never spontaneously start playback that the user didn't
@@ -88,7 +82,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             // resumes from the same position afterwards instead of skipping ahead while
             // the call held the audio session.
             logInfo("Audio session interrupted")
-            if isPlaying {
+            if queueLifecycle.isPlaying {
                 pausedByInterruption = true
                 logInfo("Pausing server playback due to interruption")
                 remoteCommandHandler?.onCommand(command: "pause", source: "interruption")
@@ -135,12 +129,10 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     /// (AirPods already send their own `pause` remote command on removal; the
     /// `streamStarted` guard makes this a no-op once that has shut the gate.)
     private func handleOldDeviceUnavailable(previousRoute: AVAudioSessionRouteDescription?) {
-        guard streamStarted else { return }
+        guard queueLifecycle.hasStartedStream else { return }
         let prev = previousRoute?.outputs.first?.portType.rawValue ?? "unknown"
         logInfo("\(prev) disappeared — pausing playback")
-        shouldPlay = false
-        streamStarted = false
-        stopAudioQueue()
+        stopAudioQueue(allowFutureStart: false)
         bufferLock.lock()
         pcmBuffer.removeAll()
         bufferLock.unlock()
@@ -157,8 +149,6 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         self.currentSampleRate = sampleRate
         self.currentChannels = channels
         self.currentBitDepth = bitDepth
-        self.streamStarted = false
-        self.shouldPlay = true
 
         // Decode codec header if present
         if let headerBase64 = codecHeader, let headerData = Data(base64Encoded: headerBase64) {
@@ -168,8 +158,9 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             self.codecHeader = nil
         }
 
-        // Stop any existing playback
-        stopAudioQueue()
+        // Keep late packets gated until the new decoder configuration is ready.
+        stopAudioQueue(allowFutureStart: false)
+        queueLifecycle.prepareToPlay()
 
         // Clear buffers
         bufferLock.lock()
@@ -218,14 +209,14 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         // Suspended (paused / interrupted): drop in-flight audio rather than
         // restart the queue, so a packet still in the consumer pipeline can't
         // undo the pause before the server stops streaming.
-        guard shouldPlay else { return }
+        guard queueLifecycle.acceptsAudio() else { return }
 
-        // Start audio queue on first data
-        if !streamStarted {
-            streamStarted = true
+        // Start audio queue on first data. The token is invalidated by any
+        // concurrent pause/stop while queue construction is in progress.
+        if let startToken = queueLifecycle.beginStartIfNeeded() {
             logDebug("First data received (\(swiftData.count) bytes)")
             NowPlayingCoordinator.shared.activatePlayback()
-            startAudioQueue()
+            startAudioQueue(token: startToken)
         }
 
         decoderLock.lock()
@@ -248,9 +239,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
     func stopRawPcmStream() {
         logInfo("Stopping stream")
-        shouldPlay = false
-        streamStarted = false
-        stopAudioQueue()
+        stopAudioQueue(allowFutureStart: false)
 
         bufferLock.lock()
         pcmBuffer.removeAll()
@@ -263,21 +252,16 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     /// resume then rebuilds clean on the next packet, like a cold start.
     func pauseSink() {
         logInfo("pauseSink")
-        shouldPlay = false
-        streamStarted = false
-        tearDownQueue()
+        tearDownQueue(allowFutureStart: false)
     }
 
     /// Reactivating the session reclaims audio from another app that grabbed it.
-    /// `shouldPlay = true` re-opens the write gate; the queue rebuilds on the next
-    /// audio packet, or is started here if one still exists (gapless restart).
+    /// Re-open the write gate; the queue rebuilds on the next audio packet.
     func resumeSink() {
         logInfo("resumeSink")
-        shouldPlay = true
         NowPlayingCoordinator.shared.activatePlayback()
-        isPlaying = true
-        if let queue = audioQueue {
-            AudioQueueStart(queue, nil)
+        queueLifecycle.resume { queue in
+            AudioQueueStart(queue, nil) == noErr
         }
     }
 
@@ -289,20 +273,22 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     }
 
     func setVolume(volume: Int32) {
-        guard let queue = audioQueue else { return }
         let floatVolume = Float(volume) / 100.0
-        AudioQueueSetParameter(queue, kAudioQueueParam_Volume, floatVolume)
+        queueLifecycle.withQueue { queue in
+            AudioQueueSetParameter(queue, kAudioQueueParam_Volume, floatVolume)
+        }
     }
 
     func setMuted(muted: Bool) {
-        guard let queue = audioQueue else { return }
-        AudioQueueSetParameter(queue, kAudioQueueParam_Volume, muted ? 0.0 : 1.0)
+        queueLifecycle.withQueue { queue in
+            AudioQueueSetParameter(queue, kAudioQueueParam_Volume, muted ? 0.0 : 1.0)
+        }
     }
 
     func dispose() {
         // The Now Playing surface is cleared by the track channel going null
         // (pipeline teardown removes the current item); no direct clear here.
-        stopAudioQueue()
+        stopAudioQueue(allowFutureStart: false)
         decoderLock.lock()
         decoder = nil
         decoderLock.unlock()
@@ -310,7 +296,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
     // MARK: - AudioQueue Management
 
-    private func startAudioQueue() {
+    private func startAudioQueue(token: AudioQueueLifecycle.StartToken) {
         // Configure audio format (always output PCM)
         audioFormat.mSampleRate = Float64(currentSampleRate)
         audioFormat.mFormatID = kAudioFormatLinearPCM
@@ -350,13 +336,13 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         )
 
         guard status == noErr, let queue = queue else {
+            queueLifecycle.cancelStart(token)
             logError("Failed to create AudioQueue: \(status)")
             return
         }
 
-        audioQueue = queue
-
-        // Allocate and prime buffers
+        // Allocate and prime buffers before publishing the handle. A concurrent
+        // pause may invalidate `token` while this work is in progress.
         for _ in 0..<kNumberOfBuffers {
             var buffer: AudioQueueBufferRef?
             let allocStatus = AudioQueueAllocateBuffer(queue, kBufferSize, &buffer)
@@ -366,32 +352,38 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             }
         }
 
-        // Start playback
-        let startStatus = AudioQueueStart(queue, nil)
-        if startStatus == noErr {
-            isPlaying = true
-            logInfo("AudioQueue started")
-        } else {
-            logError("Failed to start AudioQueue: \(startStatus)")
+        var startStatus: OSStatus = noErr
+        let installed = queueLifecycle.installIfCurrent(queue, token: token) { queue in
+            startStatus = AudioQueueStart(queue, nil)
+            return startStatus == noErr
         }
+        guard installed else {
+            // A pause/stop won while this queue was being constructed, or start
+            // failed. It was never published, so this thread owns disposal.
+            AudioQueueDispose(queue, true)
+            if startStatus != noErr {
+                logError("Failed to start AudioQueue: \(startStatus)")
+            } else {
+                logInfo("Discarded AudioQueue created during concurrent teardown")
+            }
+            return
+        }
+        logInfo("AudioQueue started")
     }
 
-    private func stopAudioQueue() {
-        tearDownQueue()
+    private func stopAudioQueue(allowFutureStart: Bool = true) {
+        tearDownQueue(allowFutureStart: allowFutureStart)
         pausedByInterruption = false // Stream stopped — no auto-resume on .ended.
     }
 
     /// `AudioQueueStop(_, true)` discards enqueued hardware buffers, so a rebuilt
     /// queue never replays stale audio. Leaves `pausedByInterruption` untouched —
     /// a pause issued during `.began` must still auto-resume on `.ended`.
-    private func tearDownQueue() {
-        guard let queue = audioQueue else { return }
+    private func tearDownQueue(allowFutureStart: Bool) {
+        guard let queue = queueLifecycle.detachQueue(allowFutureStart: allowFutureStart) else { return }
 
         AudioQueueStop(queue, true)
         AudioQueueDispose(queue, true)
-
-        audioQueue = nil
-        isPlaying = false
         logInfo("AudioQueue stopped")
     }
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		06FCDF5F9AC6BE4A12AA70C9 /* NowPlayingInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */; };
+		AQL000012F30000000000001 /* AudioQueueLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AQL000032F30000000000003 /* AudioQueueLifecycle.swift */; };
+		AQL000022F30000000000002 /* AudioQueueLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AQL000032F30000000000003 /* AudioQueueLifecycle.swift */; };
 		0B4C257E50350DDBF95D87D5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA991F8C8A0917FDD5510709 /* Foundation.framework */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */; };
@@ -49,6 +51,7 @@
 		C8FCC1982F17E001005E8312 /* AudioDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDecoders.swift; sourceTree = "<group>"; };
 		C8SI00022F1B000000000001 /* SiriIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriIntentHandler.swift; sourceTree = "<group>"; };
 		E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoStore.swift; sourceTree = "<group>"; };
+		AQL000032F30000000000003 /* AudioQueueLifecycle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioQueueLifecycle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				C8FCC1912F17C6A9005E8312 /* NowPlayingCoordinator.swift */,
+				AQL000032F30000000000003 /* AudioQueueLifecycle.swift */,
 				C8FCC1962F17E001005E8312 /* NativeAudioController.swift */,
 				C8OA00012F1B000000000001 /* OAuthWebSession.swift */,
 				C8FCC1982F17E001005E8312 /* AudioDecoders.swift */,
@@ -295,6 +299,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */,
+				AQL000022F30000000000002 /* AudioQueueLifecycle.swift in Sources */,
 				6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -306,6 +311,7 @@
 				2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				C8FCC1922F17C6A9005E8312 /* NowPlayingCoordinator.swift in Sources */,
+				AQL000012F30000000000001 /* AudioQueueLifecycle.swift in Sources */,
 				C8FCC1952F17E001005E8312 /* NativeAudioController.swift in Sources */,
 				C8OA00022F1B000000000002 /* OAuthWebSession.swift in Sources */,
 				C8FCC1972F17E001005E8312 /* AudioDecoders.swift in Sources */,

--- a/iosApp/iosAppTests/NowPlayingInfoStoreTests.swift
+++ b/iosApp/iosAppTests/NowPlayingInfoStoreTests.swift
@@ -1,5 +1,62 @@
 import XCTest
 import MediaPlayer
+import AudioToolbox
+
+final class AudioQueueLifecycleTests: XCTestCase {
+
+    /// Simulates the Siri interruption race: pause invalidates the generation
+    /// while queue creation is in flight, so the stale queue must never be
+    /// installed or started.
+    func testPauseInvalidatesQueueBeingCreated() throws {
+        let lifecycle = AudioQueueLifecycle()
+        let token = try XCTUnwrap(lifecycle.beginStartIfNeeded())
+        let fakeQueue = try XCTUnwrap(AudioQueueRef(bitPattern: 1))
+
+        XCTAssertNil(lifecycle.detachQueue(allowFutureStart: false))
+
+        var startCalled = false
+        let installed = lifecycle.installIfCurrent(fakeQueue, token: token) { _ in
+            startCalled = true
+            return true
+        }
+
+        XCTAssertFalse(installed)
+        XCTAssertFalse(startCalled)
+        XCTAssertFalse(lifecycle.isRenderingAudio)
+        XCTAssertFalse(lifecycle.acceptsAudio())
+    }
+
+    func testPreparationKeepsLatePacketsGatedUntilReady() throws {
+        let lifecycle = AudioQueueLifecycle()
+
+        XCTAssertNil(lifecycle.detachQueue(allowFutureStart: false))
+        XCTAssertNil(lifecycle.beginStartIfNeeded())
+
+        lifecycle.prepareToPlay()
+        XCTAssertNotNil(lifecycle.beginStartIfNeeded())
+    }
+
+    func testFailedStartCanBeRetriedByNextPacket() throws {
+        let lifecycle = AudioQueueLifecycle()
+        let firstToken = try XCTUnwrap(lifecycle.beginStartIfNeeded())
+        let fakeQueue = try XCTUnwrap(AudioQueueRef(bitPattern: 1))
+
+        XCTAssertFalse(lifecycle.installIfCurrent(fakeQueue, token: firstToken) { _ in false })
+        XCTAssertNotNil(lifecycle.beginStartIfNeeded())
+        XCTAssertFalse(lifecycle.isPlaying)
+    }
+
+    func testCurrentQueueIsInstalledAndDetachedExactlyOnce() throws {
+        let lifecycle = AudioQueueLifecycle()
+        let token = try XCTUnwrap(lifecycle.beginStartIfNeeded())
+        let fakeQueue = try XCTUnwrap(AudioQueueRef(bitPattern: 1))
+
+        XCTAssertTrue(lifecycle.installIfCurrent(fakeQueue, token: token) { _ in true })
+        XCTAssertTrue(lifecycle.isPlaying)
+        XCTAssertEqual(lifecycle.detachQueue(allowFutureStart: false), fakeQueue)
+        XCTAssertNil(lifecycle.detachQueue(allowFutureStart: false))
+    }
+}
 
 /// Exercises `NowPlayingInfoStore` with an injected clock, flush scheduler, and dict
 /// sink so coalescing and anchor projection are fully deterministic.


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Guard queue ownership across PCM writes, interruptions, and remote commands. Reject stale queue starts after teardown and add deterministic lifecycle tests.

## Are there any additional changes not related to the issue above?

Got a couple of reports of crashes involving CarPlay. No logs, so I'm flying a little blind, but doing a review of the existing code showed a pretty plausible path for crashes while being interrupted by Siri. This simplifies what we had by removing some booleans that could get out of sync and guards against read/write races.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

