### PR TITLE
Add a refresh button to playlist detail pages

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -159,6 +159,7 @@ fun ItemDetailsScreen(
         onLoadSimilarArtists = itemDetailsViewModel::loadSimilarArtists,
         onAlbumMappingChanged = itemDetailsViewModel::loadAlbumsForProvider,
         onTrackMappingChanged = itemDetailsViewModel::loadTopTracksForProvider,
+        onRefreshPlaylist = itemDetailsViewModel::refreshPlaylistTracks,
     )
 }
 
@@ -189,6 +190,7 @@ fun ItemDetails(
     onLoadSimilarArtists: () -> Unit = {},
     onAlbumMappingChanged: (ProviderMapping) -> Unit = { },
     onTrackMappingChanged: (ProviderMapping) -> Unit = { },
+    onRefreshPlaylist: () -> Unit = {},
 ) {
     val playlistActions = object : PlaylistActions {
         override suspend fun getEditablePlaylists(): List<Playlist> {
@@ -279,6 +281,7 @@ fun ItemDetails(
                     onLoadSimilarArtists = onLoadSimilarArtists,
                     onAlbumMappingChanged = onAlbumMappingChanged,
                     onTrackMappingChanged = onTrackMappingChanged,
+                    onRefreshPlaylist = onRefreshPlaylist,
                 )
             }
 
@@ -318,6 +321,7 @@ private fun ItemContent(
     onLoadSimilarArtists: () -> Unit,
     onAlbumMappingChanged: (ProviderMapping) -> Unit,
     onTrackMappingChanged: (ProviderMapping) -> Unit,
+    onRefreshPlaylist: () -> Unit,
 ) {
     // Tabs, the loading gate, and the selected tab are all derived in ItemDetailsViewModel.State.
     val tabs = state.tabs
@@ -371,6 +375,9 @@ private fun ItemContent(
                 playlistActions = playlistActions.takeIf { item.supportsAddToPlaylist },
                 navigateToItem = onNavigateClick,
                 onSimilarArtistsClick = { showSimilarArtists = true },
+                // force_refresh is a playlist-tracks-only server argument, so no other
+                // media type gets the action.
+                onRefresh = onRefreshPlaylist.takeIf { item is Playlist },
             )
         },
     ) {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsViewModel.kt
@@ -446,7 +446,11 @@ class ItemDetailsViewModel(
         }
     }
 
-    private fun loadPlaylistTracks(itemId: String, provider: String) {
+    private fun loadPlaylistTracks(
+        itemId: String,
+        provider: String,
+        forceRefresh: Boolean = false,
+    ) {
         viewModelScope.launch {
             _state.update { it.copy(playableItemsState = DataState.Loading()) }
 
@@ -455,7 +459,7 @@ class ItemDetailsViewModel(
                     Request.Playlist.getTracks(
                         itemId = itemId,
                         providerInstanceIdOrDomain = provider,
-                        forceRefresh = null,
+                        forceRefresh = forceRefresh.takeIf { it },
                     ),
                 ).getOrNull()
                     ?.filterIsInstance<PlayableItem>()
@@ -664,6 +668,14 @@ class ItemDetailsViewModel(
                 ),
             )
         }
+    }
+
+    // Bypasses the server's playlist-tracks cache, which is the only way to make a
+    // provider playlist (e.g. "Random Album") produce a new selection on demand.
+    fun refreshPlaylistTracks() {
+        if (_state.value.playableItemsState is DataState.Loading) return
+        val playlist = (state.value.itemState as? DataState.Data)?.data as? Playlist ?: return
+        loadPlaylistTracks(playlist.itemId, playlist.provider, forceRefresh = true)
     }
 
     fun reload() {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemHeader.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -81,6 +82,7 @@ import musicassistantclient.composeapp.generated.resources.Res
 import musicassistantclient.composeapp.generated.resources.action_similar_artists
 import musicassistantclient.composeapp.generated.resources.cd_more
 import musicassistantclient.composeapp.generated.resources.common_back
+import musicassistantclient.composeapp.generated.resources.refresh
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -157,6 +159,7 @@ internal fun ItemTopBar(
     playlistActions: PlaylistActions?,
     navigateToItem: (AppMediaItem) -> Unit,
     onSimilarArtistsClick: () -> Unit,
+    onRefresh: (() -> Unit)? = null,
 ) {
     // Flat fill equal to the header gradient's top color, so the bar reads as one
     // continuous wash with the header below it. Back/overflow icons are NOT control-tinted
@@ -187,6 +190,14 @@ internal fun ItemTopBar(
                 }
             },
             actions = {
+                onRefresh?.let { refresh ->
+                    IconButton(onClick = refresh) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            stringResource(Res.string.refresh),
+                        )
+                    }
+                }
                 ItemOverflow(
                     item = item,
                     libraryActions = libraryActions,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/PlaylistTracksRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/PlaylistTracksRequestTest.kt
@@ -1,0 +1,48 @@
+package io.music_assistant.client.api
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the wire shape of `music/playlists/playlist_tracks`. `force_refresh` is the only
+ * cache-bypass argument the server exposes for a listing, and it is what makes a provider
+ * playlist ("Random Album") produce a new selection on demand (issue #958).
+ *
+ * A typo in the argument name fails silently — the server ignores it and serves the cached
+ * list, so the refresh button would just re-render the same tracks.
+ */
+class PlaylistTracksRequestTest {
+    @Test
+    fun refreshCarriesForceRefreshFlag() {
+        val request = Request.Playlist.getTracks(
+            itemId = "p1",
+            providerInstanceIdOrDomain = "spotify",
+            forceRefresh = true,
+        )
+
+        assertEquals("music/playlists/playlist_tracks", request.command)
+        assertEquals(JsonPrimitive("p1"), request.args?.get("item_id"))
+        assertEquals(
+            JsonPrimitive("spotify"),
+            request.args?.get("provider_instance_id_or_domain"),
+        )
+        assertEquals(JsonPrimitive(true), request.args?.get("force_refresh"))
+    }
+
+    @Test
+    fun normalLoadOmitsForceRefresh() {
+        // Absent, not `false`: the server default stays authoritative and the cached list is used.
+        val request = Request.Playlist.getTracks(
+            itemId = "p1",
+            providerInstanceIdOrDomain = "spotify",
+        )
+
+        assertNull(request.args?.get("force_refresh"))
+        assertEquals(
+            setOf("item_id", "provider_instance_id_or_domain"),
+            request.args?.keys,
+        )
+    }
+}


### PR DESCRIPTION
music/playlists/playlist_tracks is the only listing command with a force_refresh argument. Wire it to a top-bar action shown on playlist details only, matching the web frontend, which sets show-refresh-button on playlisttracks and explicitly false on album listings.

Provider playlists such as "Random Album" only produce a new selection when the server cache is bypassed; the hourly sync was the sole trigger before this.

Closes #958
