### PR TITLE
Don't apply sort setting to playlist or album tracks

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -9,6 +9,7 @@ import io.music_assistant.client.data.MainDataSource
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.SortConfig
+import io.music_assistant.client.data.model.client.SortField
 import io.music_assistant.client.data.model.client.SortOption
 import io.music_assistant.client.data.model.client.SubItemContext
 import io.music_assistant.client.data.model.client.clientSorted
@@ -426,14 +427,11 @@ class ItemDetailsViewModel(
                     ?: emptyList()
 
                 rawPlayableItems = tracks
-                val sort = _state.value.playableItemsSortOption ?: SortConfig.defaultFor(
-                    SubItemContext.ALBUM_TRACKS,
-                )
                 _state.update {
                     it.copy(
                         playableItemsState = DataState.Data(
                             tracks.clientSorted(
-                                sort,
+                                SortOption(SortField.ORIGINAL),
                                 SubItemContext.ALBUM_TRACKS,
                             ),
                         ),
@@ -462,14 +460,11 @@ class ItemDetailsViewModel(
                     ?: emptyList()
 
                 rawPlayableItems = tracks
-                val sort = _state.value.playableItemsSortOption ?: SortConfig.defaultFor(
-                    SubItemContext.PLAYLIST_ITEMS,
-                )
                 _state.update {
                     it.copy(
                         playableItemsState = DataState.Data(
                             tracks.clientSorted(
-                                sort,
+                                SortOption(SortField.ORIGINAL),
                                 SubItemContext.PLAYLIST_ITEMS,
                             ),
                         ),


### PR DESCRIPTION
Fixes issues discussed on Discord.

## Is there anything about the code changes here that should be highlighted?

This just hardcodes the `ORIGINAL` sort order for now until we get better sort support from the MA server. I think I probably could have just removed `clientSorted` in these cases, but I wasn't confident that the server always returns in track order (even though it appears to from testing).

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

