### PR TITLE
Log once per session if we get an ATS error

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.android.kt
@@ -1,0 +1,5 @@
+package io.music_assistant.client.imageloader
+
+import coil3.EventListener
+
+internal actual fun createAtsBlockedImageEventListener(): EventListener = object : EventListener() {}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/imageloader/AppImageLoader.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/imageloader/AppImageLoader.kt
@@ -32,6 +32,7 @@ internal fun buildAppImageLoader(
             webrtcFetcherFactory?.let { add(it) }
             add(SvgDecoder.Factory())
         }
+        .eventListenerFactory { createAtsBlockedImageEventListener() }
         .build()
 
 internal expect fun imageDiskCacheDir(context: PlatformContext): Path

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.kt
@@ -1,0 +1,5 @@
+package io.music_assistant.client.imageloader
+
+import coil3.EventListener
+
+internal expect fun createAtsBlockedImageEventListener(): EventListener

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnostic.ios.kt
@@ -1,0 +1,36 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.music_assistant.client.imageloader
+
+import co.touchlab.kermit.Logger
+import coil3.EventListener
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import io.ktor.client.engine.darwin.DarwinHttpRequestException
+import kotlinx.atomicfu.atomic
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSURLErrorAppTransportSecurityRequiresSecureConnection
+import platform.Foundation.NSURLErrorDomain
+
+// Process-wide so recreating the image loader does not repeat the warning.
+private val hasReportedAtsBlock = atomic(false)
+private val logger = Logger.withTag("ImageLoader")
+private const val MAX_CAUSE_DEPTH = 8
+
+internal actual fun createAtsBlockedImageEventListener(): EventListener = object : EventListener() {
+    override fun onError(request: ImageRequest, result: ErrorResult) {
+        if (isAtsBlockedImageError(result.throwable) && hasReportedAtsBlock.compareAndSet(false, true)) {
+            logger.w {
+                "An image request was blocked by iOS App Transport Security (ATS). " +
+                    "Check the image server's HTTPS configuration or the app's ATS exceptions."
+            }
+        }
+    }
+}
+
+internal fun isAtsBlockedImageError(error: Throwable): Boolean =
+    generateSequence(error) { it.cause }.take(MAX_CAUSE_DEPTH).any {
+        val nativeError = (it as? DarwinHttpRequestException)?.origin
+        nativeError?.domain == NSURLErrorDomain &&
+            nativeError?.code == NSURLErrorAppTransportSecurityRequiresSecureConnection
+    }

--- a/composeApp/src/iosTest/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnosticIosTest.kt
+++ b/composeApp/src/iosTest/kotlin/io/music_assistant/client/imageloader/AtsBlockedImageDiagnosticIosTest.kt
@@ -1,0 +1,30 @@
+package io.music_assistant.client.imageloader
+
+import io.ktor.client.engine.darwin.DarwinHttpRequestException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import platform.Foundation.NSError
+
+class AtsBlockedImageDiagnosticIosTest {
+    @Test
+    fun detects_ats_in_native_error_and_kotlin_cause() {
+        val error = DarwinHttpRequestException(
+            NSError(domain = "NSURLErrorDomain", code = -1022, userInfo = emptyMap<Any?, Any?>()),
+        )
+
+        assertTrue(isAtsBlockedImageError(error))
+        assertTrue(isAtsBlockedImageError(Exception("Image failed", error)))
+    }
+
+    @Test
+    fun rejects_other_errors() {
+        assertFalse(isAtsBlockedImageError(Exception("Image failed")))
+        for ((domain, code) in listOf("NSURLErrorDomain" to -1003L, "OtherDomain" to -1022L)) {
+            val error = DarwinHttpRequestException(
+                NSError(domain = domain, code = code, userInfo = emptyMap<Any?, Any?>()),
+            )
+            assertFalse(isAtsBlockedImageError(error))
+        }
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -54,6 +54,33 @@
 	<array>
 		<string>_ma-preflight._tcp</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<!-- Allow user-managed LAN servers, including unqualified and .local names.
+		     Keep ATS enabled for public hosts; do not enable arbitrary loads. -->
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<!-- IP/CIDR exception matching is supported on iOS 17 and later.
+			     RFC 1918 private networks only. -->
+			<key>10.0.0.0/8</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>172.16.0.0/12</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>192.168.0.0/16</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Music Assistant can optionally use the camera to scan a QR code when you set up a remote connection. You can also enter the connection details manually instead.</string>
 	<key>NSLocalNetworkUsageDescription</key>


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

This will help diagnose if missing images are due to ATS or not without overwhelming the logs with a line per broken image.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`