### PR TITLE
Fix android auto isolation test flake

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -124,5 +124,6 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.ktor.client.json)
     testImplementation(libs.koin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.compose.components.resources)
 }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
@@ -80,6 +80,9 @@ private val SESSION_TRANSPORT_ACTIONS: Long =
         PlaybackStateCompat.ACTION_PLAY_FROM_MEDIA_ID or
         PlaybackStateCompat.ACTION_PLAY_FROM_SEARCH
 
+// Give Sendspin time to start without briefly blocking and rebuilding the car session.
+internal const val SESSION_BLOCK_DEBOUNCE_MS = 1500L
+
 /**
  * Single source of truth for the app's MediaSession **and** its sole writer.
  *
@@ -97,15 +100,11 @@ class SharedMediaSessionManager(
     private val applicationContext: Context,
     private val dataSource: MainDataSource,
     private val carConnection: CarConnectionMonitor,
+    private val managerScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
 ) {
     private var mediaSession: MediaSessionCompat? = null
     private var writerScope: CoroutineScope? = null
     private var refCount = 0
-
-    // Outlives the ref-counted [writerScope]: the AA-connected and blocked signals must be
-    // readable before the first [acquire] and after the last [release]. This manager is a
-    // Koin singleton, so the scope is never cancelled.
-    private val managerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     // Localized labels, resolved once before the writer collectors start (see
     // [startWriter]). The synchronous writers read these; null only in the brief
@@ -683,10 +682,4 @@ class SharedMediaSessionManager(
         } else {
             R.drawable.baseline_arrow_right_alt_24
         }
-
-    private companion object {
-        // Sendspin needs a moment to come up after the car connects. Without this window the
-        // block state flashes on every connect, tearing down and rebuilding the session.
-        const val SESSION_BLOCK_DEBOUNCE_MS = 1500L
-    }
 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/feature/AndroidAutoSessionIsolationTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/feature/AndroidAutoSessionIsolationTest.kt
@@ -1,83 +1,107 @@
 package io.music_assistant.client.feature
 
 import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.music_assistant.client.data.CarConnectionMonitor
+import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.services.SESSION_BLOCK_DEBOUNCE_MS
 import io.music_assistant.client.services.SharedMediaSessionManager
 import io.music_assistant.client.support.rules.createTestRuleChain
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.koin.java.KoinJavaComponent.inject
 
-/**
- * Regression cover for the Android Auto isolation rule: while a car host owns the session
- * and there is no local player, the session must present nothing. Before this, the session
- * kept publishing the canonical all-players now-playing, so the car showed and controlled a
- * remote player.
- */
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class AndroidAutoSessionIsolationTest {
     @get:Rule
     val testRuleChain = createTestRuleChain()
 
-    private val sharedSession: SharedMediaSessionManager by inject(
-        SharedMediaSessionManager::class.java,
-    )
+    private val dataSource: MainDataSource by inject(MainDataSource::class.java)
+    private val managerDispatcher = StandardTestDispatcher()
+    private val carConnection = object : CarConnectionMonitor {
+        override val connected = MutableStateFlow(false)
+    }
+    private val managerScope = TestScope(managerDispatcher)
+    private lateinit var sharedSession: SharedMediaSessionManager
 
     private val noOpHandler = object : SharedMediaSessionManager.AutoPlayHandler {
         override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) = Unit
         override fun onPlayFromSearch(query: String?, extras: Bundle?) = Unit
     }
 
+    @Before
+    fun setUp() {
+        sharedSession = SharedMediaSessionManager(
+            ApplicationProvider.getApplicationContext(),
+            dataSource,
+            carConnection,
+            managerScope,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        if (::sharedSession.isInitialized) {
+            sharedSession.unbindAutoHost()
+        }
+        managerScope.cancel()
+    }
+
     @Test
-    fun `no car host means no isolation and no block`() {
+    fun `no car host means no isolation and no block`() = runTest(managerDispatcher) {
+        runCurrent()
         assertFalse(sharedSession.autoHostActive.value)
         assertFalse(sharedSession.sessionBlocked.value)
     }
 
     @Test
-    fun `binding a car host with no local player blocks the session`() {
-        sharedSession.bindAutoHost(noOpHandler, isProjectionHost = true)
-        assertTrue(sharedSession.autoHostActive.value)
+    fun `binding a car host with no local player blocks the session`() =
+        runTest(managerDispatcher) {
+            runCurrent()
+            sharedSession.bindAutoHost(noOpHandler, isProjectionHost = true)
+            assertTrue(sharedSession.autoHostActive.value)
 
-        awaitBlocked(expected = true)
+            awaitBlocked(expected = true)
 
-        sharedSession.unbindAutoHost()
-        assertFalse(sharedSession.autoHostActive.value)
-        awaitBlocked(expected = false)
-    }
-
-    /**
-     * A generic media binder — Assistant, Gemini, Wear, or the app's own
-     * VoicePlayDispatchActivity — registers a play handler but must never isolate the session.
-     * It used to, which deactivated the session and blanked the phone notification for a remote
-     * player on every voice attempt.
-     */
-    @Test
-    fun `binding a non-projection host never isolates or blocks the session`() {
-        sharedSession.bindAutoHost(noOpHandler, isProjectionHost = false)
-        assertFalse(sharedSession.autoHostActive.value)
-
-        awaitBlocked(expected = false)
-
-        sharedSession.unbindAutoHost()
-        assertFalse(sharedSession.autoHostActive.value)
-    }
-
-    // The blocked flow is debounced to ride out Sendspin bootstrap, so poll rather than
-    // read once. The wait is generous enough to stay stable on a loaded CI machine.
-    private fun awaitBlocked(expected: Boolean) = runBlocking {
-        withTimeout(AWAIT_TIMEOUT_MS) {
-            sharedSession.sessionBlocked.first { it == expected }
+            sharedSession.unbindAutoHost()
+            assertFalse(sharedSession.autoHostActive.value)
+            awaitBlocked(expected = false)
         }
-    }
 
-    private companion object {
-        const val AWAIT_TIMEOUT_MS = 10_000L
+    @Test
+    fun `binding a non-projection host never isolates or blocks the session`() =
+        runTest(managerDispatcher) {
+            runCurrent()
+            sharedSession.bindAutoHost(noOpHandler, isProjectionHost = false)
+            assertFalse(sharedSession.autoHostActive.value)
+
+            awaitBlocked(expected = false)
+
+            sharedSession.unbindAutoHost()
+            assertFalse(sharedSession.autoHostActive.value)
+        }
+
+    private fun awaitBlocked(expected: Boolean) {
+        managerScope.testScheduler.advanceTimeBy(SESSION_BLOCK_DEBOUNCE_MS)
+        managerScope.testScheduler.runCurrent()
+        if (expected) {
+            assertTrue(sharedSession.sessionBlocked.value)
+        } else {
+            assertFalse(sharedSession.sessionBlocked.value)
+        }
     }
 }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Found a new test that flakes in CI: https://github.com/music-assistant/mobile-app/actions/runs/34198504380 

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

