### PR TITLE
Match artists within the same provider

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/AppMediaItemFixtures.kt
@@ -43,14 +43,15 @@ object AppMediaItemFixtures {
     fun artist(
         itemId: String = uniqueIdGenerator.nextInt().toString(),
         name: String = "Artist $itemId",
+        providerMappings: List<ProviderMapping> = listOf(
+            ProviderMapping(itemId, DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
+        ),
     ): Artist {
         return Artist(
             itemId = itemId,
             provider = DEFAULT_PROVIDER_DOMAIN,
             name = name,
-            providerMappings = listOf(
-                ProviderMapping(itemId, DEFAULT_PROVIDER_DOMAIN, DEFAULT_PROVIDER_INSTANCE),
-            ),
+            providerMappings = providerMappings,
             metadata = null,
             favorite = null,
             uri = null,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
@@ -3,28 +3,26 @@ package io.music_assistant.client.data.model.client.items
 import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.item.ItemList
-import io.music_assistant.client.ui.compose.item.toRequest
+import io.music_assistant.client.ui.compose.item.toRequests
 
 class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemRepository) {
     suspend fun run(
         artist: Artist,
-        itemListBuilder: (ProviderMapping) -> ItemList,
+        itemListBuilder: (List<ProviderMapping>) -> ItemList,
     ): ArtistItems? {
         if (artist.providerMappings.isNullOrEmpty()) {
             return null
         }
 
-        val itemLists = artist.providerMappings.map { itemListBuilder(it) }
         val providers = artist.providerMappings.groupBy { it.providerInstance }.map { it.value }
-        for (mappings in providers) {
-            val items = mappings.flatMap {
-                val itemList = itemListBuilder(it)
-                val result = mediaItemRepository.fetchMediaItems(itemList.toRequest())
+        val itemLists = providers.map { itemListBuilder(it) }
+        for (itemList in itemLists) {
+            val items = itemList.toRequests().flatMap {
+                val result = mediaItemRepository.fetchMediaItems(it)
                 result.getOrNull() ?: emptyList()
             }
 
             if (items.isNotEmpty()) {
-                val itemList = itemListBuilder(mappings.first())
                 return ArtistItems(items, itemList, itemLists)
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
@@ -15,10 +15,16 @@ class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemReposito
         }
 
         val itemLists = artist.providerMappings.map { itemListBuilder(it) }
-        for (itemList in itemLists) {
-            val result = mediaItemRepository.fetchMediaItems(itemList.toRequest())
-            val items = result.getOrNull() ?: emptyList()
+        val providers = artist.providerMappings.groupBy { it.providerInstance }.map { it.value }
+        for (mappings in providers) {
+            val items = mappings.flatMap {
+                val itemList = itemListBuilder(it)
+                val result = mediaItemRepository.fetchMediaItems(itemList.toRequest())
+                result.getOrNull() ?: emptyList()
+            }
+
             if (items.isNotEmpty()) {
+                val itemList = itemListBuilder(mappings.first())
                 return ArtistItems(items, itemList, itemLists)
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
@@ -1,9 +1,9 @@
-package io.music_assistant.client.ui.compose.item
+package io.music_assistant.client.data.model.client.items
 
-import io.music_assistant.client.data.model.client.items.AppMediaItem
-import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.ui.compose.item.ItemList
+import io.music_assistant.client.ui.compose.item.toRequest
 
 class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemRepository) {
     suspend fun run(

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCase.kt
@@ -2,6 +2,8 @@ package io.music_assistant.client.data.model.client.items
 
 import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.data.repository.fetchMediaItems
+import io.music_assistant.client.ui.compose.common.getOrEmptyList
 import io.music_assistant.client.ui.compose.item.ItemList
 import io.music_assistant.client.ui.compose.item.toRequests
 
@@ -17,11 +19,7 @@ class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemReposito
         val providers = artist.providerMappings.groupBy { it.providerInstance }.map { it.value }
         val itemLists = providers.map { itemListBuilder(it) }
         for (itemList in itemLists) {
-            val items = itemList.toRequests().flatMap {
-                val result = mediaItemRepository.fetchMediaItems(it)
-                result.getOrNull() ?: emptyList()
-            }
-
+            val items = mediaItemRepository.fetchMediaItems(itemList.toRequests()).getOrEmptyList()
             if (items.isNotEmpty()) {
                 return ArtistItems(items, itemList, itemLists)
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediator.kt
@@ -28,22 +28,22 @@ class MediaItemDataMediator(
     private val mediaItemRepository: MediaItemRepository,
 ) {
     private val stateFlow = MutableStateFlow(initial)
-    private var request: Request? = null
+    private var requests: List<Request>? = null
 
     /**
-     * Retrieve and store items using [request]. [request] will also be used to update the items
+     * Retrieve and store items using [requests]. [requests] will also be used to update the items
      * if/when needed.
      */
-    suspend fun set(request: Request) {
-        this.request = request
+    suspend fun set(requests: List<Request>) {
+        this.requests = requests
         reload()
     }
 
     /**
-     * Store [items]. [request] will be used to update the items if/when needed.
+     * Store [items]. [requests] will be used to update the items if/when needed.
      */
-    fun set(items: List<AppMediaItem>, request: Request) {
-        this.request = request
+    fun set(items: List<AppMediaItem>, requests: List<Request>) {
+        this.requests = requests
         stateFlow.value = DataState.Data(items)
     }
 
@@ -95,16 +95,27 @@ class MediaItemDataMediator(
     }
 
     private suspend fun reload() {
-        request?.let {
+        requests?.let {
             stateFlow.value = DataState.Loading()
             try {
-                stateFlow.value =
-                    DataState.Data(mediaItemRepository.fetchMediaItems(it).getOrEmptyList())
+                val items = it.flatMap {
+                    mediaItemRepository.fetchMediaItems(it).getOrEmptyList()
+                }
+
+                stateFlow.value = DataState.Data(items)
             } catch (_: Exception) {
                 stateFlow.value = DataState.Error()
             }
         }
     }
+}
+
+suspend fun MediaItemDataMediator.set(request: Request) {
+    this.set(listOf(request))
+}
+
+fun MediaItemDataMediator.set(items: List<AppMediaItem>, request: Request) {
+    this.set(items, listOf(request))
 }
 
 private fun <T : AppMediaItem> List<T>.replacing(changed: T): List<T> =

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediator.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediator.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.repository.MediaItemChange
 import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.data.repository.fetchMediaItems
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.StaleReason
 import io.music_assistant.client.ui.compose.common.getOrEmptyList
@@ -98,10 +99,7 @@ class MediaItemDataMediator(
         requests?.let {
             stateFlow.value = DataState.Loading()
             try {
-                val items = it.flatMap {
-                    mediaItemRepository.fetchMediaItems(it).getOrEmptyList()
-                }
-
+                val items = mediaItemRepository.fetchMediaItems(it).getOrEmptyList()
                 stateFlow.value = DataState.Data(items)
             } catch (_: Exception) {
                 stateFlow.value = DataState.Error()

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/repository/MediaItemRepository.kt
@@ -11,6 +11,7 @@ import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.model.server.events.MediaItemAddedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemDeletedEvent
 import io.music_assistant.client.data.model.server.events.MediaItemUpdatedEvent
+import io.music_assistant.client.ui.compose.common.getOrEmptyList
 import io.music_assistant.client.utils.HasConnectionData
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -193,6 +194,24 @@ suspend fun MediaItemRepository.fetchRecommendationFolders(): Result<List<Recomm
         },
     )
 }
+
+/**
+ * Fetch items for multiple requests and combine them into one list. Returns a failure Result
+ * if any of the requests fail (and fails fast).
+ */
+ suspend fun MediaItemRepository.fetchMediaItems(requests: List<Request>): Result<List<AppMediaItem>> {
+     val items = mutableListOf<AppMediaItem>()
+     for (request in requests) {
+         val result = this.fetchMediaItems(request)
+         if (result.isSuccess) {
+             items += result.getOrEmptyList()
+         } else {
+             return result
+         }
+     }
+
+     return Result.success(items)
+ }
 
 /** Server schema version that split `music/recommendations` into rows + per-row items. */
 private const val RECOMMENDATION_ITEMS_SCHEMA = 39

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/FetchArtistItemsUseCase.kt
@@ -1,6 +1,5 @@
 package io.music_assistant.client.ui.compose.item
 
-import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.server.ProviderMapping
@@ -9,32 +8,22 @@ import io.music_assistant.client.data.repository.MediaItemRepository
 class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemRepository) {
     suspend fun run(
         artist: Artist,
-        requestBuilder: (itemId: String, providerInstance: String) -> Request,
-    ): ItemsWithMappings<AppMediaItem>? {
+        itemListBuilder: (ProviderMapping) -> ItemList,
+    ): Pair<List<AppMediaItem>, ItemList>? {
         if (artist.providerMappings.isNullOrEmpty()) {
             return null
         }
 
         for (mapping in artist.providerMappings) {
-            val itemId = mapping.itemId
-            val providerInstance = mapping.providerInstance
-            val request = requestBuilder(itemId, providerInstance)
-            val result = mediaItemRepository.fetchMediaItems(request)
+            val itemList = itemListBuilder(mapping)
+            val result = mediaItemRepository.fetchMediaItems(itemList.toRequest())
             val items = result.getOrNull() ?: emptyList()
             if (items.isNotEmpty()) {
-                return ItemsWithMappings(items, request, mapping)
+                return Pair(items, itemList)
             }
         }
 
         val mapping = artist.providerMappings.first()
-        val itemId = mapping.itemId
-        val providerInstance = mapping.providerInstance
-        return ItemsWithMappings(emptyList(), requestBuilder(itemId, providerInstance), mapping)
+        return Pair(emptyList(), itemListBuilder(mapping))
     }
-
-    data class ItemsWithMappings<T : AppMediaItem>(
-        val items: List<T>,
-        val request: Request,
-        val mapping: ProviderMapping,
-    )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/FetchArtistItemsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/FetchArtistItemsUseCase.kt
@@ -9,21 +9,26 @@ class FetchArtistItemsUseCase(private val mediaItemRepository: MediaItemReposito
     suspend fun run(
         artist: Artist,
         itemListBuilder: (ProviderMapping) -> ItemList,
-    ): Pair<List<AppMediaItem>, ItemList>? {
+    ): ArtistItems? {
         if (artist.providerMappings.isNullOrEmpty()) {
             return null
         }
 
-        for (mapping in artist.providerMappings) {
-            val itemList = itemListBuilder(mapping)
+        val itemLists = artist.providerMappings.map { itemListBuilder(it) }
+        for (itemList in itemLists) {
             val result = mediaItemRepository.fetchMediaItems(itemList.toRequest())
             val items = result.getOrNull() ?: emptyList()
             if (items.isNotEmpty()) {
-                return Pair(items, itemList)
+                return ArtistItems(items, itemList, itemLists)
             }
         }
 
-        val mapping = artist.providerMappings.first()
-        return Pair(emptyList(), itemListBuilder(mapping))
+        return ArtistItems(emptyList(), itemLists.first(), itemLists)
     }
+
+    data class ArtistItems(
+        val items: List<AppMediaItem>,
+        val itemList: ItemList,
+        val options: List<ItemList>,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -66,7 +66,6 @@ import io.music_assistant.client.data.model.client.items.PodcastEpisode
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.stringResource
 import io.music_assistant.client.data.model.client.toClickContext
-import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.settings.ViewMode
 import io.music_assistant.client.ui.compose.common.CenteredProgress
 import io.music_assistant.client.ui.compose.common.CenteredText
@@ -941,7 +940,7 @@ private fun ArtistContent(
                     title = Res.string.artist_section_all.toDisplayString(),
                     onNavigateClick = onNavigateClick,
                     onNavigateToList = onNavigateToList,
-                    onFilterSelected = artistDetailsViewModel::loadAlbumsForProvider,
+                    onFilterSelected = artistDetailsViewModel::loadAll,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
@@ -957,7 +956,7 @@ private fun ArtistContent(
                     title = stringResource(Res.string.artist_section_top).toDisplayString(),
                     onNavigateClick = onNavigateClick,
                     onNavigateToList = onNavigateToList,
-                    onFilterSelected = artistDetailsViewModel::loadTopTracksForProvider,
+                    onFilterSelected = artistDetailsViewModel::loadTopTracks,
                     onPlayChildClick = onPlayChildClick,
                     playlistActions = playlistActions,
                     libraryActions = libraryActions,
@@ -976,7 +975,7 @@ private fun <T : AppMediaItem> SectionRow(
     title: DisplayString,
     onNavigateClick: (AppMediaItem) -> Unit,
     onNavigateToList: (String, ItemList) -> Unit,
-    onFilterSelected: (ProviderMapping) -> Unit = {},
+    onFilterSelected: (ItemList) -> Unit = {},
     onPlayChildClick: PlayHandler<AppMediaItem>,
     playlistActions: PlaylistActions,
     libraryActions: LibraryActions,
@@ -991,11 +990,11 @@ private fun <T : AppMediaItem> SectionRow(
                 title = title,
                 items = section.items,
                 list = section.itemList,
-                filter = if (section.providerFilter != null && artist.providerMappings != null) {
+                filter = if (section.providerFilter != null) {
                     ItemCategory.Filter(
-                        label = section.providerFilter.current.providerDomain.toDisplayString(),
+                        label = section.providerFilter.current.providerDomain?.toDisplayString() ?: DisplayString.Raw(""),
                         options = section.providerFilter.options,
-                        labelTransform = { it.providerDomain.toDisplayString() },
+                        labelTransform = { it.providerDomain?.toDisplayString() ?: DisplayString.Raw("") },
                         contentDescription = Res.string.cd_provider_filter,
                     )
                 } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemDetailsScreen.kt
@@ -992,9 +992,9 @@ private fun <T : AppMediaItem> SectionRow(
                 list = section.itemList,
                 filter = if (section.providerFilter != null) {
                     ItemCategory.Filter(
-                        label = section.providerFilter.current.providerDomain?.toDisplayString() ?: DisplayString.Raw(""),
+                        label = section.providerFilter.current.providerDomain.toDisplayString(),
                         options = section.providerFilter.options,
-                        labelTransform = { it.providerDomain?.toDisplayString() ?: DisplayString.Raw("") },
+                        labelTransform = { it.providerDomain.toDisplayString() },
                         contentDescription = Res.string.cd_provider_filter,
                     )
                 } else {

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
@@ -1,0 +1,55 @@
+package io.music_assistant.client.ui.compose.item
+
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.server.ServerMediaItem
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface ItemList {
+    val mediaType: MediaType
+    val providerDomain: String?
+
+    @Serializable
+    data class ArtistAlbums(
+        val providerInstance: String,
+        val artistId: String,
+        override val providerDomain: String,
+    ) : ItemList {
+        override val mediaType: MediaType = MediaType.ALBUM
+    }
+
+    @Serializable
+    data class ArtistTopTracks(
+        val providerInstance: String,
+        val artistId: String,
+        override val providerDomain: String,
+    ) : ItemList {
+        override val mediaType: MediaType = MediaType.TRACK
+    }
+
+    @Serializable
+    data class ArtistLibrary(val artistId: String) : ItemList {
+        override val mediaType: MediaType = MediaType.ALBUM
+        override val providerDomain: String? = null
+    }
+}
+
+fun ItemList.toRequest(): Request {
+    return when (this) {
+        is ItemList.ArtistAlbums -> Request.Artist.getAlbums(
+            this.artistId,
+            this.providerInstance,
+        )
+
+        is ItemList.ArtistTopTracks -> Request.Artist.getTopTracks(
+            this.artistId,
+            this.providerInstance,
+        )
+
+        is ItemList.ArtistLibrary -> Request.Artist.getAlbums(
+            this.artistId,
+            ServerMediaItem.LIBRARY_PROVIDER,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
@@ -13,31 +13,32 @@ sealed interface ItemList {
 
     @Serializable
     data class ArtistAlbums(
-        val providerInstance: String,
-        val artistId: String,
+        val mappings: List<Pair<String, String>>,
         override val providerDomain: String,
     ) : ItemList {
         override val mediaType: MediaType = MediaType.ALBUM
 
         constructor(providerMapping: ProviderMapping) : this(
-            providerInstance = providerMapping.providerInstance,
-            artistId = providerMapping.itemId,
+            mappings = listOf(Pair(providerMapping.providerInstance, providerMapping.itemId)),
             providerDomain = providerMapping.providerDomain,
+        )
+
+        constructor(providerMappings: List<ProviderMapping>) : this(
+            mappings = providerMappings.map { Pair(it.providerInstance, it.itemId) },
+            providerDomain = providerMappings.first().providerDomain,
         )
     }
 
     @Serializable
     data class ArtistTopTracks(
-        val providerInstance: String,
-        val artistId: String,
+        val mappings: List<Pair<String, String>>,
         override val providerDomain: String,
     ) : ItemList {
         override val mediaType: MediaType = MediaType.TRACK
 
-        constructor(providerMapping: ProviderMapping) : this(
-            providerInstance = providerMapping.providerInstance,
-            artistId = providerMapping.itemId,
-            providerDomain = providerMapping.providerDomain,
+        constructor(providerMappings: List<ProviderMapping>) : this(
+            mappings = providerMappings.map { Pair(it.providerInstance, it.itemId) },
+            providerDomain = providerMappings.first().providerDomain,
         )
     }
 
@@ -48,21 +49,27 @@ sealed interface ItemList {
     }
 }
 
-fun ItemList.toRequest(): Request {
+fun ItemList.toRequests(): List<Request> {
     return when (this) {
-        is ItemList.ArtistAlbums -> Request.Artist.getAlbums(
-            this.artistId,
-            this.providerInstance,
-        )
+        is ItemList.ArtistAlbums -> {
+            this.mappings.map {
+                val (providerInstance, itemId) = it
+                Request.Artist.getAlbums(itemId, providerInstance)
+            }
+        }
 
-        is ItemList.ArtistTopTracks -> Request.Artist.getTopTracks(
-            this.artistId,
-            this.providerInstance,
-        )
+        is ItemList.ArtistTopTracks -> {
+            this.mappings.map {
+                val (providerInstance, itemId) = it
+                Request.Artist.getTopTracks(itemId, providerInstance)
+            }
+        }
 
-        is ItemList.ArtistLibrary -> Request.Artist.getAlbums(
-            this.artistId,
-            ServerMediaItem.LIBRARY_PROVIDER,
+        is ItemList.ArtistLibrary -> listOf(
+            Request.Artist.getAlbums(
+                this.artistId,
+                ServerMediaItem.LIBRARY_PROVIDER,
+            ),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.ui.compose.item
 
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.MediaType
+import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.model.server.ServerMediaItem
 import kotlinx.serialization.Serializable
 
@@ -17,6 +18,12 @@ sealed interface ItemList {
         override val providerDomain: String,
     ) : ItemList {
         override val mediaType: MediaType = MediaType.ALBUM
+
+        constructor(providerMapping: ProviderMapping) : this(
+            providerInstance = providerMapping.providerInstance,
+            artistId = providerMapping.itemId,
+            providerDomain = providerMapping.providerDomain,
+        )
     }
 
     @Serializable
@@ -26,6 +33,12 @@ sealed interface ItemList {
         override val providerDomain: String,
     ) : ItemList {
         override val mediaType: MediaType = MediaType.TRACK
+
+        constructor(providerMapping: ProviderMapping) : this(
+            providerInstance = providerMapping.providerInstance,
+            artistId = providerMapping.itemId,
+            providerDomain = providerMapping.providerDomain,
+        )
     }
 
     @Serializable

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
@@ -12,17 +12,17 @@ sealed interface ItemList {
     val providerDomain: String
 
     @Serializable
-    data class ArtistAlbums(val mappings: List<ProviderMapping>) : ItemList {
+    data class ArtistAlbums(val providerMappings: List<ProviderMapping>) : ItemList {
         override val mediaType: MediaType = MediaType.ALBUM
-        override val providerDomain: String = mappings.first().providerDomain
+        override val providerDomain: String = providerMappings.first().providerDomain
 
-        constructor(providerMapping: ProviderMapping) : this(mappings = listOf(providerMapping))
+        constructor(providerMapping: ProviderMapping) : this(providerMappings = listOf(providerMapping))
     }
 
     @Serializable
-    data class ArtistTopTracks(val mappings: List<ProviderMapping>) : ItemList {
+    data class ArtistTopTracks(val providerMappings: List<ProviderMapping>) : ItemList {
         override val mediaType: MediaType = MediaType.TRACK
-        override val providerDomain: String = mappings.first().providerDomain
+        override val providerDomain: String = providerMappings.first().providerDomain
     }
 
     @Serializable
@@ -35,13 +35,13 @@ sealed interface ItemList {
 fun ItemList.toRequests(): List<Request> {
     return when (this) {
         is ItemList.ArtistAlbums -> {
-            this.mappings.map {
+            this.providerMappings.map {
                 Request.Artist.getAlbums(it.itemId, it.providerInstance)
             }
         }
 
         is ItemList.ArtistTopTracks -> {
-            this.mappings.map {
+            this.providerMappings.map {
                 Request.Artist.getTopTracks(it.itemId, it.providerInstance)
             }
         }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemList.kt
@@ -9,43 +9,26 @@ import kotlinx.serialization.Serializable
 @Serializable
 sealed interface ItemList {
     val mediaType: MediaType
-    val providerDomain: String?
+    val providerDomain: String
 
     @Serializable
-    data class ArtistAlbums(
-        val mappings: List<Pair<String, String>>,
-        override val providerDomain: String,
-    ) : ItemList {
+    data class ArtistAlbums(val mappings: List<ProviderMapping>) : ItemList {
         override val mediaType: MediaType = MediaType.ALBUM
+        override val providerDomain: String = mappings.first().providerDomain
 
-        constructor(providerMapping: ProviderMapping) : this(
-            mappings = listOf(Pair(providerMapping.providerInstance, providerMapping.itemId)),
-            providerDomain = providerMapping.providerDomain,
-        )
-
-        constructor(providerMappings: List<ProviderMapping>) : this(
-            mappings = providerMappings.map { Pair(it.providerInstance, it.itemId) },
-            providerDomain = providerMappings.first().providerDomain,
-        )
+        constructor(providerMapping: ProviderMapping) : this(mappings = listOf(providerMapping))
     }
 
     @Serializable
-    data class ArtistTopTracks(
-        val mappings: List<Pair<String, String>>,
-        override val providerDomain: String,
-    ) : ItemList {
+    data class ArtistTopTracks(val mappings: List<ProviderMapping>) : ItemList {
         override val mediaType: MediaType = MediaType.TRACK
-
-        constructor(providerMappings: List<ProviderMapping>) : this(
-            mappings = providerMappings.map { Pair(it.providerInstance, it.itemId) },
-            providerDomain = providerMappings.first().providerDomain,
-        )
+        override val providerDomain: String = mappings.first().providerDomain
     }
 
     @Serializable
     data class ArtistLibrary(val artistId: String) : ItemList {
         override val mediaType: MediaType = MediaType.ALBUM
-        override val providerDomain: String? = null
+        override val providerDomain: String = ServerMediaItem.LIBRARY_PROVIDER
     }
 }
 
@@ -53,15 +36,13 @@ fun ItemList.toRequests(): List<Request> {
     return when (this) {
         is ItemList.ArtistAlbums -> {
             this.mappings.map {
-                val (providerInstance, itemId) = it
-                Request.Artist.getAlbums(itemId, providerInstance)
+                Request.Artist.getAlbums(it.itemId, it.providerInstance)
             }
         }
 
         is ItemList.ArtistTopTracks -> {
             this.mappings.map {
-                val (providerInstance, itemId) = it
-                Request.Artist.getTopTracks(itemId, providerInstance)
+                Request.Artist.getTopTracks(it.itemId, it.providerInstance)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListScreen.kt
@@ -14,7 +14,7 @@ import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.ui.compose.common.items.ItemSortChip
 import io.music_assistant.client.ui.compose.common.viewmodel.ActionsViewModel
-import io.music_assistant.client.ui.compose.library.ItemList
+import io.music_assistant.client.ui.compose.library.ItemListContent
 import io.music_assistant.client.ui.compose.nav.TopBarLayout
 import io.music_assistant.client.ui.compose.nav.TwoRowTopAppBar
 import musicassistantclient.composeapp.generated.resources.Res
@@ -63,7 +63,7 @@ fun ItemListScreen(
             )
         },
     ) {
-        ItemList(
+        ItemListContent(
             data = state.items,
             onNavigateClick = onNavigateClick,
             onPlayClick = { item, option, radio, _ ->

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -2,14 +2,11 @@ package io.music_assistant.client.ui.compose.item
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.music_assistant.client.api.Request
-import io.music_assistant.client.data.model.client.MediaType
 import io.music_assistant.client.data.model.client.SortConfig
 import io.music_assistant.client.data.model.client.SortOption
 import io.music_assistant.client.data.model.client.clientSorted
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.itemList
-import io.music_assistant.client.data.model.server.ServerMediaItem
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.map
@@ -18,7 +15,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
 
 class ItemListViewModel(
     private val itemList: ItemList,
@@ -37,24 +33,7 @@ class ItemListViewModel(
 
     init {
         viewModelScope.launch {
-            val request = when (itemList) {
-                is ItemList.ArtistAlbums -> Request.Artist.getAlbums(
-                    itemList.artistId,
-                    itemList.providerInstance,
-                )
-
-                is ItemList.ArtistTopTracks -> Request.Artist.getTopTracks(
-                    itemList.artistId,
-                    itemList.providerInstance,
-                )
-
-                is ItemList.ArtistLibrary -> Request.Artist.getAlbums(
-                    itemList.artistId,
-                    ServerMediaItem.LIBRARY_PROVIDER,
-                )
-            }
-
-            items.set(request)
+            items.set(itemList.toRequest())
         }
     }
 
@@ -63,24 +42,4 @@ class ItemListViewModel(
     }
 
     data class State(val items: DataState<List<AppMediaItem>>, val sortOption: SortOption)
-}
-
-@Serializable
-sealed interface ItemList {
-    val mediaType: MediaType
-
-    @Serializable
-    data class ArtistAlbums(val providerInstance: String, val artistId: String) : ItemList {
-        override val mediaType: MediaType = MediaType.ALBUM
-    }
-
-    @Serializable
-    data class ArtistTopTracks(val providerInstance: String, val artistId: String) : ItemList {
-        override val mediaType: MediaType = MediaType.TRACK
-    }
-
-    @Serializable
-    data class ArtistLibrary(val artistId: String) : ItemList {
-        override val mediaType: MediaType = MediaType.ALBUM
-    }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/ItemListViewModel.kt
@@ -33,7 +33,7 @@ class ItemListViewModel(
 
     init {
         viewModelScope.launch {
-            items.set(itemList.toRequest())
+            items.set(itemList.toRequests())
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
@@ -9,13 +9,14 @@ import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.FetchArtistItemsUseCase
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.itemList
+import io.music_assistant.client.data.model.client.items.set
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.map
 import io.music_assistant.client.ui.compose.common.mapData
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel.Companion.ARTIST_SECTION_LIMIT
 import io.music_assistant.client.ui.compose.item.ItemList
-import io.music_assistant.client.ui.compose.item.toRequest
+import io.music_assistant.client.ui.compose.item.toRequests
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -99,7 +100,7 @@ class ArtistDetailsViewModel(
 
             if (artistItems != null) {
                 val (items, itemList, options) = artistItems
-                allItems.set(items, itemList.toRequest())
+                allItems.set(items, itemList.toRequests())
                 allProviderFilter.value = Section.ProviderFilter(itemList, options)
             } else {
                 allItems.setError()
@@ -111,7 +112,7 @@ class ArtistDetailsViewModel(
 
             if (result != null) {
                 val (items, itemList, options) = result
-                topTrackItems.set(items, itemList.toRequest())
+                topTrackItems.set(items, itemList.toRequests())
                 topTracksFilter.value = Section.ProviderFilter(itemList, options)
             } else {
                 topTrackItems.setError()
@@ -125,7 +126,7 @@ class ArtistDetailsViewModel(
         }
 
         viewModelScope.launch {
-            allItems.set(itemList.toRequest())
+            allItems.set(itemList.toRequests())
         }
     }
 
@@ -133,7 +134,7 @@ class ArtistDetailsViewModel(
         topTracksFilter.update { it?.copy(current = itemList) }
 
         viewModelScope.launch {
-            topTrackItems.set(itemList.toRequest())
+            topTrackItems.set(itemList.toRequests())
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
@@ -9,7 +9,6 @@ import io.music_assistant.client.data.model.client.items.Artist
 import io.music_assistant.client.data.model.client.items.FetchArtistItemsUseCase
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.itemList
-import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.map
@@ -96,9 +95,7 @@ class ArtistDetailsViewModel(
         }
 
         viewModelScope.launch {
-            val itemListBuilder: (ProviderMapping) -> ItemList =
-                { ItemList.ArtistAlbums(it.providerInstance, it.itemId, it.providerDomain) }
-            val artistItems = fetchArtistItemsUseCase.run(artist, itemListBuilder)
+            val artistItems = fetchArtistItemsUseCase.run(artist) { ItemList.ArtistAlbums(it) }
 
             if (artistItems != null) {
                 val (items, itemList, options) = artistItems
@@ -110,9 +107,7 @@ class ArtistDetailsViewModel(
         }
 
         viewModelScope.launch {
-            val itemListBuilder: (ProviderMapping) -> ItemList =
-                { ItemList.ArtistTopTracks(it.providerInstance, it.itemId, it.providerDomain) }
-            val result = fetchArtistItemsUseCase.run(artist, itemListBuilder)
+            val result = fetchArtistItemsUseCase.run(artist) { ItemList.ArtistTopTracks(it) }
 
             if (result != null) {
                 val (items, itemList, options) = result

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
@@ -16,10 +16,12 @@ import io.music_assistant.client.ui.compose.common.mapData
 import io.music_assistant.client.ui.compose.item.FetchArtistItemsUseCase
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel.Companion.ARTIST_SECTION_LIMIT
 import io.music_assistant.client.ui.compose.item.ItemList
+import io.music_assistant.client.ui.compose.item.toRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class ArtistDetailsViewModel(
@@ -50,10 +52,7 @@ class ArtistDetailsViewModel(
                         items = it
                             .filterIsInstance<Album>()
                             .take(ARTIST_SECTION_LIMIT),
-                        itemList = ItemList.ArtistAlbums(
-                            providerFilter.current.providerInstance,
-                            providerFilter.current.itemId,
-                        ),
+                        itemList = providerFilter.current,
                         providerFilter = providerFilter,
                     )
                 }
@@ -64,19 +63,16 @@ class ArtistDetailsViewModel(
         .stateIn(viewModelScope, SharingStarted.Eagerly, DataState.Loading())
 
     private val topTrackItems = itemList(mediaItemRepository)
-    private val topTracksProviderInfo = MutableStateFlow<Section.ProviderFilter?>(null)
+    private val topTracksFilter = MutableStateFlow<Section.ProviderFilter?>(null)
     val topTracks = topTrackItems.asFlow()
-        .combine(topTracksProviderInfo) { items, providerFilter ->
+        .combine(topTracksFilter) { items, providerFilter ->
             if (providerFilter != null) {
                 items.map {
                     Section(
                         items = it
                             .filterIsInstance<Track>()
                             .take(ARTIST_SECTION_LIMIT),
-                        itemList = ItemList.ArtistTopTracks(
-                            providerFilter.current.providerInstance,
-                            providerFilter.current.itemId,
-                        ),
+                        itemList = providerFilter.current,
                         providerFilter = providerFilter,
                     )
                 }
@@ -100,16 +96,16 @@ class ArtistDetailsViewModel(
         }
 
         viewModelScope.launch {
-            val itemsWithMappings = fetchArtistItemsUseCase.run(
-                artist,
-                Request.Artist::getAlbums,
-            )
+            val itemListBuilder: (ProviderMapping) -> ItemList =
+                { ItemList.ArtistAlbums(it.providerInstance, it.itemId, it.providerDomain) }
+            val result = fetchArtistItemsUseCase.run(artist, itemListBuilder)
 
-            if (itemsWithMappings != null) {
-                allItems.set(itemsWithMappings.items, itemsWithMappings.request)
+            if (result != null) {
+                val (items, itemList) = result
+                allItems.set(items, itemList.toRequest())
                 allProviderFilter.value = Section.ProviderFilter(
-                    itemsWithMappings.mapping,
-                    artist.providerMappings ?: emptyList(),
+                    itemList,
+                    artist.providerMappings?.map { itemListBuilder(it) } ?: emptyList(),
                 )
             } else {
                 allItems.setError()
@@ -117,16 +113,16 @@ class ArtistDetailsViewModel(
         }
 
         viewModelScope.launch {
-            val itemsWithMappings = fetchArtistItemsUseCase.run(
-                artist,
-                Request.Artist::getTopTracks,
-            )
+            val itemListBuilder: (ProviderMapping) -> ItemList =
+                { ItemList.ArtistTopTracks(it.providerInstance, it.itemId, it.providerDomain) }
+            val result = fetchArtistItemsUseCase.run(artist, itemListBuilder)
 
-            if (itemsWithMappings != null) {
-                topTrackItems.set(itemsWithMappings.items, itemsWithMappings.request)
-                topTracksProviderInfo.value = Section.ProviderFilter(
-                    itemsWithMappings.mapping,
-                    artist.providerMappings ?: emptyList(),
+            if (result != null) {
+                val (items, itemList) = result
+                topTrackItems.set(items, itemList.toRequest())
+                topTracksFilter.value = Section.ProviderFilter(
+                    itemList,
+                    artist.providerMappings?.map { itemListBuilder(it) } ?: emptyList(),
                 )
             } else {
                 topTrackItems.setError()
@@ -134,29 +130,21 @@ class ArtistDetailsViewModel(
         }
     }
 
-    fun loadAlbumsForProvider(mapping: ProviderMapping) {
-        allProviderFilter.value = Section.ProviderFilter(
-            mapping,
-            artist.providerMappings ?: emptyList(),
-        )
+    fun loadAll(itemList: ItemList) {
+        allProviderFilter.update {
+            it?.copy(current = itemList)
+        }
 
         viewModelScope.launch {
-            val itemId = mapping.itemId
-            val providerInstance = mapping.providerInstance
-            allItems.set(Request.Artist.getAlbums(itemId, providerInstance))
+            allItems.set(itemList.toRequest())
         }
     }
 
-    fun loadTopTracksForProvider(mapping: ProviderMapping) {
-        topTracksProviderInfo.value = Section.ProviderFilter(
-            mapping,
-            artist.providerMappings ?: emptyList(),
-        )
+    fun loadTopTracks(itemList: ItemList) {
+        topTracksFilter.update { it?.copy(current = itemList) }
 
         viewModelScope.launch {
-            val itemId = mapping.itemId
-            val providerInstance = mapping.providerInstance
-            topTrackItems.set(Request.Artist.getTopTracks(itemId, providerInstance))
+            topTrackItems.set(itemList.toRequest())
         }
     }
 
@@ -166,8 +154,8 @@ class ArtistDetailsViewModel(
         val providerFilter: ProviderFilter? = null,
     ) {
         data class ProviderFilter(
-            val current: ProviderMapping,
-            val options: List<ProviderMapping>,
+            val current: ItemList,
+            val options: List<ItemList>,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
@@ -6,6 +6,7 @@ import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.items.Album
 import io.music_assistant.client.data.model.client.items.AppMediaItem
 import io.music_assistant.client.data.model.client.items.Artist
+import io.music_assistant.client.data.model.client.items.FetchArtistItemsUseCase
 import io.music_assistant.client.data.model.client.items.Track
 import io.music_assistant.client.data.model.client.items.itemList
 import io.music_assistant.client.data.model.server.ProviderMapping
@@ -13,7 +14,6 @@ import io.music_assistant.client.data.repository.MediaItemRepository
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.map
 import io.music_assistant.client.ui.compose.common.mapData
-import io.music_assistant.client.ui.compose.item.FetchArtistItemsUseCase
 import io.music_assistant.client.ui.compose.item.ItemDetailsViewModel.Companion.ARTIST_SECTION_LIMIT
 import io.music_assistant.client.ui.compose.item.ItemList
 import io.music_assistant.client.ui.compose.item.toRequest

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/item/artist/ArtistDetailsViewModel.kt
@@ -98,15 +98,12 @@ class ArtistDetailsViewModel(
         viewModelScope.launch {
             val itemListBuilder: (ProviderMapping) -> ItemList =
                 { ItemList.ArtistAlbums(it.providerInstance, it.itemId, it.providerDomain) }
-            val result = fetchArtistItemsUseCase.run(artist, itemListBuilder)
+            val artistItems = fetchArtistItemsUseCase.run(artist, itemListBuilder)
 
-            if (result != null) {
-                val (items, itemList) = result
+            if (artistItems != null) {
+                val (items, itemList, options) = artistItems
                 allItems.set(items, itemList.toRequest())
-                allProviderFilter.value = Section.ProviderFilter(
-                    itemList,
-                    artist.providerMappings?.map { itemListBuilder(it) } ?: emptyList(),
-                )
+                allProviderFilter.value = Section.ProviderFilter(itemList, options)
             } else {
                 allItems.setError()
             }
@@ -118,12 +115,9 @@ class ArtistDetailsViewModel(
             val result = fetchArtistItemsUseCase.run(artist, itemListBuilder)
 
             if (result != null) {
-                val (items, itemList) = result
+                val (items, itemList, options) = result
                 topTrackItems.set(items, itemList.toRequest())
-                topTracksFilter.value = Section.ProviderFilter(
-                    itemList,
-                    artist.providerMappings?.map { itemListBuilder(it) } ?: emptyList(),
-                )
+                topTracksFilter.value = Section.ProviderFilter(itemList, options)
             } else {
                 topTrackItems.setError()
             }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListContent.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/ItemListContent.kt
@@ -52,7 +52,7 @@ import org.jetbrains.compose.resources.stringResource
  * search with [onGlobalSearch].
  */
 @Composable
-fun ItemList(
+fun ItemListContent(
     modifier: Modifier = Modifier,
     data: DataState<List<AppMediaItem>>,
     onNavigateClick: (AppMediaItem) -> Unit,

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/library/LibraryListScreen.kt
@@ -102,7 +102,7 @@ fun LibraryListScreen(
             )
         },
     ) {
-        ItemList(
+        ItemListContent(
             data = state.dataState,
             onNavigateClick = onNavigateClick,
             onPlayClick = { item, option, radio, _ ->

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -19,13 +19,6 @@ class FetchArtistItemsUseCaseTest {
         val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
         val provider1Albums = listOf(AppMediaItemFixtures.album(artist = artist))
         val provider2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
-        val itemListBuilder: (ProviderMapping) -> ItemList = {
-            ItemList.ArtistAlbums(
-                providerInstance = it.providerInstance,
-                artistId = it.itemId,
-                providerDomain = it.providerDomain,
-            )
-        }
 
         mediaItemRepository.setItemsResult(
             request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
@@ -38,13 +31,13 @@ class FetchArtistItemsUseCaseTest {
         )
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
-        val artistItems = useCase.run(artist, itemListBuilder)
+        val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
 
         assertEquals(
             FetchArtistItemsUseCase.ArtistItems(
                 items = provider1Albums,
-                itemList = itemListBuilder(provider1),
-                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+                itemList = ItemList.ArtistAlbums(provider1),
+                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
             ),
             artistItems,
         )
@@ -56,13 +49,6 @@ class FetchArtistItemsUseCaseTest {
         val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
         val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
         val provider2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
-        val itemListBuilder: (ProviderMapping) -> ItemList = {
-            ItemList.ArtistAlbums(
-                providerInstance = it.providerInstance,
-                artistId = it.itemId,
-                providerDomain = it.providerDomain,
-            )
-        }
 
         mediaItemRepository.setItemsResult(
             request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
@@ -75,13 +61,13 @@ class FetchArtistItemsUseCaseTest {
         )
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
-        val artistItems = useCase.run(artist, itemListBuilder)
+        val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
 
         assertEquals(
             FetchArtistItemsUseCase.ArtistItems(
                 items = provider2Albums,
-                itemList = itemListBuilder(provider2),
-                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+                itemList = ItemList.ArtistAlbums(provider2),
+                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
             ),
             artistItems,
         )
@@ -92,13 +78,6 @@ class FetchArtistItemsUseCaseTest {
         val provider1 = ProviderMapping("1", "niflheim", "niflheim-1")
         val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
         val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
-        val itemListBuilder: (ProviderMapping) -> ItemList = {
-            ItemList.ArtistAlbums(
-                providerInstance = it.providerInstance,
-                artistId = it.itemId,
-                providerDomain = it.providerDomain,
-            )
-        }
 
         mediaItemRepository.setItemsResult(
             request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
@@ -111,13 +90,13 @@ class FetchArtistItemsUseCaseTest {
         )
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
-        val artistItems = useCase.run(artist, itemListBuilder)
+        val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
 
         assertEquals(
             FetchArtistItemsUseCase.ArtistItems(
                 items = emptyList(),
-                itemList = itemListBuilder(provider1),
-                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+                itemList = ItemList.ArtistAlbums(provider1),
+                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
             ),
             artistItems,
         )
@@ -126,16 +105,9 @@ class FetchArtistItemsUseCaseTest {
     @Test
     fun `returns null when artist has no provider mappings`() = runTest {
         val artist = AppMediaItemFixtures.artist(providerMappings = emptyList())
-        val itemListBuilder: (ProviderMapping) -> ItemList = {
-            ItemList.ArtistAlbums(
-                providerInstance = it.providerInstance,
-                artistId = it.itemId,
-                providerDomain = it.providerDomain,
-            )
-        }
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
-        val artistItems = useCase.run(artist, itemListBuilder)
+        val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
         assertEquals(null, artistItems)
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -2,6 +2,7 @@ package io.music_assistant.client.data.model.client.items
 
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
+import io.music_assistant.client.data.model.client.items.FetchArtistItemsUseCase.ArtistItems
 import io.music_assistant.client.data.model.client.items.support.StubMediaItemRepository
 import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.ui.compose.item.ItemList
@@ -32,12 +33,14 @@ class FetchArtistItemsUseCaseTest {
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
-
         assertEquals(
-            FetchArtistItemsUseCase.ArtistItems(
+            ArtistItems(
                 items = provider1Albums,
                 itemList = ItemList.ArtistAlbums(provider1),
-                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
+                options = listOf(
+                    ItemList.ArtistAlbums(provider1),
+                    ItemList.ArtistAlbums(provider2),
+                ),
             ),
             artistItems,
         )
@@ -62,12 +65,14 @@ class FetchArtistItemsUseCaseTest {
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
-
         assertEquals(
-            FetchArtistItemsUseCase.ArtistItems(
+            ArtistItems(
                 items = provider2Albums,
                 itemList = ItemList.ArtistAlbums(provider2),
-                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
+                options = listOf(
+                    ItemList.ArtistAlbums(provider1),
+                    ItemList.ArtistAlbums(provider2),
+                ),
             ),
             artistItems,
         )
@@ -91,12 +96,14 @@ class FetchArtistItemsUseCaseTest {
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
-
         assertEquals(
-            FetchArtistItemsUseCase.ArtistItems(
+            ArtistItems(
                 items = emptyList(),
                 itemList = ItemList.ArtistAlbums(provider1),
-                options = listOf(ItemList.ArtistAlbums(provider1), ItemList.ArtistAlbums(provider2)),
+                options = listOf(
+                    ItemList.ArtistAlbums(provider1),
+                    ItemList.ArtistAlbums(provider2),
+                ),
             ),
             artistItems,
         )
@@ -109,5 +116,35 @@ class FetchArtistItemsUseCaseTest {
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
         assertEquals(null, artistItems)
+    }
+
+    @Test
+    fun `combines mappings if they are the same instance`() = runTest {
+        val mapping1 = ProviderMapping("1", "niflheim", "niflheim-1")
+        val mapping2 = ProviderMapping("2", "niflheim", "niflheim-1")
+        val artist = AppMediaItemFixtures.artist(providerMappings = listOf(mapping1, mapping2))
+        val mapping1Albums = listOf(AppMediaItemFixtures.album(artist = artist))
+        val mapping2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(mapping1.itemId, mapping1.providerInstance),
+            result = Result.success(mapping1Albums),
+        )
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(mapping2.itemId, mapping2.providerInstance),
+            result = Result.success(mapping2Albums),
+        )
+
+        val useCase = FetchArtistItemsUseCase(mediaItemRepository)
+        val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
+        assertEquals(
+            ArtistItems(
+                items = mapping1Albums + mapping2Albums,
+                itemList = ItemList.ArtistAlbums(mapping1),
+                options = listOf(ItemList.ArtistAlbums(mapping1), ItemList.ArtistAlbums(mapping2)),
+            ),
+            artistItems,
+        )
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -6,6 +6,7 @@ import io.music_assistant.client.data.model.client.items.FetchArtistItemsUseCase
 import io.music_assistant.client.data.model.client.items.support.StubMediaItemRepository
 import io.music_assistant.client.data.model.server.ProviderMapping
 import io.music_assistant.client.ui.compose.item.ItemList
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -119,9 +120,10 @@ class FetchArtistItemsUseCaseTest {
     }
 
     @Test
-    fun `combines mappings if they are the same instance`() = runTest {
-        val mapping1 = ProviderMapping("1", "niflheim", "niflheim-1")
-        val mapping2 = ProviderMapping("2", "niflheim", "niflheim-1")
+    fun `combines mappings if they are the same instance`(): TestResult = runTest {
+        val providerDomain = "niflheim"
+        val mapping1 = ProviderMapping("1", providerDomain, "niflheim-1")
+        val mapping2 = ProviderMapping("2", providerDomain, "niflheim-1")
         val artist = AppMediaItemFixtures.artist(providerMappings = listOf(mapping1, mapping2))
         val mapping1Albums = listOf(AppMediaItemFixtures.album(artist = artist))
         val mapping2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
@@ -138,11 +140,18 @@ class FetchArtistItemsUseCaseTest {
 
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
+
+        val expectedItemList = ItemList.ArtistAlbums(
+            mappings = listOf(mapping1, mapping2).map {
+                Pair(it.providerInstance, it.itemId)
+            },
+            providerDomain = providerDomain,
+        )
         assertEquals(
             ArtistItems(
                 items = mapping1Albums + mapping2Albums,
-                itemList = ItemList.ArtistAlbums(mapping1),
-                options = listOf(ItemList.ArtistAlbums(mapping1), ItemList.ArtistAlbums(mapping2)),
+                itemList = expectedItemList,
+                options = listOf(expectedItemList),
             ),
             artistItems,
         )

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -13,6 +13,44 @@ class FetchArtistItemsUseCaseTest {
     private val mediaItemRepository = StubMediaItemRepository()
 
     @Test
+    fun `returns first provider's items when it has items`() = runTest {
+        val provider1 = ProviderMapping("1", "niflheim", "niflheim-1")
+        val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
+        val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
+        val provider1Albums = listOf(AppMediaItemFixtures.album(artist = artist))
+        val provider2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
+        val itemListBuilder: (ProviderMapping) -> ItemList = {
+            ItemList.ArtistAlbums(
+                providerInstance = it.providerInstance,
+                artistId = it.itemId,
+                providerDomain = it.providerDomain,
+            )
+        }
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
+            result = Result.success(provider1Albums),
+        )
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider2.itemId, provider2.providerInstance),
+            result = Result.success(provider2Albums),
+        )
+
+        val useCase = FetchArtistItemsUseCase(mediaItemRepository)
+        val artistItems = useCase.run(artist, itemListBuilder)
+
+        assertEquals(
+            FetchArtistItemsUseCase.ArtistItems(
+                items = provider1Albums,
+                itemList = itemListBuilder(provider1),
+                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+            ),
+            artistItems,
+        )
+    }
+
+    @Test
     fun `returns first non-empty provider's items`() = runTest {
         val provider1 = ProviderMapping("1", "niflheim", "niflheim-1")
         val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
@@ -47,5 +85,57 @@ class FetchArtistItemsUseCaseTest {
             ),
             artistItems,
         )
+    }
+
+    @Test
+    fun `returns with first provider if all providers are empty`() = runTest {
+        val provider1 = ProviderMapping("1", "niflheim", "niflheim-1")
+        val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
+        val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
+        val itemListBuilder: (ProviderMapping) -> ItemList = {
+            ItemList.ArtistAlbums(
+                providerInstance = it.providerInstance,
+                artistId = it.itemId,
+                providerDomain = it.providerDomain,
+            )
+        }
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
+            result = Result.success(emptyList()),
+        )
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider2.itemId, provider2.providerInstance),
+            result = Result.success(emptyList()),
+        )
+
+        val useCase = FetchArtistItemsUseCase(mediaItemRepository)
+        val artistItems = useCase.run(artist, itemListBuilder)
+
+        assertEquals(
+            FetchArtistItemsUseCase.ArtistItems(
+                items = emptyList(),
+                itemList = itemListBuilder(provider1),
+                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+            ),
+            artistItems,
+        )
+    }
+
+    @Test
+    fun `returns null when artist has no provider mappings`() = runTest {
+        val artist = AppMediaItemFixtures.artist(providerMappings = emptyList())
+        val itemListBuilder: (ProviderMapping) -> ItemList = {
+            ItemList.ArtistAlbums(
+                providerInstance = it.providerInstance,
+                artistId = it.itemId,
+                providerDomain = it.providerDomain,
+            )
+        }
+
+        val useCase = FetchArtistItemsUseCase(mediaItemRepository)
+        val artistItems = useCase.run(artist, itemListBuilder)
+        assertEquals(null, artistItems)
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -1,0 +1,51 @@
+package io.music_assistant.client.data.model.client.items
+
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.AppMediaItemFixtures
+import io.music_assistant.client.data.model.client.items.support.StubMediaItemRepository
+import io.music_assistant.client.data.model.server.ProviderMapping
+import io.music_assistant.client.ui.compose.item.ItemList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FetchArtistItemsUseCaseTest {
+    private val mediaItemRepository = StubMediaItemRepository()
+
+    @Test
+    fun `returns first non-empty provider's items`() = runTest {
+        val provider1 = ProviderMapping("1", "niflheim", "niflheim-1")
+        val provider2 = ProviderMapping("1", "muspelheim", "muspelheim-1")
+        val artist = AppMediaItemFixtures.artist(providerMappings = listOf(provider1, provider2))
+        val provider2Albums = listOf(AppMediaItemFixtures.album(artist = artist))
+        val itemListBuilder: (ProviderMapping) -> ItemList = {
+            ItemList.ArtistAlbums(
+                providerInstance = it.providerInstance,
+                artistId = it.itemId,
+                providerDomain = it.providerDomain,
+            )
+        }
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider1.itemId, provider1.providerInstance),
+            result = Result.success(emptyList()),
+        )
+
+        mediaItemRepository.setItemsResult(
+            request = Request.Artist.getAlbums(provider2.itemId, provider2.providerInstance),
+            result = Result.success(provider2Albums),
+        )
+
+        val useCase = FetchArtistItemsUseCase(mediaItemRepository)
+        val artistItems = useCase.run(artist, itemListBuilder)
+
+        assertEquals(
+            FetchArtistItemsUseCase.ArtistItems(
+                items = provider2Albums,
+                itemList = itemListBuilder(provider2),
+                options = listOf(itemListBuilder(provider1), itemListBuilder(provider2)),
+            ),
+            artistItems,
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -141,7 +141,7 @@ class FetchArtistItemsUseCaseTest {
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
 
-        val expectedItemList = ItemList.ArtistAlbums(mappings = listOf(mapping1, mapping2))
+        val expectedItemList = ItemList.ArtistAlbums(providerMappings = listOf(mapping1, mapping2))
         assertEquals(
             ArtistItems(
                 items = mapping1Albums + mapping2Albums,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/FetchArtistItemsUseCaseTest.kt
@@ -141,12 +141,7 @@ class FetchArtistItemsUseCaseTest {
         val useCase = FetchArtistItemsUseCase(mediaItemRepository)
         val artistItems = useCase.run(artist) { ItemList.ArtistAlbums(it) }
 
-        val expectedItemList = ItemList.ArtistAlbums(
-            mappings = listOf(mapping1, mapping2).map {
-                Pair(it.providerInstance, it.itemId)
-            },
-            providerDomain = providerDomain,
-        )
+        val expectedItemList = ItemList.ArtistAlbums(mappings = listOf(mapping1, mapping2))
         assertEquals(
             ArtistItems(
                 items = mapping1Albums + mapping2Albums,

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/MediaItemDataMediatorTest.kt
@@ -2,16 +2,13 @@ package io.music_assistant.client.data.model.client.items
 
 import io.music_assistant.client.api.Request
 import io.music_assistant.client.data.model.client.AppMediaItemFixtures
+import io.music_assistant.client.data.model.client.items.support.StubMediaItemRepository
 import io.music_assistant.client.data.repository.MediaItemChange
-import io.music_assistant.client.data.repository.MediaItemRepository
-import io.music_assistant.client.data.repository.SearchResultData
 import io.music_assistant.client.ui.compose.common.DataState
 import io.music_assistant.client.ui.compose.common.StaleReason
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -146,40 +143,5 @@ class MediaItemDataMediatorTest {
 
         mediaItemRepository.fireChange(MediaItemChange.Deleted(item2))
         assertEquals(DataState.Data(remainingItems), mediator.asFlow().value)
-    }
-}
-
-private class StubMediaItemRepository : MediaItemRepository {
-    private val itemsResults = mutableMapOf<Request, Result<List<AppMediaItem>>>()
-
-    override suspend fun fetchMediaItems(request: Request): Result<List<AppMediaItem>> {
-        return itemsResults[request]!!
-    }
-
-    private val _itemChanges = MutableSharedFlow<MediaItemChange>()
-    override val itemChanges: SharedFlow<MediaItemChange> = _itemChanges
-
-    override suspend fun search(request: Request): Result<SearchResultData> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun fetchMediaItem(request: Request): Result<AppMediaItem?> {
-        TODO("Not yet implemented")
-    }
-
-    override fun supportsRecommendationRowItems(): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun publishLocalChange(change: MediaItemChange) {
-        TODO("Not yet implemented")
-    }
-
-    fun setItemsResult(request: Request, result: Result<List<AppMediaItem>>) {
-        itemsResults[request] = result
-    }
-
-    suspend fun fireChange(change: MediaItemChange) {
-        _itemChanges.emit(change)
     }
 }

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/support/StubMediaItemRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/support/StubMediaItemRepository.kt
@@ -1,0 +1,50 @@
+package io.music_assistant.client.data.model.client.items.support
+
+import io.music_assistant.client.api.Request
+import io.music_assistant.client.data.model.client.items.AppMediaItem
+import io.music_assistant.client.data.repository.MediaItemChange
+import io.music_assistant.client.data.repository.MediaItemRepository
+import io.music_assistant.client.data.repository.SearchResultData
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.serialization.json.JsonObject
+import kotlin.collections.set
+
+class StubMediaItemRepository : MediaItemRepository {
+    private val itemsResults = mutableMapOf<Pair<String, JsonObject?>, Result<List<AppMediaItem>>>()
+
+    override suspend fun fetchMediaItems(request: Request): Result<List<AppMediaItem>> {
+        return itemsResults[request.key()] ?: throw IllegalStateException("No stub for: $request")
+    }
+
+    private val _itemChanges = MutableSharedFlow<MediaItemChange>()
+    override val itemChanges: SharedFlow<MediaItemChange> = _itemChanges
+
+    override suspend fun search(request: Request): Result<SearchResultData> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMediaItem(request: Request): Result<AppMediaItem?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun supportsRecommendationRowItems(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun publishLocalChange(change: MediaItemChange) {
+        TODO("Not yet implemented")
+    }
+
+    fun setItemsResult(request: Request, result: Result<List<AppMediaItem>>) {
+        itemsResults[request.key()] = result
+    }
+
+    suspend fun fireChange(change: MediaItemChange) {
+        _itemChanges.emit(change)
+    }
+
+    fun Request.key(): Pair<String, JsonObject?> {
+        return Pair(this.command, this.args)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/support/StubMediaItemRepository.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/model/client/items/support/StubMediaItemRepository.kt
@@ -14,7 +14,7 @@ class StubMediaItemRepository : MediaItemRepository {
     private val itemsResults = mutableMapOf<Pair<String, JsonObject?>, Result<List<AppMediaItem>>>()
 
     override suspend fun fetchMediaItems(request: Request): Result<List<AppMediaItem>> {
-        return itemsResults[request.key()] ?: throw IllegalStateException("No stub for: $request")
+        return itemsResults[request.key()] ?: error("No stub for: $request")
     }
 
     private val _itemChanges = MutableSharedFlow<MediaItemChange>()


### PR DESCRIPTION
Work towards #801

This tidies up artist pages where an artist has multiple mappings across a single provider (like when they have collaboration albums for example).

Last thing to follow-up with is showing provider names instead of the raw domain.

## Is there anything about the code changes here that should be highlighted?

The main change to get this working was to expand the `ItemList` concept so it can support multiple mappings allowing to easily list items from across them. That

## Before submitting this PR, make sure you have:
- [x] Given this PR a readable name that can be used in the app's changelog
- [x] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

