### PR TITLE
Prevent WebRTC sends from crashing during close

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/SendspinClient.kt
@@ -23,7 +23,6 @@ import io.music_assistant.client.player.sendspin.session.SendspinProtocolSession
 import io.music_assistant.client.player.sendspin.session.SessionEvent
 import io.music_assistant.client.player.sendspin.session.SessionOutcome
 import io.music_assistant.client.player.sendspin.transport.SendspinTransport
-import io.music_assistant.client.player.sendspin.transport.WebRTCDataChannelTransport
 import io.music_assistant.client.player.sendspin.transport.WebSocketSendspinTransport
 import io.music_assistant.client.utils.myJson
 import kotlinx.coroutines.CancellationException
@@ -153,7 +152,7 @@ class SendspinClient(
             currentVolume = mediaPlayerController.getCurrentSystemVolume()
             logger.i { "Initializing with system volume: $currentVolume%" }
 
-            terminalTransport = sendspinTransport is WebRTCDataChannelTransport
+            terminalTransport = sendspinTransport.isSingleUse
             val protocolSession = createSession(sendspinTransport)
             session = protocolSession
 
@@ -368,8 +367,12 @@ class SendspinClient(
 
             SessionEvent.Disconnected -> {
                 val current = _state.value
-                if (current !is SendspinState.Reconnecting) {
-                    _state.update { SendspinState.Idle }
+                when {
+                    // A single-use transport never opens a second epoch, so a
+                    // disconnect IS exhaustion — Idle would strand the player with
+                    // nobody to renegotiate the channel.
+                    terminalTransport -> enterChannelExhausted()
+                    current !is SendspinState.Reconnecting -> _state.update { SendspinState.Idle }
                 }
             }
 
@@ -379,17 +382,8 @@ class SendspinClient(
 
             is SessionEvent.Failed -> {
                 if (terminalTransport) {
-                    // Surface as exhaustion so the controller negotiates a fresh channel.
                     logger.w(event.cause) { "Session failed on terminal transport — channel exhausted" }
-                    stateReporter?.stop()
-                    _state.update {
-                        SendspinState.Error(
-                            SendspinError.Permanent(
-                                cause = WebRTCSendspinChannelExhausted(),
-                                userAction = "Reconnecting remote channel",
-                            ),
-                        )
-                    }
+                    enterChannelExhausted()
                 } else if (event.permanent) {
                     // Keep the pipeline draining its buffer; a quick reconnect resumes into it.
                     stateReporter?.stop()
@@ -412,6 +406,22 @@ class SendspinClient(
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * The single-use transport is spent: surface it as a permanent error so
+     * [io.music_assistant.client.data.LocalPlayerController] negotiates a fresh channel.
+     */
+    private fun enterChannelExhausted() {
+        stateReporter?.stop()
+        _state.update {
+            SendspinState.Error(
+                SendspinError.Permanent(
+                    cause = WebRTCSendspinChannelExhausted(),
+                    userAction = "Reconnecting remote channel",
+                ),
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/StateReporter.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/StateReporter.kt
@@ -80,10 +80,20 @@ class StateReporter(
     /**
      * Send immediate state report to server (event-driven).
      * Used for volume/mute changes or initial sync.
+     *
+     * Best-effort, like the periodic path above: a report racing a transport that is
+     * going down must not escape into the caller's collector, which typically runs in
+     * a supervised scope with no exception handler.
      */
     suspend fun reportNow(state: PlayerStateValue) {
         logger.d { "Reporting state: state=$state" }
-        messageDispatcher.sendState(PlayerStateObject(state = state))
+        try {
+            messageDispatcher.sendState(PlayerStateObject(state = state))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.w { "Dropped state report ($state): ${e.message}" }
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/SendspinTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/SendspinTransport.kt
@@ -57,6 +57,13 @@ interface SendspinTransport {
     /** The single ordered inbound event stream. */
     val events: Flow<InboundTransportEvent>
 
+    /**
+     * True when this transport opens exactly one epoch: any [InboundTransportEvent.Disconnected]
+     * is terminal and recovery needs a fresh transport instance. False when the transport
+     * reconnects itself and a disconnect may be followed by another `Connected`.
+     */
+    val isSingleUse: Boolean
+
     suspend fun connect()
 
     suspend fun sendText(message: String)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
@@ -69,9 +69,25 @@ class WebRTCDataChannelTransport(
                     eventsChannel.send(event)
                 }
             } finally {
-                // Single producer: the closed signal follows every buffered frame
-                // instead of racing past them on a separate coroutine.
-                eventsChannel.trySend(InboundTransportEvent.Disconnected(EPOCH))
+                // A normal transport disconnect leaves the wrapper open because the channel is
+                // owned by WebRTCConnectionManager. A channel that is already closing/closed is
+                // terminal for this single-use Sendspin transport and needs a fresh negotiation.
+                val state = dataChannelWrapper.state.value
+                if (state == DataChannelState.Open) {
+                    // Single producer: the closed signal follows every buffered frame instead of
+                    // racing past them on a separate coroutine.
+                    eventsChannel.trySend(InboundTransportEvent.Disconnected(EPOCH))
+                } else {
+                    eventsChannel.trySend(
+                        InboundTransportEvent.Error(
+                            epoch = EPOCH,
+                            cause = IllegalStateException(
+                                "WebRTC Sendspin data channel closed (state: $state)",
+                            ),
+                            permanent = true,
+                        ),
+                    )
+                }
             }
         }
     }
@@ -81,8 +97,10 @@ class WebRTCDataChannelTransport(
         if (currentState != DataChannelState.Open) {
             // Closing can race with state reporting and queued protocol sends. The wrapper is
             // best-effort after close, so dropping this frame avoids turning normal teardown
-            // into an uncaught coroutine exception.
+            // into an uncaught coroutine exception. Disconnect the transport as well so the
+            // protocol session observes the dead channel promptly.
             logger.w { "Dropping text send while channel is not open (state: $currentState)" }
+            disconnect()
             return
         }
 
@@ -94,8 +112,10 @@ class WebRTCDataChannelTransport(
         if (currentState != DataChannelState.Open) {
             // Closing can race with state reporting and queued protocol sends. The wrapper is
             // best-effort after close, so dropping this frame avoids turning normal teardown
-            // into an uncaught coroutine exception.
+            // into an uncaught coroutine exception. Disconnect the transport as well so the
+            // protocol session observes the dead channel promptly.
             logger.w { "Dropping binary send while channel is not open (state: $currentState)" }
+            disconnect()
             return
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
@@ -29,6 +29,8 @@ class WebRTCDataChannelTransport(
     private val eventsChannel = Channel<InboundTransportEvent>(Channel.UNLIMITED)
     override val events: Flow<InboundTransportEvent> = eventsChannel.receiveAsFlow()
 
+    override val isSingleUse: Boolean = true
+
     private var pumping = false
 
     init {
@@ -69,25 +71,11 @@ class WebRTCDataChannelTransport(
                     eventsChannel.send(event)
                 }
             } finally {
-                // A normal transport disconnect leaves the wrapper open because the channel is
-                // owned by WebRTCConnectionManager. A channel that is already closing/closed is
-                // terminal for this single-use Sendspin transport and needs a fresh negotiation.
-                val state = dataChannelWrapper.state.value
-                if (state == DataChannelState.Open) {
-                    // Single producer: the closed signal follows every buffered frame instead of
-                    // racing past them on a separate coroutine.
-                    eventsChannel.trySend(InboundTransportEvent.Disconnected(EPOCH))
-                } else {
-                    eventsChannel.trySend(
-                        InboundTransportEvent.Error(
-                            epoch = EPOCH,
-                            cause = IllegalStateException(
-                                "WebRTC Sendspin data channel closed (state: $state)",
-                            ),
-                            permanent = true,
-                        ),
-                    )
-                }
+                // Single producer: the closed signal follows every buffered frame
+                // instead of racing past them on a separate coroutine. Whether that
+                // disconnect is terminal is [isSingleUse], not a state peek here —
+                // the wrapper's Closed state is published after the inbound feed ends.
+                eventsChannel.trySend(InboundTransportEvent.Disconnected(EPOCH))
             }
         }
     }
@@ -95,13 +83,8 @@ class WebRTCDataChannelTransport(
     override suspend fun sendText(message: String) {
         val currentState = dataChannelWrapper.state.value
         if (currentState != DataChannelState.Open) {
-            // Closing can race with state reporting and queued protocol sends. The wrapper is
-            // best-effort after close, so dropping this frame avoids turning normal teardown
-            // into an uncaught coroutine exception. Disconnect the transport as well so the
-            // protocol session observes the dead channel promptly.
-            logger.w { "Dropping text send while channel is not open (state: $currentState)" }
-            disconnect()
-            return
+            logger.w { "Attempted to send text while channel not open (state: $currentState)" }
+            error("Channel not open (state: $currentState)")
         }
 
         dataChannelWrapper.send(message)
@@ -110,13 +93,8 @@ class WebRTCDataChannelTransport(
     override suspend fun sendBinary(data: ByteArray) {
         val currentState = dataChannelWrapper.state.value
         if (currentState != DataChannelState.Open) {
-            // Closing can race with state reporting and queued protocol sends. The wrapper is
-            // best-effort after close, so dropping this frame avoids turning normal teardown
-            // into an uncaught coroutine exception. Disconnect the transport as well so the
-            // protocol session observes the dead channel promptly.
-            logger.w { "Dropping binary send while channel is not open (state: $currentState)" }
-            disconnect()
-            return
+            logger.w { "Attempted to send binary while channel not open (state: $currentState)" }
+            error("Channel not open (state: $currentState)")
         }
 
         dataChannelWrapper.sendBinary(data)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCDataChannelTransport.kt
@@ -79,8 +79,11 @@ class WebRTCDataChannelTransport(
     override suspend fun sendText(message: String) {
         val currentState = dataChannelWrapper.state.value
         if (currentState != DataChannelState.Open) {
-            logger.w { "Attempted to send text while channel not open (state: $currentState)" }
-            error("Channel not open (state: $currentState)")
+            // Closing can race with state reporting and queued protocol sends. The wrapper is
+            // best-effort after close, so dropping this frame avoids turning normal teardown
+            // into an uncaught coroutine exception.
+            logger.w { "Dropping text send while channel is not open (state: $currentState)" }
+            return
         }
 
         dataChannelWrapper.send(message)
@@ -89,8 +92,11 @@ class WebRTCDataChannelTransport(
     override suspend fun sendBinary(data: ByteArray) {
         val currentState = dataChannelWrapper.state.value
         if (currentState != DataChannelState.Open) {
-            logger.w { "Attempted to send binary while channel not open (state: $currentState)" }
-            error("Channel not open (state: $currentState)")
+            // Closing can race with state reporting and queued protocol sends. The wrapper is
+            // best-effort after close, so dropping this frame avoids turning normal teardown
+            // into an uncaught coroutine exception.
+            logger.w { "Dropping binary send while channel is not open (state: $currentState)" }
+            return
         }
 
         dataChannelWrapper.sendBinary(data)

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebSocketSendspinTransport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/player/sendspin/transport/WebSocketSendspinTransport.kt
@@ -19,6 +19,8 @@ class WebSocketSendspinTransport(
     override val events: Flow<InboundTransportEvent>
         get() = sendspinWsHandler.events
 
+    override val isSingleUse: Boolean = false
+
     override suspend fun connect() {
         sendspinWsHandler.connect()
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/StateReporterTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/StateReporterTest.kt
@@ -1,0 +1,33 @@
+package io.music_assistant.client.player.sendspin
+
+import io.music_assistant.client.player.sendspin.model.PlayerStateValue
+import io.music_assistant.client.player.sendspin.protocol.MessageDispatcher
+import io.music_assistant.client.player.sendspin.session.SendspinOutboundSender
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+/**
+ * A state report races a transport that is going down all the time: the channel
+ * closes between the state change and the send. Its callers in [SendspinClient]
+ * are flow collectors in a supervised scope with no exception handler, so an
+ * escaping throw reaches the platform's default handler and kills the app.
+ * Reporting is best-effort — a dropped report is corrected by the next one.
+ */
+class StateReporterTest {
+    private object DeadSender : SendspinOutboundSender {
+        override suspend fun sendJson(json: String): Unit = error("Channel not open (state: Closed)")
+    }
+
+    @Test
+    fun reportNowSwallowsASendFailureOnADeadTransport() = runTest {
+        val dispatcher = MessageDispatcher(emptyFlow(), DeadSender, ClockSynchronizer())
+        val reporter = StateReporter(dispatcher) { SendspinState.Idle }
+
+        // Must not throw.
+        reporter.reportNow(PlayerStateValue.SYNCHRONIZED)
+
+        reporter.close()
+        dispatcher.stop()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/session/FakeSendspinTransport.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/session/FakeSendspinTransport.kt
@@ -16,6 +16,8 @@ class FakeSendspinTransport : SendspinTransport {
     private val eventsChannel = Channel<InboundTransportEvent>(Channel.UNLIMITED)
     override val events: Flow<InboundTransportEvent> = eventsChannel.receiveAsFlow()
 
+    override var isSingleUse: Boolean = false
+
     val textOut = Channel<String>(Channel.UNLIMITED)
     val binaryOut = Channel<ByteArray>(Channel.UNLIMITED)
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -31,8 +32,13 @@ class WebRTCTransportCloseOrderingTest {
             script.receiveCatching().getOrNull() ?: throw CancellationException("source closed")
     }
 
+    /**
+     * Both transports report a send on a dead connection the same way: they throw.
+     * A silent drop would be worse than a throw on the encrypted protocol, where the
+     * Noise nonce is already spent on the frame before the transport ever sees it.
+     */
     @Test
-    fun sendingAfterTheDataChannelClosesDoesNotThrowAndReportsTerminalFailure() = runTest {
+    fun sendingAfterTheDataChannelClosesThrows() = runTest {
         withContext(Dispatchers.Default) {
             val source = ScriptedReceiveSource()
             val wrapper = DataChannelWrapper(
@@ -46,22 +52,12 @@ class WebRTCTransportCloseOrderingTest {
             val events = transport.events.produceIn(this)
             transport.connect()
             assertIs<InboundTransportEvent.Connected>(withTimeout(5_000) { events.receive() })
-            source.script.trySend(DataChannelInbound.Text("pump-ready"))
-            assertEquals(
-                "pump-ready",
-                assertIs<InboundTransportEvent.Text>(withTimeout(5_000) { events.receive() }).text,
-            )
 
             wrapper.close()
-            val result = runCatching {
-                transport.sendBinary(byteArrayOf(4, 1, 2, 3))
-                transport.sendText("after-close")
-            }
 
-            assertTrue(result.isSuccess)
-            val failure = assertIs<InboundTransportEvent.Error>(withTimeout(5_000) { events.receive() })
-            assertTrue(failure.permanent)
-            assertTrue(failure.cause.message.orEmpty().contains("closed"))
+            assertFailsWith<IllegalStateException> { transport.sendText("after-close") }
+            assertFailsWith<IllegalStateException> { transport.sendBinary(byteArrayOf(4, 1, 2, 3)) }
+            assertTrue(transport.isSingleUse)
             events.cancel()
             transport.close()
         }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
@@ -32,23 +32,37 @@ class WebRTCTransportCloseOrderingTest {
     }
 
     @Test
-    fun sendingAfterTheDataChannelClosesDoesNotThrow() = runTest {
+    fun sendingAfterTheDataChannelClosesDoesNotThrowAndReportsTerminalFailure() = runTest {
         withContext(Dispatchers.Default) {
             val source = ScriptedReceiveSource()
             val wrapper = DataChannelWrapper(
                 dataChannel = null,
                 connectionEvents = null,
                 receiveSource = source,
-                initialState = DataChannelState.Closed,
+                initialState = DataChannelState.Open,
                 label = "sendspin",
             )
             val transport = WebRTCDataChannelTransport(wrapper)
+            val events = transport.events.produceIn(this)
+            transport.connect()
+            assertIs<InboundTransportEvent.Connected>(withTimeout(5_000) { events.receive() })
+            source.script.trySend(DataChannelInbound.Text("pump-ready"))
+            assertEquals(
+                "pump-ready",
+                assertIs<InboundTransportEvent.Text>(withTimeout(5_000) { events.receive() }).text,
+            )
 
+            wrapper.close()
             val result = runCatching {
                 transport.sendBinary(byteArrayOf(4, 1, 2, 3))
+                transport.sendText("after-close")
             }
 
             assertTrue(result.isSuccess)
+            val failure = assertIs<InboundTransportEvent.Error>(withTimeout(5_000) { events.receive() })
+            assertTrue(failure.permanent)
+            assertTrue(failure.cause.message.orEmpty().contains("closed"))
+            events.cancel()
             transport.close()
         }
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/player/sendspin/transport/WebRTCTransportCloseOrderingTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 /**
  * The channel-closed signal must be produced by the same coroutine that pumps
@@ -28,6 +29,28 @@ class WebRTCTransportCloseOrderingTest {
 
         override suspend fun receive(): DataChannelInbound =
             script.receiveCatching().getOrNull() ?: throw CancellationException("source closed")
+    }
+
+    @Test
+    fun sendingAfterTheDataChannelClosesDoesNotThrow() = runTest {
+        withContext(Dispatchers.Default) {
+            val source = ScriptedReceiveSource()
+            val wrapper = DataChannelWrapper(
+                dataChannel = null,
+                connectionEvents = null,
+                receiveSource = source,
+                initialState = DataChannelState.Closed,
+                label = "sendspin",
+            )
+            val transport = WebRTCDataChannelTransport(wrapper)
+
+            val result = runCatching {
+                transport.sendBinary(byteArrayOf(4, 1, 2, 3))
+            }
+
+            assertTrue(result.isSuccess)
+            transport.close()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Finally got the crash logs to download from the OHF org and immdiately spotted these from field crash reports.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

