### PR TITLE
Favourite the song on air from a radio stream (Android Auto + player)

### DIFF
--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
@@ -1,6 +1,7 @@
 package io.music_assistant.client.services
 
 import android.os.SystemClock
+import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.RepeatMode
@@ -27,6 +28,9 @@ data class MediaNotificationData(
     // Current item is a favoritable track: a favorite toggle competes for a slot
     // (see sessionActions for the slot rule).
     val isFavoritableTrack: Boolean,
+    // Current item is a radio stream with a real song on air: same slot competition
+    // as isFavoritableTrack, but the action always adds (see getFavoriteIcon).
+    val isFavoritableStream: Boolean,
     val isFavorite: Boolean,
     val isPlaying: Boolean,
     val imageUrl: String?,
@@ -61,6 +65,7 @@ data class MediaNotificationData(
             currentChapter: ResolvedChapter? = null,
         ) = run {
             val currentTrack = playerData.queueInfo?.currentItem?.track as? AppMediaItem
+            val isFavoritableStream = playerData.hasFavoritableStreamTrack()
             MediaNotificationData(
             multiplePlayers = multiplePlayers,
             longItemId = playerData.player.currentMedia?.hashCode()?.toLong(),
@@ -74,7 +79,11 @@ data class MediaNotificationData(
             isLongFormContent = playerData.queueInfo?.currentItem?.track.isLongFormSpokenContent,
             isFavoritableTrack = currentTrack
                 ?.let { it.mediaType == MediaType.TRACK && it.canBeFavorited } == true,
-            isFavorite = currentTrack?.favorite == true,
+            isFavoritableStream = isFavoritableStream,
+            // The station's own favorite flag would show a filled heart for an already-
+            // favorited station even though nothing has been favorited for the on-air song,
+            // so the stream case always renders un-filled.
+            isFavorite = currentTrack?.favorite == true && !isFavoritableStream,
             isPlaying = playerData.player.isPlaying,
             imageUrl = playerData.player.currentMedia?.imageUrl,
             chapterName = currentChapter?.displayName,

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaNotificationData.kt
@@ -1,7 +1,6 @@
 package io.music_assistant.client.services
 
 import android.os.SystemClock
-import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.RepeatMode
@@ -63,9 +62,11 @@ data class MediaNotificationData(
             multiplePlayers: Boolean,
             effectiveElapsedSec: Double?,
             currentChapter: ResolvedChapter? = null,
+            // Real on-air stream song AND the connected server can resolve it — see
+            // MainDataSource.canFavoriteCurrentlyPlaying, the single source for this.
+            isFavoritableStream: Boolean = false,
         ) = run {
             val currentTrack = playerData.queueInfo?.currentItem?.track as? AppMediaItem
-            val isFavoritableStream = playerData.hasFavoritableStreamTrack()
             MediaNotificationData(
             multiplePlayers = multiplePlayers,
             longItemId = playerData.player.currentMedia?.hashCode()?.toLong(),

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaSessionActions.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/MediaSessionActions.kt
@@ -51,7 +51,7 @@ internal fun sessionActions(data: MediaNotificationData): List<SessionAction> = 
 }.take(SLOT_COUNT)
 
 private fun MediaNotificationData.supports(action: SessionAction) = when (action) {
-    SessionAction.FAVORITE -> isFavoritableTrack
+    SessionAction.FAVORITE -> isFavoritableTrack || isFavoritableStream
     SessionAction.SHUFFLE -> shuffleEnabled != null
     SessionAction.REPEAT -> repeatMode != null
     SessionAction.SWITCH_PLAYER -> multiplePlayers

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
@@ -23,6 +23,7 @@ import io.music_assistant.client.auto.toMediaDescription
 import io.music_assistant.client.auto.toUri
 import io.music_assistant.client.data.CarConnectionMonitor
 import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.RepeatMode
@@ -434,10 +435,15 @@ class SharedMediaSessionManager(
                         }
                     }
 
-                    "ACTION_TOGGLE_FAVORITE" ->
-                        (currentPlayer()?.queueInfo?.currentItem?.track as? AppMediaItem)
+                    "ACTION_TOGGLE_FAVORITE" -> {
+                        val pd = currentPlayer()
+                        (pd?.queueInfo?.currentItem?.track as? AppMediaItem)
                             ?.takeIf { it.mediaType == MediaType.TRACK && it.canBeFavorited }
                             ?.let { dataSource.toggleFavorite(it) }
+                            // Radio: no track to toggle, just the stream's on-air song to add.
+                            ?: pd?.takeIf { it.hasFavoritableStreamTrack() }
+                                ?.let { dataSource.favoriteCurrentlyPlaying(it) }
+                    }
                 }
             }
         }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
@@ -23,7 +23,6 @@ import io.music_assistant.client.auto.toMediaDescription
 import io.music_assistant.client.auto.toUri
 import io.music_assistant.client.data.CarConnectionMonitor
 import io.music_assistant.client.data.MainDataSource
-import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.RepeatMode
@@ -365,6 +364,7 @@ class SharedMediaSessionManager(
                     multiplePlayers = multiplePlayers,
                     effectiveElapsedSec = elapsedSec,
                     currentChapter = chapter,
+                    isFavoritableStream = dataSource.canFavoriteCurrentlyPlaying(player),
                 )
             }
             .distinctUntilChanged { old, new -> MediaNotificationData.areTooSimilarToUpdate(old, new) }
@@ -441,7 +441,7 @@ class SharedMediaSessionManager(
                             ?.takeIf { it.mediaType == MediaType.TRACK && it.canBeFavorited }
                             ?.let { dataSource.toggleFavorite(it) }
                             // Radio: no track to toggle, just the stream's on-air song to add.
-                            ?: pd?.takeIf { it.hasFavoritableStreamTrack() }
+                            ?: pd?.takeIf { dataSource.canFavoriteCurrentlyPlaying(it) }
                                 ?.let { dataSource.favoriteCurrentlyPlaying(it) }
                     }
                 }

--- a/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
+++ b/androidApp/src/main/kotlin/io/music_assistant/client/services/SharedMediaSessionManager.kt
@@ -440,8 +440,9 @@ class SharedMediaSessionManager(
                         (pd?.queueInfo?.currentItem?.track as? AppMediaItem)
                             ?.takeIf { it.mediaType == MediaType.TRACK && it.canBeFavorited }
                             ?.let { dataSource.toggleFavorite(it) }
-                            // Radio: no track to toggle, just the stream's on-air song to add.
-                            ?: pd?.takeIf { dataSource.canFavoriteCurrentlyPlaying(it) }
+                            // Radio: no track to toggle, just the stream's on-air song to add
+                            // (favoriteCurrentlyPlaying guards support and metadata itself).
+                            ?: pd
                                 ?.let { dataSource.favoriteCurrentlyPlaying(it) }
                     }
                 }

--- a/androidApp/src/test/kotlin/io/music_assistant/client/services/MediaSessionActionsTest.kt
+++ b/androidApp/src/test/kotlin/io/music_assistant/client/services/MediaSessionActionsTest.kt
@@ -115,6 +115,38 @@ class MediaSessionActionsTest {
         }
     }
 
+    @Test
+    fun `stream favorite wins the same slot as track favorite`() {
+        assertEquals(
+            listOf(SessionAction.SWITCH_PLAYER, SessionAction.FAVORITE),
+            sessionActions(
+                data(
+                    multiplePlayers = true,
+                    isFavoritableTrack = false,
+                    isFavoritableStream = true,
+                ),
+            ),
+        )
+        assertEquals(
+            listOf(SessionAction.SHUFFLE, SessionAction.FAVORITE),
+            sessionActions(data(isFavoritableTrack = false, isFavoritableStream = true)),
+        )
+    }
+
+    @Test
+    fun `no favorite slot when neither track nor stream is favoritable`() {
+        assertEquals(
+            listOf(SessionAction.SWITCH_PLAYER, SessionAction.SHUFFLE),
+            sessionActions(
+                data(
+                    multiplePlayers = true,
+                    isFavoritableTrack = false,
+                    isFavoritableStream = false,
+                ),
+            ),
+        )
+    }
+
     /**
      * Mirrors the gates in [MediaNotificationData.from]: a dynamic playlist nulls both
      * queue toggles because the server does not accept them there.
@@ -124,6 +156,7 @@ class MediaSessionActionsTest {
         isDynamic: Boolean = false,
         isFavoritableTrack: Boolean = true,
         isLongFormContent: Boolean = false,
+        isFavoritableStream: Boolean = false,
     ) = MediaNotificationData(
         multiplePlayers = multiplePlayers,
         longItemId = null,
@@ -134,6 +167,7 @@ class MediaSessionActionsTest {
         shuffleEnabled = false.takeIf { !isDynamic },
         isLongFormContent = isLongFormContent,
         isFavoritableTrack = isFavoritableTrack,
+        isFavoritableStream = isFavoritableStream,
         isFavorite = false,
         isPlaying = true,
         imageUrl = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/APICommands.kt
@@ -14,6 +14,7 @@ object APICommands {
     const val PLAYERS_CMD_UNGROUP = "$PLAYERS_CMD/ungroup"
     const val PLAYERS_SLEEP_TIMER_SET = "players/sleep_timer/set"
     const val PLAYERS_SLEEP_TIMER_CLEAR = "players/sleep_timer/clear"
+    const val PLAYERS_ADD_CURRENTLY_PLAYING_TO_FAVORITES = "players/add_currently_playing_to_favorites"
 
     // Player Queue commands
     const val PLAYER_QUEUES_ALL = "player_queues/all"

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/api/Request.kt
@@ -173,6 +173,19 @@ data class Request @OptIn(ExperimentalUuidApi::class) constructor(
                 put("player_id", JsonPrimitive(playerId))
             },
         )
+
+        /**
+         * Resolves [playerId]'s current on-air stream title to a library item and
+         * favourites it. Add-only: the queue's `favorite` flag belongs to the station,
+         * not the song, so there is no matching "remove" call. Raises server-side when
+         * the player has no stream title or the title can't be resolved to an item.
+         */
+        fun addCurrentlyPlayingToFavorites(playerId: String) = Request(
+            command = APICommands.PLAYERS_ADD_CURRENTLY_PLAYING_TO_FAVORITES,
+            args = buildJsonObject {
+                put("player_id", JsonPrimitive(playerId))
+            },
+        )
     }
 
     data object Queue {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -44,6 +44,7 @@ import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueTimeUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
 import io.music_assistant.client.data.model.server.grantsScope
+import io.music_assistant.client.data.model.server.supportsFavoriteCurrentlyPlaying
 import io.music_assistant.client.player.MediaPlayerController
 import io.music_assistant.client.player.sendspin.model.GoodbyeReason
 import io.music_assistant.client.settings.SettingsRepository
@@ -908,6 +909,30 @@ class MainDataSource(
                 )
             }
             result.onFailure { setFavoriteOverride(item, item.favorite) }
+        }
+    }
+
+    /**
+     * Favourites the song currently on air on [playerData]'s radio stream. Unlike
+     * [toggleFavorite], this always adds: the queue payload's `favorite` flag belongs
+     * to the station, not the on-air song, so there is no truthful "already
+     * favourited" state to toggle from. No optimistic override — the server resolves
+     * the favourited item from the stream title, not from the queue item, so there is
+     * nothing local to flip ahead of the round trip.
+     */
+    fun favoriteCurrentlyPlaying(playerData: PlayerData) {
+        launch {
+            val schemaVersion =
+                (apiClient.sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion
+            if (!supportsFavoriteCurrentlyPlaying(schemaVersion)) {
+                log.w { "Server schema $schemaVersion predates add_currently_playing_to_favorites" }
+                return@launch
+            }
+            apiClient.sendRequest(
+                Request.Player.addCurrentlyPlayingToFavorites(playerData.player.id),
+            ).onFailure {
+                log.e(it) { "Failed to favorite currently playing for ${playerData.player.id}" }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -44,7 +44,6 @@ import io.music_assistant.client.data.model.server.events.QueueItemsUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueTimeUpdatedEvent
 import io.music_assistant.client.data.model.server.events.QueueUpdatedEvent
 import io.music_assistant.client.data.model.server.grantsScope
-import io.music_assistant.client.data.model.server.supportsFavoriteCurrentlyPlaying
 import io.music_assistant.client.player.MediaPlayerController
 import io.music_assistant.client.player.sendspin.model.GoodbyeReason
 import io.music_assistant.client.settings.SettingsRepository
@@ -913,26 +912,31 @@ class MainDataSource(
     }
 
     /**
+     * True when [playerData] has a real on-air stream song the connected server can
+     * resolve to a favouritable item. Gates the stream-favourite heart on both the
+     * media session and the in-app player, and guards [favoriteCurrentlyPlaying].
+     */
+    fun canFavoriteCurrentlyPlaying(playerData: PlayerData): Boolean =
+        playerData.canFavoriteCurrentlyPlaying(
+            (apiClient.sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion,
+        )
+
+    /**
      * Favourites the song currently on air on [playerData]'s radio stream. Unlike
      * [toggleFavorite], this always adds: the queue payload's `favorite` flag belongs
      * to the station, not the on-air song, so there is no truthful "already
      * favourited" state to toggle from. No optimistic override — the server resolves
      * the favourited item from the stream title, not from the queue item, so there is
-     * nothing local to flip ahead of the round trip.
+     * nothing local to flip ahead of the round trip. A server that can't resolve the
+     * title (no title / not in any library) is an expected refusal, not an error —
+     * same silent convention as [toggleFavorite]'s onFailure.
      */
     fun favoriteCurrentlyPlaying(playerData: PlayerData) {
+        if (!canFavoriteCurrentlyPlaying(playerData)) return
         launch {
-            val schemaVersion =
-                (apiClient.sessionState.value as? HasConnectionData)?.serverInfo?.schemaVersion
-            if (!supportsFavoriteCurrentlyPlaying(schemaVersion)) {
-                log.w { "Server schema $schemaVersion predates add_currently_playing_to_favorites" }
-                return@launch
-            }
             apiClient.sendRequest(
                 Request.Player.addCurrentlyPlayingToFavorites(playerData.player.id),
-            ).onFailure {
-                log.e(it) { "Failed to favorite currently playing for ${playerData.player.id}" }
-            }
+            )
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/MainDataSource.kt
@@ -927,9 +927,9 @@ class MainDataSource(
      * to the station, not the on-air song, so there is no truthful "already
      * favourited" state to toggle from. No optimistic override — the server resolves
      * the favourited item from the stream title, not from the queue item, so there is
-     * nothing local to flip ahead of the round trip. A server that can't resolve the
-     * title (no title / not in any library) is an expected refusal, not an error —
-     * same silent convention as [toggleFavorite]'s onFailure.
+     * nothing local to flip ahead of the round trip. An unsupported server or an
+     * unresolvable title is an expected refusal, not an error — silent, like
+     * [toggleFavorite]'s onFailure.
      */
     fun favoriteCurrentlyPlaying(playerData: PlayerData) {
         if (!canFavoriteCurrentlyPlaying(playerData)) return

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -10,6 +10,7 @@ import io.music_assistant.client.data.model.client.items.PlayableItem
 import io.music_assistant.client.data.model.client.items.image
 import io.music_assistant.client.data.model.client.items.isLongFormSpokenContent
 import io.music_assistant.client.data.model.client.navigationChapters
+import io.music_assistant.client.data.model.server.supportsFavoriteCurrentlyPlaying
 import io.music_assistant.client.utils.monotonicMs
 import kotlin.math.abs
 
@@ -162,6 +163,10 @@ fun PlayerData.hasFavoritableStreamTrack(): Boolean {
     val currentItem = queueInfo?.currentItem ?: return false
     return radioStreamTitle(this, currentItem) != null
 }
+
+/** [hasFavoritableStreamTrack] AND the connected server can resolve it (schema >= 27). */
+fun PlayerData.canFavoriteCurrentlyPlaying(schemaVersion: Int?): Boolean =
+    hasFavoritableStreamTrack() && supportsFavoriteCurrentlyPlaying(schemaVersion)
 
 /**
  * Maps local state to a transport anchor; [currentChapter] makes elapsed time

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -124,20 +124,43 @@ private fun withRadioStreamMetadata(
     playerData: PlayerData,
     currentItem: QueueTrack,
 ): NowPlayingTrack {
-    if (currentItem.track.mediaType != MediaType.RADIO) return base
-    val media = playerData.player.currentMedia ?: return base
-    // The server always stamps queue_item_id when an MA queue item is current;
-    // media stamped otherwise is not this station's stream.
-    if (media.queueItemId != currentItem.id) return base
-    // A title equal to the station name carries no information (idle streams and
-    // the synthesized pre-play fallback both produce it).
-    val streamTitle = media.title?.takeIf { it.isNotBlank() && it != base.title } ?: return base
+    val streamTitle = radioStreamTitle(playerData, currentItem) ?: return base
+    val media = playerData.player.currentMedia
     return base.copy(
         title = streamTitle,
-        artist = media.artist?.takeIf { it.isNotBlank() },
+        artist = media?.artist?.takeIf { it.isNotBlank() },
         album = base.title,
-        artworkUrl = media.imageUrl ?: base.artworkUrl,
+        artworkUrl = media?.imageUrl ?: base.artworkUrl,
     )
+}
+
+/**
+ * The stream's on-air song title, or null when there is none to show: a static
+ * station display, an idle/pre-play stream, or a `currentMedia` payload stamped for a
+ * different queue item. Shared with [hasFavoritableStreamTrack] so the Now Playing
+ * metadata, the media session and the in-app player all agree on when a radio stream
+ * has a real song playing, for any server or provider.
+ */
+private fun radioStreamTitle(playerData: PlayerData, currentItem: QueueTrack): String? {
+    if (currentItem.track.mediaType != MediaType.RADIO) return null
+    val media = playerData.player.currentMedia ?: return null
+    // The server always stamps queue_item_id when an MA queue item is current;
+    // media stamped otherwise is not this station's stream.
+    if (media.queueItemId != currentItem.id) return null
+    // A title equal to the station name carries no information (idle streams and
+    // the synthesized pre-play fallback both produce it).
+    return media.title?.takeIf { it.isNotBlank() && it != currentItem.track.displayName }
+}
+
+/**
+ * True while [PlayerData]'s current queue item is a radio stream reporting a real
+ * on-air song. This is the only "there is a song to favourite" signal that holds for
+ * every server and provider, so [MainDataSource.favoriteCurrentlyPlaying] is gated on
+ * it rather than on stream-specific metadata.
+ */
+fun PlayerData.hasFavoritableStreamTrack(): Boolean {
+    val currentItem = queueInfo?.currentItem ?: return false
+    return radioStreamTitle(this, currentItem) != null
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/FavoriteCurrentlyPlayingSupport.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/server/FavoriteCurrentlyPlayingSupport.kt
@@ -1,0 +1,7 @@
+package io.music_assistant.client.data.model.server
+
+/** First server API schema with `players/add_currently_playing_to_favorites`. */
+const val FAVORITE_CURRENTLY_PLAYING_MIN_SCHEMA = 27
+
+fun supportsFavoriteCurrentlyPlaying(schemaVersion: Int?): Boolean =
+    schemaVersion != null && schemaVersion >= FAVORITE_CURRENTLY_PLAYING_MIN_SCHEMA

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -6,6 +6,7 @@ import co.touchlab.kermit.Logger
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.api.ServiceClient
 import io.music_assistant.client.data.MainDataSource
+import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.QueueOption
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Genre
@@ -64,6 +65,9 @@ class ActionsViewModel(
      * Sets exact or toggles favorite status of the item.
      */
     override fun onFavoriteClick(item: AppMediaItem) = dataSource.toggleFavorite(item)
+
+    /** Favourites the on-air song for a radio stream. See [MainDataSource.favoriteCurrentlyPlaying]. */
+    fun onFavoriteStreamClick(playerData: PlayerData) = dataSource.favoriteCurrentlyPlaying(playerData)
 
     override suspend fun getEditablePlaylists(): List<Playlist> =
         mediaItemRepository.fetchMediaItems(Request.Playlist.listLibrary())

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/common/viewmodel/ActionsViewModel.kt
@@ -69,6 +69,9 @@ class ActionsViewModel(
     /** Favourites the on-air song for a radio stream. See [MainDataSource.favoriteCurrentlyPlaying]. */
     fun onFavoriteStreamClick(playerData: PlayerData) = dataSource.favoriteCurrentlyPlaying(playerData)
 
+    /** See [MainDataSource.canFavoriteCurrentlyPlaying]. */
+    fun canFavoriteStream(playerData: PlayerData) = dataSource.canFavoriteCurrentlyPlaying(playerData)
+
     override suspend fun getEditablePlaylists(): List<Playlist> =
         mediaItemRepository.fetchMediaItems(Request.Playlist.listLibrary())
             .getOrNull()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.Player
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
@@ -282,6 +283,7 @@ fun FullPlayerItem(
     colors: PlayerColors,
     playerAction: (PlayerData, PlayerAction) -> Unit,
     onFavoriteClick: (AppMediaItem) -> Unit,
+    onFavoriteStreamClick: (PlayerData) -> Unit = {},
     livePositionFlow: Flow<Double>?,
     bufferedAheadSecFlow: Flow<Double>? = null,
     lyricsAvailable: Boolean = false,
@@ -694,6 +696,20 @@ fun FullPlayerItem(
                         imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                         contentDescription = stringResource(Res.string.cd_favorite),
                         tint = if (isFavorite) favoriteTint else colors.controlTint,
+                    )
+                }
+            } else if (item.hasFavoritableStreamTrack()) {
+                // Radio favourite adds the on-air song to the library; the queue's `favorite`
+                // flag is the station's, not the song's, so there is no "already favourited"
+                // state and the heart always renders un-filled.
+                IconButton(
+                    modifier = Modifier.size(favoriteSlot),
+                    onClick = { onFavoriteStreamClick(item) },
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.FavoriteBorder,
+                        contentDescription = stringResource(Res.string.cd_favorite),
+                        tint = colors.controlTint,
                     )
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayerItems.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import io.music_assistant.client.data.hasFavoritableStreamTrack
 import io.music_assistant.client.data.model.client.Player
 import io.music_assistant.client.data.model.client.PlayerData
 import io.music_assistant.client.data.model.client.PlayerDataFixtures
@@ -284,6 +283,8 @@ fun FullPlayerItem(
     playerAction: (PlayerData, PlayerAction) -> Unit,
     onFavoriteClick: (AppMediaItem) -> Unit,
     onFavoriteStreamClick: (PlayerData) -> Unit = {},
+    // See MainDataSource.canFavoriteCurrentlyPlaying: on-air song AND server support.
+    canFavoriteStream: Boolean = false,
     livePositionFlow: Flow<Double>?,
     bufferedAheadSecFlow: Flow<Double>? = null,
     lyricsAvailable: Boolean = false,
@@ -698,7 +699,7 @@ fun FullPlayerItem(
                         tint = if (isFavorite) favoriteTint else colors.controlTint,
                     )
                 }
-            } else if (item.hasFavoritableStreamTrack()) {
+            } else if (canFavoriteStream) {
                 // Radio favourite adds the on-air song to the library; the queue's `favorite`
                 // flag is the station's, not the song's, so there is no "already favourited"
                 // state and the heart always renders un-filled.

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -339,6 +339,9 @@ fun PlayersPager(
                                 onFavoriteClick = {
                                     actionsViewModel.onFavoriteClick(it)
                                 },
+                                onFavoriteStreamClick = {
+                                    actionsViewModel.onFavoriteStreamClick(it)
+                                },
                                 onClose = onClose,
                                 queueAction = { homeScreenViewModel.queueAction(it) },
                                 allPlayers = playerDataList,
@@ -430,6 +433,7 @@ private fun ExpandedPlayerPage(
     playerAction: (PlayerData, PlayerAction) -> Unit,
     onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
     onFavoriteClick: (AppMediaItem) -> Unit,
+    onFavoriteStreamClick: (PlayerData) -> Unit = {},
     onClose: () -> Unit,
     queueAction: (QueueAction) -> Unit,
     allPlayers: List<PlayerData>,
@@ -618,6 +622,7 @@ private fun ExpandedPlayerPage(
                             colors = colors,
                             playerAction = playerAction,
                             onFavoriteClick = onFavoriteClick,
+                            onFavoriteStreamClick = onFavoriteStreamClick,
                             lyricsAvailable = lyricsAvailable,
                             onLyricsClick = onLyricsClick,
                             onAudioChainClick = onAudioChainClick,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/home/players/PlayersPager.kt
@@ -342,6 +342,7 @@ fun PlayersPager(
                                 onFavoriteStreamClick = {
                                     actionsViewModel.onFavoriteStreamClick(it)
                                 },
+                                canFavoriteStream = actionsViewModel.canFavoriteStream(player),
                                 onClose = onClose,
                                 queueAction = { homeScreenViewModel.queueAction(it) },
                                 allPlayers = playerDataList,
@@ -434,6 +435,7 @@ private fun ExpandedPlayerPage(
     onAddToPlaylist: ((AppMediaItem) -> Unit)? = null,
     onFavoriteClick: (AppMediaItem) -> Unit,
     onFavoriteStreamClick: (PlayerData) -> Unit = {},
+    canFavoriteStream: Boolean = false,
     onClose: () -> Unit,
     queueAction: (QueueAction) -> Unit,
     allPlayers: List<PlayerData>,
@@ -623,6 +625,7 @@ private fun ExpandedPlayerPage(
                             playerAction = playerAction,
                             onFavoriteClick = onFavoriteClick,
                             onFavoriteStreamClick = onFavoriteStreamClick,
+                            canFavoriteStream = canFavoriteStream,
                             lyricsAvailable = lyricsAvailable,
                             onLyricsClick = onLyricsClick,
                             onAudioChainClick = onAudioChainClick,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AddCurrentlyPlayingToFavoritesRequestTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/api/AddCurrentlyPlayingToFavoritesRequestTest.kt
@@ -1,0 +1,17 @@
+package io.music_assistant.client.api
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Pins the wire shape of the radio-favorite command against the server's api_command signature. */
+class AddCurrentlyPlayingToFavoritesRequestTest {
+    @Test
+    fun carriesPlayerIdOnly() {
+        val request = Request.Player.addCurrentlyPlayingToFavorites(playerId = "player-1")
+
+        assertEquals("players/add_currently_playing_to_favorites", request.command)
+        assertEquals(JsonPrimitive("player-1"), request.args?.get("player_id"))
+        assertEquals(setOf("player_id"), request.args?.keys)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -121,24 +121,25 @@ class NowPlayingTrackChannelTest {
     }
 }
 
-class NowPlayingRadioStreamMetadataTest {
-    private fun streamMedia(
-        title: String? = "Song",
-        artist: String? = "Artist",
-        queueItemId: String? = "queue-item-1",
-        imageUrl: String? = null,
-    ) = PlayerMedia(
-        title = title,
-        artist = artist,
-        album = null,
-        imageUrl = imageUrl,
-        duration = null,
-        queueId = "queue-1",
-        queueItemId = queueItemId,
-        mediaType = MediaType.RADIO,
-        uri = null,
-    )
+/** Shared by [NowPlayingRadioStreamMetadataTest] and [PlayerDataHasFavoritableStreamTrackTest]. */
+private fun streamMedia(
+    title: String? = "Song",
+    artist: String? = "Artist",
+    queueItemId: String? = "queue-item-1",
+    imageUrl: String? = null,
+) = PlayerMedia(
+    title = title,
+    artist = artist,
+    album = null,
+    imageUrl = imageUrl,
+    duration = null,
+    queueId = "queue-1",
+    queueItemId = queueItemId,
+    mediaType = MediaType.RADIO,
+    uri = null,
+)
 
+class NowPlayingRadioStreamMetadataTest {
     private fun radioTrack(media: PlayerMedia?): NowPlayingTrack =
         buildNowPlayingTrack(
             playerData(testRadio(), queueInfo(queueId = "queue-1"), currentMedia = media),
@@ -194,6 +195,54 @@ class NowPlayingRadioStreamMetadataTest {
             playerData(testTrack(), queueInfo(queueId = "queue-1"), currentMedia = streamMedia()),
         )!!
         assertEquals("name", built.title)
+    }
+}
+
+/**
+ * Pins [PlayerData.hasFavoritableStreamTrack] against the same fixtures as
+ * [NowPlayingRadioStreamMetadataTest] — it must agree with what the Now Playing
+ * metadata actually renders, since the media session and the in-app player both act
+ * on it for the "favourite the song on air" gesture.
+ */
+class PlayerDataHasFavoritableStreamTrackTest {
+    private fun radioPlayerData(media: PlayerMedia?): PlayerData =
+        playerData(testRadio(), queueInfo(queueId = "queue-1"), currentMedia = media)
+
+    @Test
+    fun radioWithRealTitleIsFavoritable() {
+        assertTrue(radioPlayerData(streamMedia()).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun titleEqualToStationNameIsNotFavoritable() {
+        assertFalse(radioPlayerData(streamMedia(title = "name")).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun blankTitleIsNotFavoritable() {
+        assertFalse(radioPlayerData(streamMedia(title = " ")).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun missingTitleIsNotFavoritable() {
+        assertFalse(radioPlayerData(streamMedia(title = null)).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun queueItemIdMismatchIsNotFavoritable() {
+        val media = streamMedia(queueItemId = "queue-item-other")
+        assertFalse(radioPlayerData(media).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun noCurrentMediaIsNotFavoritable() {
+        assertFalse(radioPlayerData(null).hasFavoritableStreamTrack())
+    }
+
+    @Test
+    fun nonRadioContentIsNotFavoritable() {
+        val data = playerData(testTrack(), queueInfo(queueId = "queue-1"), currentMedia = streamMedia())
+        assertFalse(data.hasFavoritableStreamTrack())
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -244,6 +244,18 @@ class PlayerDataHasFavoritableStreamTrackTest {
         val data = playerData(testTrack(), queueInfo(queueId = "queue-1"), currentMedia = streamMedia())
         assertFalse(data.hasFavoritableStreamTrack())
     }
+
+    // canFavoriteCurrentlyPlaying additionally requires server support (schema >= 27):
+    // a real on-air song is not enough on its own.
+    @Test
+    fun realTitleBelowSchema27IsNotFavoritable() {
+        assertFalse(radioPlayerData(streamMedia()).canFavoriteCurrentlyPlaying(26))
+    }
+
+    @Test
+    fun realTitleAtOrAboveSchema27IsFavoritable() {
+        assertTrue(radioPlayerData(streamMedia()).canFavoriteCurrentlyPlaying(27))
+    }
 }
 
 class NowPlayingTransportDedupTest {

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/FavoriteCurrentlyPlayingSupportTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/server/FavoriteCurrentlyPlayingSupportTest.kt
@@ -1,0 +1,25 @@
+package io.music_assistant.client.data.model.server
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Pins the radio-favorite schema gate against the server's `players/add_currently_playing_to_favorites`. */
+class FavoriteCurrentlyPlayingSupportTest {
+    @Test
+    fun unknownSchemaIsUnsupported() {
+        assertFalse(supportsFavoriteCurrentlyPlaying(null))
+    }
+
+    @Test
+    fun schemaBelowThresholdIsUnsupported() {
+        assertFalse(supportsFavoriteCurrentlyPlaying(20))
+        assertFalse(supportsFavoriteCurrentlyPlaying(26))
+    }
+
+    @Test
+    fun schemaAtOrAboveThresholdIsSupported() {
+        assertTrue(supportsFavoriteCurrentlyPlaying(27))
+        assertTrue(supportsFavoriteCurrentlyPlaying(LOCAL_SCHEMA_VERSION))
+    }
+}


### PR DESCRIPTION
Closes #992

## Is there anything about the code changes here that should be highlighted?

**What it does.** When a radio stream has a real song on air, the favourite action is now offered — in the Android Auto / notification media session and on the in-app player heart — and it calls the server's `players/add_currently_playing_to_favorites` for that player. The server resolves the stream's current title to a library item and favourites *that*, so the listener hearts the song, not the station.

**The "song on air" signal is the one the app already uses to display one.** The inline rule in `NowPlayingChannels.withRadioStreamMetadata` (RADIO item, `currentMedia.queueItemId == currentItem.id`, non-blank title that isn't the station name) is extracted into `radioStreamTitle` / `PlayerData.hasFavoritableStreamTrack()` and shared by Now Playing, the media session and the player UI, so all three agree for any server and provider. No stream-specific metadata is assumed.

**Add-only, un-filled heart.** The queue payload's `favorite` flag belongs to the station, not the on-air song, so there is no truthful "already favourited" state for a stream: the stream case never toggles and always renders the outline heart. Repeated taps are idempotent server-side. Library-track favouriting is untouched — the TRACK branch in `ACTION_TOGGLE_FAVORITE` and `toggleFavorite` are as before.

**Version gate.** The command exists from server schema 27; `supportsFavoriteCurrentlyPlaying(schemaVersion)` follows the existing `EncryptionModeGate` / `LeaderLeaveSupport` pattern and treats an unknown schema as unsupported.

**Unsupported servers and expected refusals stay silent.** The stream ♥ is offered only when there is a song on air *and* the connected server has `players/add_currently_playing_to_favorites` (schema ≥ 27, gated the same way as `EncryptionModeGate` / `LeaderLeaveSupport`); on an older server nothing is shown and nothing is logged, so behaviour is identical to today. When the server can't resolve the title (no ICY metadata, or the song isn't in any library) that's treated as an expected refusal — no error log, no UI — matching how `toggleFavorite`'s failure is handled.

## Are there any additional changes not related to the issue above?

None. The `withRadioStreamMetadata` refactor is behaviour-preserving (the existing `NowPlayingRadioStreamMetadataTest` cases still pass unchanged); no translations, generated files or dependencies touched.

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug` — BUILD SUCCESSFUL, 806 tests (791 before), 0 failures, detekt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198cQrZ4nN32gxCGpwtZy9Q
