### PR TITLE
Don't pre-fill in the textbox of the hostname field

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/settings/SettingsScreen.kt
@@ -217,7 +217,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                var ipAddress by remember { mutableStateOf(Defaults.URI) }
+                var ipAddress by remember { mutableStateOf("") }
                 var port by remember { mutableStateOf(Defaults.PORT.toString()) }
                 var isTls by remember { mutableStateOf(false) }
                 var basePath by remember { mutableStateOf("") }
@@ -291,13 +291,13 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
                             onBasePathChange = { basePath = it },
                             onDirectConnect = {
                                 viewModel.attemptConnection(
-                                    ipAddress,
+                                    ipAddress.ifBlank { Defaults.URI },
                                     port,
                                     isTls,
                                     basePath,
                                 )
                             },
-                            directConnectEnabled = ipAddress.isValidHost() &&
+                            directConnectEnabled = ipAddress.ifBlank { Defaults.URI }.isValidHost() &&
                                     port.isIpPort() &&
                                     basePath.isValidBasePath(),
                             sessionState = sessionState,
@@ -307,7 +307,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
 
                     SessionState.Connecting -> {
                         ConnectingSection(
-                            ipAddress = ipAddress,
+                            ipAddress = ipAddress.ifBlank { Defaults.URI },
                             port = port,
                             preferredMethod = preferredMethod,
                             onCancel = { viewModel.disconnect() },
@@ -316,7 +316,7 @@ fun SettingsScreen(goHome: () -> Unit, exitApp: () -> Unit) {
 
                     is SessionState.Reconnecting -> {
                         ConnectingSection(
-                            ipAddress = ipAddress,
+                            ipAddress = ipAddress.ifBlank { Defaults.URI },
                             port = port,
                             preferredMethod = preferredMethod,
                             onCancel = { viewModel.disconnect() },
@@ -541,7 +541,14 @@ private fun ConnectionMethodTabs(
     var showHistoryDialog by remember { mutableStateOf(false) }
 
     val directHasToken = port.toIntOrNull()
-        ?.let { viewModel.hasCredentialsForDirect(ipAddress, it, isTls, basePath) } ?: false
+        ?.let {
+            viewModel.hasCredentialsForDirect(
+                ipAddress.ifBlank { Defaults.URI },
+                it,
+                isTls,
+                basePath,
+            )
+        } ?: false
     val webrtcHasToken = webrtcRemoteId.isNotBlank() &&
             viewModel.hasCredentialsForWebRTC(webrtcRemoteId)
 
@@ -674,7 +681,7 @@ private fun DirectConnectionContent(
         value = ipAddress,
         onValueChange = onIpAddressChange,
         label = { Text(stringResource(Res.string.settings_server_host)) },
-        placeholder = { Text("homeassistant.local") },
+        placeholder = { Text(Defaults.URI) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         keyboardActions = KeyboardActions(
@@ -748,7 +755,12 @@ private fun DirectConnectionContent(
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = 12.dp),
-        text = ConnectionInfo.previewWsUrl(ipAddress, port, isTls, basePath),
+        text = ConnectionInfo.previewWsUrl(
+            ipAddress.ifBlank { Defaults.URI },
+            port,
+            isTls,
+            basePath,
+        ),
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

While still showing homeassistant.local as the default. That is, still use homeassistant.local as the default if the field is empty, and still show it as such, but don't make the user delete it to replace with their own hostname, if they aren't using homeassistant.local.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

