### PR TITLE
Follow-up on dialog tear-down fix

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Lyrics.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/Lyrics.kt
@@ -1,5 +1,8 @@
 package io.music_assistant.client.data.model.client
 
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.utils.LrcParser
+
 /**
  * Lyrics for a track, as returned by the server's `metadata/get_track_lyrics`.
  *
@@ -14,3 +17,22 @@ sealed interface Lyrics {
 
 /** A single timestamped LRC line. [timeMs] is the offset from track start. */
 data class LrcLine(val timeMs: Long, val text: String)
+
+/**
+ * The lyrics a track carries, or null when it has none.
+ *
+ * [Lyrics.Synced] wins over the plain text when the LRC payload parses to at least one line.
+ */
+val Track.lyrics: Lyrics?
+    get() = metadata?.let { metadata ->
+        val plain = metadata.lyrics
+        val lrc = metadata.lrcLyrics
+        when {
+            !lrc.isNullOrBlank() -> LrcParser.parse(lrc).takeIf { it.isNotEmpty() }
+                ?.let { Lyrics.Synced(it) }
+                ?: Lyrics.Plain(lrc)
+
+            !plain.isNullOrBlank() -> Lyrics.Plain(plain)
+            else -> null
+        }
+    }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerData.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/PlayerData.kt
@@ -71,3 +71,5 @@ data class PlayerData(
         val isGroup: Boolean,
     )
 }
+
+fun List<PlayerData>.byId(id: String): PlayerData? = firstOrNull { it.playerId == id }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/CollapsibleQueue.kt
@@ -70,9 +70,7 @@ import io.music_assistant.client.ui.compose.common.NoOverscroll
 import io.music_assistant.client.ui.compose.common.action.QueueAction
 import io.music_assistant.client.ui.compose.common.icons.PlayIcon
 import io.music_assistant.client.ui.compose.common.icons.TrackIcon
-import io.music_assistant.client.ui.compose.common.items.AddToPlaylistDialog
 import io.music_assistant.client.ui.compose.common.items.DISABLED_ITEM_ALPHA
-import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.localizedSubtitle
 import io.music_assistant.client.ui.compose.common.painters.rememberPlaceholderPainter
 import io.music_assistant.client.ui.contentColorByLuminance
@@ -110,7 +108,7 @@ fun CollapsibleQueue(
     tint: Color,
     isCurrentPage: Boolean = true,
     contentPadding: PaddingValues,
-    playlistActions: PlaylistActions? = null,
+    onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
     onChapterClick: (Chapter) -> Unit = {},
     livePositionFlow: Flow<Double>? = null,
 ) {
@@ -172,7 +170,7 @@ fun CollapsibleQueue(
                 isCurrentPage = isCurrentPage,
                 contentPadding = contentPadding,
                 queueAction = queueAction,
-                playlistActions = playlistActions,
+                onAddToPlaylist = onAddToPlaylist,
                 onChapterClick = onChapterClick,
                 livePositionFlow = livePositionFlow,
             )
@@ -190,7 +188,7 @@ fun Queue(
     isCurrentPage: Boolean,
     contentPadding: PaddingValues,
     queueAction: (QueueAction) -> Unit,
-    playlistActions: PlaylistActions? = null,
+    onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
     onChapterClick: (Chapter) -> Unit = {},
     livePositionFlow: Flow<Double>? = null,
 ) {
@@ -269,7 +267,6 @@ fun Queue(
                     var dragStartIndex by remember { mutableStateOf<Int?>(null) }
                     var dragEndIndex by remember { mutableStateOf<Int?>(null) }
                     var menuItemId by remember { mutableStateOf<String?>(null) }
-                    var addToPlaylistTrack by remember { mutableStateOf<Track?>(null) }
                     val listState = rememberLazyListState()
 
                     // Flattened rows: real queue items, plus chapter rows under the
@@ -531,7 +528,7 @@ fun Queue(
                                         onDismissRequest = { menuItemId = null },
                                     ) {
                                         val track = item.track as? Track
-                                        if (track != null && playlistActions != null) {
+                                        if (track != null && onAddToPlaylist != null) {
                                             DropdownMenuItem(
                                                 text = {
                                                     Text(stringResource(Res.string.action_add_to_playlist))
@@ -543,7 +540,7 @@ fun Queue(
                                                     )
                                                 },
                                                 onClick = {
-                                                    addToPlaylistTrack = track
+                                                    onAddToPlaylist(track)
                                                     menuItemId = null
                                                 },
                                             )
@@ -569,16 +566,6 @@ fun Queue(
                                     }
                                 }
                             }
-                        }
-                    }
-
-                    addToPlaylistTrack?.let { track ->
-                        if (playlistActions != null) {
-                            AddToPlaylistDialog(
-                                item = track,
-                                playlistActions = playlistActions,
-                                onDismiss = { addToPlaylistTrack = null },
-                            )
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogHost.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogHost.kt
@@ -1,0 +1,121 @@
+package io.music_assistant.client.ui.compose.home.players
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.byId
+import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.lyrics
+import io.music_assistant.client.ui.compose.common.action.PlayerAction
+import io.music_assistant.client.ui.compose.common.items.AddToPlaylistDialog
+import io.music_assistant.client.ui.compose.common.items.PlaylistActions
+import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
+
+/**
+ * Renders the one open player dialog, outside the pager.
+ *
+ * Every dialog on the players screen lives here so that removing or reordering a pager page
+ * can never tear down an open dialog. The host resolves [request] against the newest
+ * [players] on each composition: when the player or the track the request names is gone, it
+ * clears the request instead of leaving a stale id behind that a returning player would
+ * revive.
+ *
+ * [homeScreenViewModel] is passed whole rather than as one callback per action: this is a
+ * feature composable for a single screen, and the narrow form needs eleven parameters.
+ */
+@Composable
+fun PlayerDialogHost(
+    request: PlayerDialogRequest?,
+    players: List<PlayerData>,
+    homeScreenViewModel: HomeScreenViewModel,
+    dspSettingsViewModel: DspSettingsViewModel,
+    playlistActions: PlaylistActions?,
+    canLeaveGroup: Boolean,
+    onMoveToPlayer: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    request ?: return
+    val player = players.byId(request.playerId)?.takeIf { request.hasAnchor(it) }
+        ?: return DismissEffect(request, onDismiss)
+
+    when (request) {
+        is PlayerDialogRequest.Select -> SelectPlayerDialog(
+            selectedPlayer = player,
+            players = players,
+            onDismissRequest = onDismiss,
+            onMoveToPlayer = onMoveToPlayer,
+            onReorder = { homeScreenViewModel.onPlayersSortChanged(it) },
+        )
+
+        is PlayerDialogRequest.Group -> GroupSettingsDialog(
+            player = player,
+            onDismissRequest = onDismiss,
+            groupAction = { playerId, action ->
+                homeScreenViewModel.playerAction(playerId, action)
+            },
+            localPlayerId = homeScreenViewModel.localPlayerId,
+            onAdjustPlaybackDelay = { homeScreenViewModel.adjustSendspinStaticDelayMs(it) },
+            canLeaveGroup = canLeaveGroup,
+        )
+
+        is PlayerDialogRequest.Dsp -> DspSettingsDialog(
+            playerId = request.playerId,
+            dspSettingsViewModel = dspSettingsViewModel,
+            onDismissRequest = onDismiss,
+        )
+
+        is PlayerDialogRequest.SleepTimer -> SleepTimerDialog(
+            expiresAtSec = player.player.sleepTimerExpiresAt,
+            onSelect = { homeScreenViewModel.setSleepTimer(request.playerId, it) },
+            onClear = { homeScreenViewModel.clearSleepTimer(request.playerId) },
+            onDismissRequest = onDismiss,
+        )
+
+        is PlayerDialogRequest.Lyrics -> {
+            val lyrics = (player.queueInfo?.currentItem?.track as? Track)?.lyrics
+                ?: return DismissEffect(request, onDismiss)
+            val queueId = player.queueId
+            val livePositionFlow = remember(queueId) {
+                queueId?.let { homeScreenViewModel.observePosition(it) }
+            }
+            LyricsSheet(
+                lyrics = lyrics,
+                livePositionFlow = livePositionFlow,
+                onDismiss = onDismiss,
+            )
+        }
+
+        is PlayerDialogRequest.AudioChain -> player.queueInfo?.currentItem?.let { queueTrack ->
+            AudioChainDialog(
+                queueTrack = queueTrack,
+                player = player,
+                onDismissRequest = onDismiss,
+            )
+        }
+
+        is PlayerDialogRequest.PlaybackSpeed -> player.queueInfo?.playbackSpeed?.let { speed ->
+            PlaybackSpeedDialog(
+                currentSpeed = speed,
+                onConfirm = {
+                    homeScreenViewModel.playerAction(player, PlayerAction.SetPlaybackSpeed(it))
+                },
+                onDismissRequest = onDismiss,
+            )
+        }
+
+        is PlayerDialogRequest.AddToPlaylist -> playlistActions?.let { actions ->
+            AddToPlaylistDialog(
+                item = request.item,
+                playlistActions = actions,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+/** Clears a request whose anchor is gone, once per request. */
+@Composable
+private fun DismissEffect(request: PlayerDialogRequest, onDismiss: () -> Unit) {
+    LaunchedEffect(request) { onDismiss() }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogRequest.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogRequest.kt
@@ -1,0 +1,67 @@
+package io.music_assistant.client.ui.compose.home.players
+
+import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.model.client.items.Track
+
+/**
+ * The one dialog the players screen currently shows, if any.
+ *
+ * A single slot instead of one flag per dialog: the dialogs are modal, so only one can be
+ * legal at a time, and the slot makes that structural. Every request names the player it
+ * belongs to by id, never by [PlayerData] value, so the dialog keeps reading the latest
+ * server state while the pager reorders or drops pages under it.
+ */
+sealed interface PlayerDialogRequest {
+    val playerId: String
+
+    data class Select(override val playerId: String) : PlayerDialogRequest
+
+    data class Group(override val playerId: String) : PlayerDialogRequest
+
+    data class Dsp(override val playerId: String) : PlayerDialogRequest
+
+    data class SleepTimer(override val playerId: String) : PlayerDialogRequest
+
+    data class Lyrics(override val playerId: String, val trackId: String) : PlayerDialogRequest
+
+    data class AudioChain(
+        override val playerId: String,
+        val queueItemId: String,
+    ) : PlayerDialogRequest
+
+    data class PlaybackSpeed(
+        override val playerId: String,
+        val queueItemId: String,
+    ) : PlayerDialogRequest
+
+    /**
+     * Carries the item itself: the add-to-playlist target is a snapshot taken at click time
+     * (a queue row the user long-pressed), not something to re-derive from the player.
+     */
+    data class AddToPlaylist(
+        override val playerId: String,
+        val item: AppMediaItem,
+    ) : PlayerDialogRequest
+}
+
+/**
+ * True while the thing this dialog describes still exists on [player].
+ *
+ * This replaces the `remember(currentQueueItem?.id)` keys that the page-local dialog state
+ * used to carry. The host closes a request that fails the check, so a dialog cannot outlive
+ * the track it describes.
+ */
+fun PlayerDialogRequest.hasAnchor(player: PlayerData): Boolean = when (this) {
+    is PlayerDialogRequest.Lyrics ->
+        (player.queueInfo?.currentItem?.track as? Track)?.itemId == trackId
+
+    is PlayerDialogRequest.AudioChain ->
+        player.queueInfo?.currentItem?.id == queueItemId
+
+    is PlayerDialogRequest.PlaybackSpeed ->
+        player.queueInfo?.let { it.currentItem?.id == queueItemId && it.playbackSpeed != null }
+            ?: false
+
+    else -> true
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -286,6 +286,10 @@ fun FullPlayerItem(
     bufferedAheadSecFlow: Flow<Double>? = null,
     lyricsAvailable: Boolean = false,
     onLyricsClick: () -> Unit = {},
+    // The quality pill and the speed pill only ask for their dialog; the dialogs themselves
+    // live outside the pager so a page change cannot tear them down mid-gesture.
+    onAudioChainClick: () -> Unit = {},
+    onPlaybackSpeedClick: () -> Unit = {},
     // Server preference gate for the chapter-relative timeline.
     chapterProgressEnabled: Boolean = true,
 ) {
@@ -571,8 +575,6 @@ fun FullPlayerItem(
             val currentQueueItem = item.queueInfo?.currentItem
             val tier = currentQueueItem?.qualityTier
             val isLq = tier == QualityTier.LQ
-            var showChainDialog by remember(currentQueueItem?.id) { mutableStateOf(false) }
-            var showSpeedDialog by remember(currentQueueItem?.id) { mutableStateOf(false) }
 
             // Variable speed: server-supported only for audiobooks/podcasts, and only
             // when the queue payload carries `playback_speed` (feature-detect gate).
@@ -580,22 +582,6 @@ fun FullPlayerItem(
             val isSpokenContent = currentQueueItem?.track is Audiobook ||
                     currentQueueItem?.track is PodcastEpisode
             val showSpeed = isSpokenContent && playbackSpeed != null && !poweredOff
-
-            if (showChainDialog && currentQueueItem != null) {
-                AudioChainDialog(
-                    queueTrack = currentQueueItem,
-                    player = item,
-                    onDismissRequest = { showChainDialog = false },
-                )
-            }
-
-            if (showSpeedDialog && playbackSpeed != null) {
-                PlaybackSpeedDialog(
-                    currentSpeed = playbackSpeed,
-                    onConfirm = { playerAction(item, PlayerAction.SetPlaybackSpeed(it)) },
-                    onDismissRequest = { showSpeedDialog = false },
-                )
-            }
 
             CenteredThreeSlotRow(
                 modifier = Modifier.fillMaxWidth(),
@@ -614,7 +600,7 @@ fun FullPlayerItem(
                             modifier = Modifier
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(colors.controlTint)
-                                .clickable { showSpeedDialog = true }
+                                .clickable(onClick = onPlaybackSpeedClick)
                                 .padding(horizontal = 8.dp, vertical = 2.dp),
                         ) {
                             Text(
@@ -640,7 +626,7 @@ fun FullPlayerItem(
                                         colors.controlTint
                                     },
                                 )
-                                .clickable(enabled = tier != null) { showChainDialog = true }
+                                .clickable(enabled = tier != null, onClick = onAudioChainClick)
                                 .padding(horizontal = 8.dp, vertical = 2.dp),
                         ) {
                             Text(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -52,7 +52,6 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,7 +74,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.window.core.layout.WindowSizeClass
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
-import io.music_assistant.client.data.model.client.Lyrics
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
 import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueue
@@ -83,6 +81,7 @@ import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueueTra
 import io.music_assistant.client.data.model.client.chapterSeekSeconds
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Track
+import io.music_assistant.client.data.model.client.lyrics
 import io.music_assistant.client.player.sendspin.SendspinState
 import io.music_assistant.client.ui.alphaOn
 import io.music_assistant.client.ui.compose.common.CenteredThreeSlotRow
@@ -99,8 +98,6 @@ import io.music_assistant.client.ui.compose.common.bufferIndicatorMenuOption
 import io.music_assistant.client.ui.compose.common.dynamicColorsMenuOption
 import io.music_assistant.client.ui.compose.common.icons.VolumeIcon
 import io.music_assistant.client.ui.compose.common.icons.VolumeMutedIcon
-import io.music_assistant.client.ui.compose.common.items.AddToPlaylistDialog
-import io.music_assistant.client.ui.compose.common.items.PlaylistActions
 import io.music_assistant.client.ui.compose.common.items.navigationOptions
 import io.music_assistant.client.ui.compose.common.rememberAnimatedPlayerColors
 import io.music_assistant.client.ui.compose.common.rememberDynamicColorsEnabled
@@ -111,7 +108,6 @@ import io.music_assistant.client.ui.compose.home.HomeScreenViewModel
 import io.music_assistant.client.ui.compose.home.HorizontalPagerIndicator
 import io.music_assistant.client.ui.compose.home.Queue
 import io.music_assistant.client.ui.inactive
-import io.music_assistant.client.utils.LrcParser
 import io.music_assistant.client.utils.WindowClass
 import io.music_assistant.client.utils.conditional
 import kotlinx.coroutines.flow.Flow
@@ -183,72 +179,21 @@ fun PlayersPager(
         var isQueueExpanded by remember { mutableStateOf(false) }
         // Extract playerData list to ensure proper recomposition
         val playerDataList = state.playerData
-        // Select-player dialog is hoisted out of the pager so that reordering-induced
-        // pager scrolls don't tear down the dialog's composable.
-        var selectDialogPlayerId by remember<MutableState<String?>> { mutableStateOf(null) }
-        val selectDialogPlayer = selectDialogPlayerId?.let { id ->
-            playerDataList.firstOrNull { it.player.id == id }
-        }
-        if (selectDialogPlayer != null) {
-            SelectPlayerDialog(
-                selectedPlayer = selectDialogPlayer,
-                players = playerDataList,
-                onDismissRequest = { selectDialogPlayerId = null },
-                onMoveToPlayer = { moveToPlayer(it) },
-                onReorder = { homeScreenViewModel.onPlayersSortChanged(it) },
-            )
-        }
-
-        // Keep dialogs outside the pager so page removal/reordering cannot tear down a dialog
-        // while UIKit is cancelling its hover recognizers. IDs keep ownership stable while the
-        // player data itself continues to come from the latest server state.
-        var groupDialogPlayerId by remember { mutableStateOf<String?>(null) }
-        var dspDialogPlayerId by remember { mutableStateOf<String?>(null) }
-        var sleepTimerDialogPlayerId by remember { mutableStateOf<String?>(null) }
-        val groupDialogPlayer = groupDialogPlayerId?.let { id ->
-            playerDataList.firstOrNull { it.player.id == id }
-        }
-        val dspDialogPlayer = dspDialogPlayerId?.let { id ->
-            playerDataList.firstOrNull { it.player.id == id }
-        }
-        val sleepTimerDialogPlayer = sleepTimerDialogPlayerId?.let { id ->
-            playerDataList.firstOrNull { it.player.id == id }
-        }
-
-        groupDialogPlayer?.let { player ->
-            GroupSettingsDialog(
-                player = player,
-                onDismissRequest = { groupDialogPlayerId = null },
-                groupAction = { playerId: String, action: PlayerAction ->
-                    homeScreenViewModel.playerAction(
-                        playerId,
-                        action,
-                    )
-                },
-                localPlayerId = homeScreenViewModel.localPlayerId,
-                onAdjustPlaybackDelay = {
-                    homeScreenViewModel.adjustSendspinStaticDelayMs(it)
-                },
-                canLeaveGroup = leaderLeaveSupported,
-            )
-        }
-        dspDialogPlayer?.let { player ->
-            DspSettingsDialog(
-                playerId = player.player.id,
-                dspSettingsViewModel = dspSettingsViewModel,
-                onDismissRequest = { dspDialogPlayerId = null },
-            )
-        }
-        sleepTimerDialogPlayer?.let { player ->
-            SleepTimerDialog(
-                expiresAtSec = player.player.sleepTimerExpiresAt,
-                onSelect = {
-                    homeScreenViewModel.setSleepTimer(player.player.id, it)
-                },
-                onClear = { homeScreenViewModel.clearSleepTimer(player.player.id) },
-                onDismissRequest = { sleepTimerDialogPlayerId = null },
-            )
-        }
+        // Every player dialog lives outside the pager, so removing or reordering a page cannot
+        // tear down an open dialog while UIKit is cancelling its hover recognizers. The host
+        // resolves the request against the newest player data and clears it once the player or
+        // the track it names is gone.
+        var dialogRequest by remember { mutableStateOf<PlayerDialogRequest?>(null) }
+        PlayerDialogHost(
+            request = dialogRequest,
+            players = playerDataList,
+            homeScreenViewModel = homeScreenViewModel,
+            dspSettingsViewModel = dspSettingsViewModel,
+            playlistActions = actionsViewModel,
+            canLeaveGroup = leaderLeaveSupported,
+            onMoveToPlayer = moveToPlayer,
+            onDismiss = { dialogRequest = null },
+        )
 
         val playerColors = playerDataList.associateWith {
             val media = it.player.currentMedia
@@ -281,10 +226,59 @@ fun PlayersPager(
                 key = { page -> playerDataList.getOrNull(page)?.player?.id ?: page },
             ) { page ->
                 val player = playerDataList.getOrNull(page) ?: return@HorizontalPager
-                val onSelectPlayer = { selectDialogPlayerId = player.player.id }
-                val onGroupButton = { groupDialogPlayerId = player.player.id }
-                val onDspButton = { dspDialogPlayerId = player.player.id }
-                val onSleepTimerButton = { sleepTimerDialogPlayerId = player.player.id }
+                // Openers are memoized on the ids they capture: PlayerData is not stable, so an
+                // un-remembered lambda would be a new instance every pass and the page below
+                // would never skip recomposition.
+                val playerId = player.playerId
+                val currentQueueItem = player.queueInfo?.currentItem
+                val currentTrack = currentQueueItem?.track as? Track
+                val lyrics = currentTrack?.lyrics
+                val trackId = currentTrack?.itemId
+                val queueItemId = currentQueueItem?.id
+                val onSelectPlayer: () -> Unit = remember(playerId) {
+                    {
+                        dialogRequest = PlayerDialogRequest.Select(playerId)
+                    }
+                }
+                val onGroupButton: () -> Unit = remember(playerId) {
+                    {
+                        dialogRequest = PlayerDialogRequest.Group(playerId)
+                    }
+                }
+                val onDspButton: () -> Unit = remember(playerId) {
+                    {
+                        dialogRequest = PlayerDialogRequest.Dsp(playerId)
+                    }
+                }
+                val onSleepTimerButton: () -> Unit = remember(playerId) {
+                    {
+                        dialogRequest = PlayerDialogRequest.SleepTimer(playerId)
+                    }
+                }
+                val onLyricsClick: () -> Unit = remember(playerId, trackId) {
+                    {
+                        trackId?.let { dialogRequest = PlayerDialogRequest.Lyrics(playerId, it) }
+                    }
+                }
+                val onAudioChainClick: () -> Unit = remember(playerId, queueItemId) {
+                    {
+                        queueItemId?.let {
+                            dialogRequest = PlayerDialogRequest.AudioChain(playerId, it)
+                        }
+                    }
+                }
+                val onPlaybackSpeedClick: () -> Unit = remember(playerId, queueItemId) {
+                    {
+                        queueItemId?.let {
+                            dialogRequest = PlayerDialogRequest.PlaybackSpeed(playerId, it)
+                        }
+                    }
+                }
+                val onAddToPlaylist: (AppMediaItem) -> Unit = remember(playerId) {
+                    {
+                        dialogRequest = PlayerDialogRequest.AddToPlaylist(playerId, it)
+                    }
+                }
 
                 val colors by playerColors.getValue(player)
 
@@ -318,24 +312,9 @@ fun PlayersPager(
                                 null
                             }
                         }
-                        // Lyrics: only the displayed page drives the shared VM, so the
-                        // fetch (and the button) track the player currently on screen.
-                        val currentTrack = player.queueInfo?.currentItem?.track as? Track
+                        // Only the displayed page drives the shared lyrics VM, so the button
+                        // tracks the player currently on screen.
                         val isCurrentPage = page == playerPagerState.currentPage
-
-                        val lyrics = currentTrack?.metadata?.let { metadata ->
-                            val plain = metadata.lyrics
-                            val lrc = metadata.lrcLyrics
-                            when {
-                                !lrc.isNullOrBlank() ->
-                                    LrcParser.parse(lrc).takeIf { it.isNotEmpty() }
-                                        ?.let { Lyrics.Synced(it) }
-                                        ?: Lyrics.Plain(lrc)
-                                !plain.isNullOrBlank() -> Lyrics.Plain(plain)
-                                else -> null
-                            }
-                        }
-                        var sheetLyrics by remember(currentTrack) { mutableStateOf<Lyrics?>(null) }
                         if (!expanded) {
                             CollapsedPlayerPage(
                                 isWideScreen = isWideScreen,
@@ -356,7 +335,7 @@ fun PlayersPager(
                                 onDspButton = onDspButton.takeIf { !player.player.isGroup },
                                 onSleepTimerButton = onSleepTimerButton.takeIf { sleepTimerSupported },
                                 playerAction = playerAction1,
-                                playlistActions = actionsViewModel,
+                                onAddToPlaylist = onAddToPlaylist,
                                 onFavoriteClick = {
                                     actionsViewModel.onFavoriteClick(it)
                                 },
@@ -374,15 +353,10 @@ fun PlayersPager(
                                 livePositionFlow = livePositionFlow,
                                 bufferedAheadSecFlow = bufferedAheadSecFlow,
                                 lyricsAvailable = isCurrentPage && lyrics != null,
-                                onLyricsClick = { sheetLyrics = lyrics },
+                                onLyricsClick = onLyricsClick,
+                                onAudioChainClick = onAudioChainClick,
+                                onPlaybackSpeedClick = onPlaybackSpeedClick,
                                 chapterProgressEnabled = chapterProgressEnabled,
-                            )
-                        }
-                        sheetLyrics?.let { shown ->
-                            LyricsSheet(
-                                lyrics = shown,
-                                livePositionFlow = livePositionFlow,
-                                onDismiss = { sheetLyrics = null },
                             )
                         }
                     }
@@ -454,7 +428,7 @@ private fun ExpandedPlayerPage(
     onDspButton: (() -> Unit)?,
     onSleepTimerButton: (() -> Unit)?,
     playerAction: (PlayerData, PlayerAction) -> Unit,
-    playlistActions: PlaylistActions? = null,
+    onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
     onFavoriteClick: (AppMediaItem) -> Unit,
     onClose: () -> Unit,
     queueAction: (QueueAction) -> Unit,
@@ -471,6 +445,8 @@ private fun ExpandedPlayerPage(
     bufferedAheadSecFlow: Flow<Double>? = null,
     lyricsAvailable: Boolean = false,
     onLyricsClick: () -> Unit = {},
+    onAudioChainClick: () -> Unit = {},
+    onPlaybackSpeedClick: () -> Unit = {},
     chapterProgressEnabled: Boolean = true,
 ) {
     // The queue sits beside the player whenever the window is wide (see
@@ -527,7 +503,7 @@ private fun ExpandedPlayerPage(
                     },
                     onPlayerSelected = { moveToPlayer(it) },
                     onOpenDsp = onDspButton,
-                    playlistActions = playlistActions,
+                    onAddToPlaylist = onAddToPlaylist,
                 )
             },
         )
@@ -644,6 +620,8 @@ private fun ExpandedPlayerPage(
                             onFavoriteClick = onFavoriteClick,
                             lyricsAvailable = lyricsAvailable,
                             onLyricsClick = onLyricsClick,
+                            onAudioChainClick = onAudioChainClick,
+                            onPlaybackSpeedClick = onPlaybackSpeedClick,
                             livePositionFlow = livePositionFlow,
                             bufferedAheadSecFlow = bufferedAheadSecFlow,
                             chapterProgressEnabled = chapterProgressEnabled,
@@ -772,7 +750,7 @@ private fun ExpandedPlayerPage(
 
                 if (!showSideQueue) {
                     CollapsibleQueue(
-                        playlistActions = playlistActions,
+                        onAddToPlaylist = onAddToPlaylist,
                         modifier = Modifier
                             .conditional(
                                 condition = isQueueExpanded,
@@ -811,7 +789,7 @@ private fun ExpandedPlayerPage(
                     isCurrentPage = isCurrentPage,
                     contentPadding = contentPadding,
                     queueAction = queueAction,
-                    playlistActions = playlistActions,
+                    onAddToPlaylist = onAddToPlaylist,
                     livePositionFlow = livePositionFlow,
                     onChapterClick = { chapter ->
                         playerAction(player, PlayerAction.SeekTo(chapterSeekSeconds(chapter.start)))
@@ -831,11 +809,10 @@ private fun PlayerOverflowMenu(
     navigateToItem: (AppMediaItem) -> Unit,
     onPlayerSelected: (String) -> Unit,
     onOpenDsp: (() -> Unit)?,
-    playlistActions: PlaylistActions? = null,
+    onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
 ) {
     var transferMenuExpanded by remember { mutableStateOf(false) }
     val currentTrack = currentPlayer.queueInfo?.currentItem?.track as? Track
-    var showAddToPlaylist by remember { mutableStateOf(false) }
 
     val queueData = currentPlayer.queue as? DataState.Data
     val queueInfo = queueData?.data?.info
@@ -946,12 +923,12 @@ private fun PlayerOverflowMenu(
         )
             ?: emptyList()
     val trackActions = buildList {
-        if (currentTrack != null && playlistActions != null) {
+        currentTrack?.takeIf { onAddToPlaylist != null }?.let { track ->
             add(
                 OverflowMenuOption(
                     title = stringResource(Res.string.action_add_to_playlist),
                     icon = Icons.AutoMirrored.Filled.PlaylistAdd,
-                    onClick = { showAddToPlaylist = true },
+                    onClick = { onAddToPlaylist?.invoke(track) },
                 ),
             )
         }
@@ -978,14 +955,6 @@ private fun PlayerOverflowMenu(
                 )
             }
         }
-    }
-
-    if (showAddToPlaylist && currentTrack != null && playlistActions != null) {
-        AddToPlaylistDialog(
-            item = currentTrack,
-            playlistActions = playlistActions,
-            onDismiss = { showAddToPlaylist = false },
-        )
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerDialogRequestTest.kt
@@ -1,0 +1,88 @@
+package io.music_assistant.client.ui.compose.home.players
+
+import io.music_assistant.client.data.model.client.AppMediaItemFixtures
+import io.music_assistant.client.data.model.client.PlayerData
+import io.music_assistant.client.data.model.client.PlayerDataFixtures
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueue
+import io.music_assistant.client.data.model.client.PlayerDataFixtures.toQueueTrack
+import io.music_assistant.client.data.model.client.byId
+import io.music_assistant.client.ui.compose.common.DataState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The anchor rule is what stops a hoisted dialog outliving the track it describes, and what
+ * stops a stale player id from reviving a dismissed dialog. It is a pure function, so it is
+ * checked here rather than through the Compose host.
+ */
+class PlayerDialogRequestTest {
+    private fun playerWith(
+        queueItemId: String,
+        trackId: String = "track-1",
+        playbackSpeed: Double? = null,
+    ): PlayerData {
+        val track = AppMediaItemFixtures.track(itemId = trackId)
+        val queue = listOf(track.toQueueTrack(id = queueItemId)).toQueue()
+        val data = PlayerDataFixtures.playerData(queue)
+        return data.copy(
+            queue = DataState.Data(
+                queue.copy(info = queue.info.copy(playbackSpeed = playbackSpeed)),
+            ),
+        )
+    }
+
+    @Test
+    fun `player-scoped requests hold while the player exists`() {
+        val player = playerWith(queueItemId = "q1")
+        val id = player.playerId
+        val item = AppMediaItemFixtures.track()
+
+        assertTrue(PlayerDialogRequest.Select(id).hasAnchor(player))
+        assertTrue(PlayerDialogRequest.Group(id).hasAnchor(player))
+        assertTrue(PlayerDialogRequest.Dsp(id).hasAnchor(player))
+        assertTrue(PlayerDialogRequest.SleepTimer(id).hasAnchor(player))
+        assertTrue(PlayerDialogRequest.AddToPlaylist(id, item).hasAnchor(player))
+    }
+
+    @Test
+    fun `lyrics request drops when the current track changes`() {
+        val player = playerWith(queueItemId = "q1", trackId = "track-1")
+        val request = PlayerDialogRequest.Lyrics(player.playerId, trackId = "track-1")
+
+        assertTrue(request.hasAnchor(player))
+        assertFalse(request.hasAnchor(playerWith(queueItemId = "q2", trackId = "track-2")))
+    }
+
+    @Test
+    fun `audio chain request drops when the queue item changes`() {
+        val player = playerWith(queueItemId = "q1")
+        val request = PlayerDialogRequest.AudioChain(player.playerId, queueItemId = "q1")
+
+        assertTrue(request.hasAnchor(player))
+        assertFalse(request.hasAnchor(playerWith(queueItemId = "q2")))
+    }
+
+    @Test
+    fun `playback speed request needs both the queue item and a speed`() {
+        val player = playerWith(queueItemId = "q1", playbackSpeed = 1.5)
+        val request = PlayerDialogRequest.PlaybackSpeed(player.playerId, queueItemId = "q1")
+
+        assertTrue(request.hasAnchor(player))
+        // Track advanced.
+        assertFalse(request.hasAnchor(playerWith(queueItemId = "q2", playbackSpeed = 1.5)))
+        // Server stopped reporting variable speed for the queue.
+        assertFalse(request.hasAnchor(playerWith(queueItemId = "q1", playbackSpeed = null)))
+    }
+
+    @Test
+    fun `byId finds the player the request names and misses once it is gone`() {
+        val first = playerWith(queueItemId = "q1")
+        val second = playerWith(queueItemId = "q2")
+
+        assertEquals(first, listOf(first, second).byId(first.playerId))
+        assertNull(listOf(second).byId(first.playerId))
+    }
+}


### PR DESCRIPTION
Every modal dialog reachable from PlayersPager now goes through one sealed PlayerDialogRequest state and one PlayerDialogHost rendered outside the pager.

PR #966 hoisted three dialogs but cleared their player ids only on dismiss, so a player that left and rejoined the list re-opened its dialog on its own. It also left five dialogs inside the pager page with the original teardown hazard, and four parallel nullable ids encoding 16 states of which 5 were legal.

- PlayerDialogRequest: 8 cases + hasAnchor(), a pure predicate that replaces the per-page remember() keys. The host clears a request whose anchor is gone.
- Hoist LyricsSheet, AudioChainDialog, PlaybackSpeedDialog and both AddToPlaylistDialog sites out of the pager page and the queue list.
- PlayerOverflowMenu, CollapsibleQueue and Queue take onAddToPlaylist instead of the whole PlaylistActions interface.
- Memoize the dialog openers: PlayerData is not @Immutable, so the un-remembered lambdas broke skipping in ExpandedPlayerPage.
- Add List<PlayerData>.byId() and Track.lyrics, each replacing duplicated code.

Anchored DropdownMenus are unchanged: a dropdown is positioned against its anchor and must be torn down with it.
