### PR TITLE
Fix occasionaly audio glitches in iOS

### DIFF
--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -238,8 +238,18 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
         do {
             let pcmData = try decoder.decode(swiftData)
+            let bytesPerSample = currentCodec == "flac" || currentBitDepth == 24
+                ? 4
+                : Int(currentBitDepth / 8)
+            let bytesPerFrame = max(1, Int(currentChannels) * bytesPerSample)
+
+            let pcmChunks = PCMChunker.split(
+                pcmData,
+                frameSize: bytesPerFrame,
+                capacity: Int(kBufferSize)
+            )
             bufferLock.lock()
-            pcmBuffer.append(pcmData)
+            pcmBuffer.append(contentsOf: pcmChunks)
             bufferLock.unlock()
         } catch {
             logDebug("Decode error: \(error)")

--- a/iosApp/PCMChunker.swift
+++ b/iosApp/PCMChunker.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Splits interleaved PCM into chunks that fit an AudioQueue buffer.
+///
+/// Expects whole-frame input; a short tail chunk is emitted as-is, not truncated.
+enum PCMChunker {
+    static func split(_ data: Data, frameSize: Int, capacity: Int) -> [Data] {
+        precondition(frameSize > 0)
+        precondition(capacity >= frameSize)
+
+        guard !data.isEmpty else { return [] }
+
+        let chunkCapacity = capacity - (capacity % frameSize)
+        var chunks: [Data] = []
+        chunks.reserveCapacity((data.count + chunkCapacity - 1) / chunkCapacity)
+
+        var offset = 0
+        while offset < data.count {
+            let length = min(chunkCapacity, data.count - offset)
+            chunks.append(data.subdata(in: offset..<(offset + length)))
+            offset += length
+        }
+        return chunks
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */; };
+		C29F123E61DAA17B671EC956 /* PCMChunker.swift in iosAppTests Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1992F18C88B00185678 /* PCMChunker.swift */; };
+		C29F123E61DAA17B671EC958 /* PCMChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */; };
+		C29F123E61DAA17B671EC957 /* PCMChunker.swift in iosApp Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1992F18C88B00185678 /* PCMChunker.swift */; };
 		C85119262F18C7A900185678 /* Copus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119252F18C7A900185678 /* Copus */; };
 		C85119282F18C7A900185678 /* Opus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119272F18C7A900185678 /* Opus */; };
 		C851192B2F18C88B00185678 /* FLAC in Frameworks */ = {isa = PBXBuildFile; productRef = C851192A2F18C88B00185678 /* FLAC */; };
@@ -51,6 +54,8 @@
 		C8FCC1982F17E001005E8312 /* AudioDecoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDecoders.swift; sourceTree = "<group>"; };
 		C8SI00022F1B000000000001 /* SiriIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriIntentHandler.swift; sourceTree = "<group>"; };
 		E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoStore.swift; sourceTree = "<group>"; };
+		C8FCC1992F18C88B00185678 /* PCMChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunker.swift; sourceTree = "<group>"; };
+		C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunkerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */,
+				C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */,
 			);
 			path = iosAppTests;
 			sourceTree = "<group>";
@@ -113,6 +119,7 @@
 				7555FF7C242A565900829871 /* Products */,
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
 				E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */,
+				C8FCC1992F18C88B00185678 /* PCMChunker.swift */,
 				6697875A889242950A65544F /* iosAppTests */,
 			);
 			sourceTree = "<group>";
@@ -298,6 +305,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */,
+				C29F123E61DAA17B671EC958 /* PCMChunkerTests.swift in Sources */,
+				C29F123E61DAA17B671EC956 /* PCMChunker.swift in iosAppTests Sources */,
 				6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -310,6 +319,7 @@
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				C8FCC1922F17C6A9005E8312 /* NowPlayingCoordinator.swift in Sources */,
 				C8FCC1952F17E001005E8312 /* NativeAudioController.swift in Sources */,
+				C29F123E61DAA17B671EC957 /* PCMChunker.swift in iosApp Sources */,
 				C8OA00022F1B000000000002 /* OAuthWebSession.swift in Sources */,
 				C8OA00022F1B000000000004 /* LocalNetworkProbe.swift in Sources */,
 				C8FCC1972F17E001005E8312 /* AudioDecoders.swift in Sources */,

--- a/iosApp/iosAppTests/PCMChunkerTests.swift
+++ b/iosApp/iosAppTests/PCMChunkerTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+final class PCMChunkerTests: XCTestCase {
+    func testEmptyInputProducesNoChunks() {
+        XCTAssertEqual(
+            PCMChunker.split(Data(), frameSize: 8, capacity: 64),
+            []
+        )
+    }
+
+    func testInputWithinCapacityRemainsOneChunk() {
+        let input = Data(0..<32)
+
+        let chunks = PCMChunker.split(input, frameSize: 8, capacity: 64)
+
+        XCTAssertEqual(chunks, [input])
+    }
+
+    func testExactCapacityRemainsOneChunk() {
+        let input = Data(0..<64)
+
+        let chunks = PCMChunker.split(input, frameSize: 8, capacity: 64)
+
+        XCTAssertEqual(chunks, [input])
+    }
+
+    func testOversizedInputPreservesAllBytesInFrameAlignedChunks() {
+        let input = Data((0..<200).map { UInt8($0) })
+
+        let chunks = PCMChunker.split(input, frameSize: 8, capacity: 64)
+
+        XCTAssertEqual(chunks.map(\.count), [64, 64, 64, 8])
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 64 && $0.count % 8 == 0 })
+        XCTAssertEqual(chunks.reduce(into: Data()) { $0.append($1) }, input)
+    }
+
+    func testCapacityIsReducedToTheLargestWholeFrame() {
+        let input = Data((0..<42).map { UInt8($0) })
+
+        let chunks = PCMChunker.split(input, frameSize: 6, capacity: 10)
+
+        XCTAssertEqual(chunks.map(\.count), [6, 6, 6, 6, 6, 6, 6])
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 10 && $0.count % 6 == 0 })
+        XCTAssertEqual(chunks.reduce(into: Data()) { $0.append($1) }, input)
+    }
+
+    func testRealisticOversizedPcmBlockPreservesEveryByte() {
+        let input = Data(repeating: 0xA5, count: 368_640)
+
+        let chunks = PCMChunker.split(input, frameSize: 8, capacity: 65_536)
+
+        XCTAssertEqual(chunks.map(\.count), [65_536, 65_536, 65_536, 65_536, 65_536, 40_960])
+        XCTAssertEqual(chunks.reduce(0) { $0 + $1.count }, input.count)
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 65_536 && $0.count % 8 == 0 })
+    }
+}


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

We had a latent bug where we'd truncate PCM blocks over 64KB in iOS. We just rarely/never handed the native audio controller oversized chunks. The incipient sendspin rewrite changed the batching so we ended up truncating audio quite a bit more often. Now we chunk anything over-sized to fit.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

