### PR TITLE
Recover the MA command session on background local Play

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/KtorServiceClient.kt
@@ -147,6 +147,9 @@ class KtorServiceClient(
     private var isInBackground = false
     private var hasActiveExternalConsumer = false
     private var hasActivePlayback = false
+    private val playbackRecovery = PlaybackRecoveryWindow()
+    private val canRecoverInBackground: Boolean
+        get() = hasActiveExternalConsumer || hasActivePlayback || playbackRecovery.isActive
     private var backgroundedAt = 0L
 
     private val silentReauth = SilentReauth(
@@ -382,9 +385,14 @@ class KtorServiceClient(
         logger.i { "External consumer inactive (state=${stateLabel(_sessionState.value)})" }
     }
 
-    /**
-     * Called when any player starts playing. Prevents background teardown.
-     */
+    override fun requestPlaybackRecovery() {
+        // Set this before scheduling recovery: a stale socket may report its drop
+        // as soon as the queued Play attempts to use it.
+        playbackRecovery.request()
+        launch { ensureReadyForCommands() }
+    }
+
+    /** Called when playback is confirmed, rather than merely requested. */
     override fun onPlaybackActive() {
         hasActivePlayback = true
         logger.i { "Playback active (state=${stateLabel(_sessionState.value)})" }
@@ -403,6 +411,7 @@ class KtorServiceClient(
     }
 
     override fun noServer() {
+        playbackRecovery.clear()
         _sessionState.update { SessionState.Disconnected.NoServerData }
     }
 
@@ -550,7 +559,7 @@ class KtorServiceClient(
                         }
 
                         is TransportState.Reconnecting -> {
-                            if (isInBackground && !hasActiveExternalConsumer && !hasActivePlayback) {
+                            if (isInBackground && !canRecoverInBackground) {
                                 backgroundedConnectionInfo = backgroundInfo()
                                 transport.disconnect()
                                 _sessionState.update { SessionState.Disconnected.Backgrounded }
@@ -749,13 +758,14 @@ class KtorServiceClient(
     }
 
     override fun disconnectByUser() {
+        playbackRecovery.clear()
         disconnect(SessionState.Disconnected.ByUser)
     }
 
     private fun disconnect(newState: SessionState.Disconnected) {
         launch {
             if (newState is SessionState.Disconnected.Backgrounded &&
-                (!isInBackground || hasActiveExternalConsumer || hasActivePlayback)
+                (!isInBackground || canRecoverInBackground)
             ) {
                 logger.i { "Backgrounded disconnect aborted — app already foregrounded" }
                 return@launch
@@ -843,6 +853,7 @@ class KtorServiceClient(
     }
 
     override fun logout() {
+        playbackRecovery.clear()
         if (_sessionState.value !is SessionState.Connected) return
         _sessionState.update {
             (it as? SessionState.Connected)?.update(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/PlaybackRecoveryWindow.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/PlaybackRecoveryWindow.kt
@@ -1,0 +1,25 @@
+package io.music_assistant.client.api
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/** A short grace period for explicit Play while confirmed playback is still inactive. */
+internal class PlaybackRecoveryWindow(private val clock: TimeSource = TimeSource.Monotonic) {
+    private val requestedAt = MutableStateFlow<TimeMark?>(null)
+
+    val isActive: Boolean get() = requestedAt.value?.elapsedNow()?.let { it < DURATION } == true
+
+    fun request() {
+        requestedAt.value = clock.markNow()
+    }
+
+    fun clear() {
+        requestedAt.value = null
+    }
+
+    private companion object {
+        val DURATION = 10.seconds
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/ServiceClient.kt
@@ -35,6 +35,10 @@ interface ServiceClient {
     fun connect(connection: ConnectionInfo)
     fun connectWebRTC(remoteId: RemoteId)
     fun onExternalConsumerActive()
+
+    /** Explicit local Play may need to restore the command connection before audio can start. */
+    fun requestPlaybackRecovery() = Unit
+
     fun onPlaybackActive()
     fun onExternalConsumerInactive()
     fun onPlaybackInactive()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalCommandQueue.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalCommandQueue.kt
@@ -28,6 +28,7 @@ internal class LocalCommandQueue(
     private val isReady: StateFlow<Boolean>,
     private val send: suspend (Request) -> Result<*>,
     scope: CoroutineScope,
+    private val requestPlaybackRecovery: () -> Unit = {},
 ) {
     private val log = Logger.withTag("LocalCommandQueue")
     private val mutex = Mutex()
@@ -42,6 +43,9 @@ internal class LocalCommandQueue(
     }
 
     suspend fun sendOrQueue(action: PlayerAction, request: Request) {
+        // Readiness can be stale even when true. Register Play intent before
+        // either the offline fast path or the first send can observe a drop.
+        if (action == PlayerAction.Play) requestPlaybackRecovery()
         if (!isReady.value) {
             enqueue(action, request)
             return

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerAdapter.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/LocalPlayerAdapter.kt
@@ -150,7 +150,12 @@ class LocalPlayerAdapter(
         }
         .stateIn(this, SharingStarted.Eagerly, 0.0)
 
-    private val commands = LocalCommandQueue(apiClient.isReadyForCommands, apiClient::sendRequest, this)
+    private val commands = LocalCommandQueue(
+        apiClient.isReadyForCommands,
+        apiClient::sendRequest,
+        this,
+        requestPlaybackRecovery = apiClient::requestPlaybackRecovery,
+    )
     private var pendingPlayTimeoutJob: Job? = null
     private var pausedByInterruption = false
 
@@ -222,7 +227,11 @@ class LocalPlayerAdapter(
      * Applies the optimistic UI update, then sends or offline-queues the request.
      */
     fun handleLocalCommand(data: PlayerData, action: PlayerAction) {
-        val resolved = playerRequestFactory.resolve(data, action)
+        val resolved = if (action == PlayerAction.TogglePlayPause) {
+            if (data.player.isPlaying || _localPlayerData.value?.pendingPlay == true) PlayerAction.Pause else PlayerAction.Play
+        } else {
+            playerRequestFactory.resolve(data, action)
+        }
         applyOptimisticUpdate(data, resolved)
         launch {
             val request = playerRequestFactory.buildRequest(data, resolved) ?: return@launch
@@ -314,10 +323,6 @@ class LocalPlayerAdapter(
     }
 
     private fun optimisticPlay() {
-        if (!apiClient.isReadyForCommands.value) {
-            log.i { "Suppressing pending local play while the command transport is not ready" }
-            return
-        }
         _localPlayerData.update { current -> current?.copy(pendingPlay = true) }
         armPendingPlayTimeout()
     }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/PlaybackRecoveryWindowTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/PlaybackRecoveryWindowTest.kt
@@ -1,0 +1,46 @@
+package io.music_assistant.client.api
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+class PlaybackRecoveryWindowTest {
+    private val clock = TestTimeSource()
+    private val window = PlaybackRecoveryWindow(clock)
+
+    @Test
+    fun pausedIdleDoesNotAllowBackgroundRecoveryWithoutUserIntent() {
+        assertFalse(window.isActive)
+    }
+
+    @Test
+    fun explicitPlayProtectsRecoveryButCannotKeepItAliveIndefinitely() {
+        window.request()
+        assertTrue(window.isActive)
+        clock += 9_999.milliseconds
+        assertTrue(window.isActive)
+        clock += 1.milliseconds
+        assertFalse(window.isActive)
+    }
+
+    @Test
+    fun anotherExplicitPlayGetsItsOwnFullGracePeriod() {
+        window.request()
+        clock += 9.seconds
+        window.request()
+        clock += 1.seconds
+        assertTrue(window.isActive)
+        clock += 9.seconds
+        assertFalse(window.isActive)
+    }
+
+    @Test
+    fun userDisconnectClearsTheGracePeriod() {
+        window.request()
+        window.clear()
+        assertFalse(window.isActive)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalCommandQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/LocalCommandQueueTest.kt
@@ -5,6 +5,7 @@ import io.music_assistant.client.ui.compose.common.action.PlayerAction
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -13,6 +14,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LocalCommandQueueTest {
@@ -31,6 +33,75 @@ class LocalCommandQueueTest {
 
     /** Runs the background collector and any replay spacing (advanceUntilIdle skips background-only work). */
     private fun TestScope.settle() = advanceTimeBy(1_000)
+
+    @Test
+    fun offlinePlayRequestsMaRecoveryAndDrainsWithoutForegroundOrSendspinEvents() = runTest {
+        ready.value = false
+        var recoveries = 0
+        val queue = LocalCommandQueue(ready, ::record, backgroundScope) {
+            recoveries++
+            backgroundScope.launch {
+                delay(100)
+                ready.value = true
+            }
+        }
+        queue.sendOrQueue(PlayerAction.Play, request("play"))
+        assertEquals(1, recoveries)
+        assertEquals(emptyList(), sent)
+        settle()
+        assertEquals(listOf("play"), sent)
+    }
+
+    @Test
+    fun playProtectsRecoveryBeforeAStaleReadySocketCanFail() = runTest {
+        var protected = false
+        var attempts = 0
+        val queue = LocalCommandQueue(
+            ready,
+            { request ->
+                assertTrue(protected, "recovery must be allowed before sending")
+                attempts++
+                if (attempts == 1) {
+                    ready.value = false
+                    Result.failure<Unit>(IllegalStateException("stale socket"))
+                } else {
+                    record(request)
+                }
+            },
+            backgroundScope,
+            requestPlaybackRecovery = { protected = true },
+        )
+        queue.sendOrQueue(PlayerAction.Play, request("play"))
+        ready.value = true
+        settle()
+        assertEquals(2, attempts)
+        assertEquals(listOf("play"), sent)
+    }
+
+    @Test
+    fun pauseDuringRecoveryReplacesQueuedPlayWithoutRequestingAnotherRecovery() = runTest {
+        ready.value = false
+        var recoveries = 0
+        val queue = LocalCommandQueue(ready, ::record, backgroundScope) { recoveries++ }
+        queue.sendOrQueue(PlayerAction.Play, request("play"))
+        queue.sendOrQueue(PlayerAction.Pause, request("pause"))
+        assertEquals(1, recoveries)
+        ready.value = true
+        settle()
+        assertEquals(listOf("pause"), sent)
+    }
+
+    @Test
+    fun unrelatedOfflineCommandsDoNotWakeTheMaSession() = runTest {
+        ready.value = false
+        var recoveries = 0
+        val queue = LocalCommandQueue(ready, ::record, backgroundScope) { recoveries++ }
+        queue.sendOrQueue(PlayerAction.Pause, request("pause"))
+        queue.sendOrQueue(PlayerAction.SeekTo(10), request("seek"))
+        settle()
+        assertEquals(0, recoveries)
+        assertEquals(emptyList(), sent)
+    }
 
     @Test
     fun commandQueuedDuringAnMaOnlyOutageIsSentOnceWhenReadinessReturns() = runTest {


### PR DESCRIPTION
Closes #978

## Is there anything about the code changes here that should be highlighted?

Based on #975 (`sendspin-rewrite`, bcff77171adecc24635ccb35fd34b9bf4f0f80f9). Please review/merge after that dependency and retarget to main when appropriate.

The new Sendspin player can reconnect independently, but local Play still travels through the MA command connection. When that connection is background-disconnected, LocalCommandQueue waits for readiness without requesting recovery. A stale connection can also report its drop on the first Play send, while confirmed playback is still inactive.

An explicit local Play now requests the existing MA readiness/recovery path before either queueing or sending. Both background teardown guards recognize a ten-second, monotonic recovery grace period. The grace period expires without a persistent keepalive and is cleared on logout, user disconnect or removal of the server. Confirmed playback continues to use the existing playback-active guard.

Local UI toggles resolve to explicit Play/Pause, including Pause while Play is pending. Offline Play shows the existing bounded pending indicator, allowing the user to cancel queued Play through the existing queue deduplication.

Validation:
- `./gradlew detektAll checkTestNames testAndroidHostTest :androidApp:testDebug :composeApp:compileKotlinIosSimulatorArm64 :composeApp:compileTestKotlinIosSimulatorArm64` passed on JDK 21.
- 869 Android host/unit tests passed: composeApp 548, androidApp 124, shared-icons 3, sendspin 194. No failures, errors or skips.
- Eight added regressions cover cold recovery without foreground/Sendspin events, stale-ready send ordering, queued Pause superseding Play, unrelated offline commands, grace-period expiry/renewal and clearing it on explicit disconnect.
- iOS code and tests compile. iOS simulator execution remains blocked by unfinished local Xcode/CoreSimulator first-launch setup; no physical-device verification yet.

The ten-second bound applies to background recovery permission, not the lifetime of upstream's offline queue. This retains #975's replay/error semantics and relies on its Sendspin reconnection. Please test the full path with both sockets stale, a long background pause, system Play without opening the app, and Pause during recovery. An iOS TestFlight build would let the reporter verify iOS 26.6.1 / MA 2.10.2, including AirPods separately.

## Are there any additional changes not related to the issue above?

None. The patch is limited to MA command recovery and local Play intent on top of #975.

## Before submitting this PR, make sure you have:

- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

Draft pending iOS device validation. The current CI workflows target PRs to main, so retargeting this PR to sendspin-rewrite may not trigger those workflows; local checks are listed above.
