### PR TITLE
Fix some crashes in iOS when sending remote commands

### DIFF
--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/player/MediaPlayerController.ios.kt
@@ -4,6 +4,8 @@ package io.music_assistant.client.player
 
 import co.touchlab.kermit.Logger
 import io.music_assistant.client.player.sendspin.model.AudioCodec
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 
 /**
  * MediaPlayerController - iOS implementation for Sendspin
@@ -15,8 +17,13 @@ import io.music_assistant.client.player.sendspin.model.AudioCodec
 actual class MediaPlayerController actual constructor(platformContext: PlatformContext) {
     private val log = Logger.withTag("MediaPlayerController")
 
+    private val remoteCommandLock = SynchronizedObject()
+    private var remoteCommandHandler: ((String) -> Unit)? = null
+
     // Callback for remote commands from Control Center
-    actual var onRemoteCommand: ((String) -> Unit)? = null
+    actual var onRemoteCommand: ((String) -> Unit)?
+        get() = synchronized(remoteCommandLock) { remoteCommandHandler }
+        set(value) { synchronized(remoteCommandLock) { remoteCommandHandler = value } }
 
     // Sendspin streaming methods
     actual fun prepareStream(

--- a/iosApp/NativeAudioController.swift
+++ b/iosApp/NativeAudioController.swift
@@ -91,7 +91,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             if isPlaying {
                 pausedByInterruption = true
                 logInfo("Pausing server playback due to interruption")
-                remoteCommandHandler?.onCommand(command: "pause", source: "interruption")
+                remoteCommandHandler.withSnapshot { $0?.onCommand(command: "pause", source: "interruption") }
             }
         case .ended:
             guard pausedByInterruption else { break }
@@ -103,7 +103,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
             // audio device exclusively.
             if !AVAudioSession.sharedInstance().secondaryAudioShouldBeSilencedHint {
                 logInfo("Resuming server playback after interruption")
-                remoteCommandHandler?.onCommand(command: "play", source: "interruption")
+                remoteCommandHandler.withSnapshot { $0?.onCommand(command: "play", source: "interruption") }
             } else {
                 logInfo("Another app holds audio — staying paused")
             }
@@ -144,7 +144,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
         bufferLock.lock()
         pcmBuffer.removeAll()
         bufferLock.unlock()
-        remoteCommandHandler?.onCommand(command: "pause", source: "route_loss")
+        remoteCommandHandler.withSnapshot { $0?.onCommand(command: "pause", source: "route_loss") }
     }
 
     // MARK: - PlatformAudioPlayer Protocol
@@ -430,7 +430,7 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
 
     // MARK: - Now Playing (Control Center / Lock Screen)
 
-    private var remoteCommandHandler: RemoteCommandHandler?
+    private let remoteCommandHandler = RemoteCommandHandlerStore<RemoteCommandHandler?>(nil)
 
     func setLongFormSeekIntervals(backSeconds: Int64, forwardSeconds: Int64) {
         NowPlayingCoordinator.shared.setLongFormSeekIntervals(
@@ -440,11 +440,11 @@ class NativeAudioController: NSObject, PlatformAudioPlayer {
     }
 
     func setRemoteCommandHandler(handler: RemoteCommandHandler?) {
-        self.remoteCommandHandler = handler
+        remoteCommandHandler.replace(handler)
 
         NowPlayingCoordinator.shared.setCommandHandler { [weak self] command in
             self?.logInfo("Remote command: \(command)")
-            self?.remoteCommandHandler?.onCommand(command: command, source: "remote")
+            self?.remoteCommandHandler.withSnapshot { $0?.onCommand(command: command, source: "remote") }
         }
     }
 }

--- a/iosApp/NowPlayingCoordinator.swift
+++ b/iosApp/NowPlayingCoordinator.swift
@@ -54,7 +54,7 @@ final class NowPlayingCoordinator {
         return "Info center assign: \(info.count) keys title=\(title) rate=\(rate) elapsed=\(elapsed)"
     }
 
-    private var commandHandler: CommandHandler?
+    private let commandHandler = RemoteCommandHandlerStore<CommandHandler?>(nil)
 
     // MARK: - Channel subscriptions
 
@@ -398,7 +398,7 @@ final class NowPlayingCoordinator {
     /// Sets the handler for remote commands
     /// We now support dynamic handler updates without re-registering commands
     func setCommandHandler(_ handler: @escaping CommandHandler) {
-        self.commandHandler = handler
+        commandHandler.replace(handler)
         logDebug("Command handler updated")
     }
 
@@ -408,6 +408,8 @@ final class NowPlayingCoordinator {
     func dispatchCarCommand(_ command: String) {
         dispatchPrecondition(condition: .onQueue(.main))
         let resolvedCommand = resolveRemoteCommand(command)
+        var commandHandler: CommandHandler?
+        self.commandHandler.withSnapshot { commandHandler = $0 }
         guard let commandHandler else {
             // Narrow window (the handler is wired during player init, before
             // any CarPlay button can become enabled), but a silently vanishing
@@ -433,7 +435,7 @@ final class NowPlayingCoordinator {
                 guard let self = self else { return .commandFailed }
                 let resolvedCommand = self.resolveRemoteCommand(cmd)
                 self.logDebug("Remote command received: \(resolvedCommand)")
-                self.commandHandler?(resolvedCommand)
+                self.commandHandler.withSnapshot { $0?(resolvedCommand) }
                 return .success
             }
         }
@@ -461,7 +463,7 @@ final class NowPlayingCoordinator {
             // lock-screen thumb can correct backward when the KMP anchor lands.
             let seekPosition = positionEvent.positionTime.rounded(.down)
             self?.logInfo("Remote seek command received: \(seekPosition)")
-            self?.commandHandler?("seek:\(seekPosition)")
+            self?.commandHandler.withSnapshot { $0?("seek:\(seekPosition)") }
             return .success
         }
     }

--- a/iosApp/RemoteCommandHandlerStore.swift
+++ b/iosApp/RemoteCommandHandlerStore.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class RemoteCommandHandlerStore<Value> {
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func replace(_ value: Value) {
+        lock.lock()
+        let oldValue = self.value
+        self.value = value
+        withExtendedLifetime(oldValue) {
+            lock.unlock()
+        }
+    }
+
+    func withSnapshot(_ body: (Value) -> Void) {
+        lock.lock()
+        let snapshot = value
+        lock.unlock()
+        body(snapshot)
+    }
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		C29F123E61DAA17B671EC955 /* NowPlayingInfoStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */; };
 		C29F123E61DAA17B671EC956 /* PCMChunker.swift in iosAppTests Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1992F18C88B00185678 /* PCMChunker.swift */; };
+		E8RCH0012F1A000000000001 /* RemoteCommandHandlerStore.swift in iosApp Sources */ = {isa = PBXBuildFile; fileRef = E8RCH0002F1A000000000002 /* RemoteCommandHandlerStore.swift */; };
+		E8RCH0012F1A000000000003 /* RemoteCommandHandlerStore.swift in iosAppTests Sources */ = {isa = PBXBuildFile; fileRef = E8RCH0002F1A000000000002 /* RemoteCommandHandlerStore.swift */; };
+		E8RCH0012F1A000000000004 /* RemoteCommandHandlerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8RCH0002F1A000000000005 /* RemoteCommandHandlerStoreTests.swift */; };
 		C29F123E61DAA17B671EC958 /* PCMChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */; };
 		C29F123E61DAA17B671EC957 /* PCMChunker.swift in iosApp Sources */ = {isa = PBXBuildFile; fileRef = C8FCC1992F18C88B00185678 /* PCMChunker.swift */; };
 		C85119262F18C7A900185678 /* Copus in Frameworks */ = {isa = PBXBuildFile; productRef = C85119252F18C7A900185678 /* Copus */; };
@@ -63,6 +66,8 @@
 		E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoStore.swift; sourceTree = "<group>"; };
 		C8FCC1992F18C88B00185678 /* PCMChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunker.swift; sourceTree = "<group>"; };
 		C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCMChunkerTests.swift; sourceTree = "<group>"; };
+		E8RCH0002F1A000000000002 /* RemoteCommandHandlerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCommandHandlerStore.swift; sourceTree = "<group>"; };
+		E8RCH0002F1A000000000005 /* RemoteCommandHandlerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCommandHandlerStoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +115,7 @@
 				2FE624765BDE4DC4138CA710 /* NowPlayingInfoStoreTests.swift */,
 				C8FCC19A2F18C88B00185678 /* PCMChunkerTests.swift */,
 				C8CP00072F1A000000000005 /* CarPlayNavigationCoordinatorTests.swift */,
+				E8RCH0002F1A000000000005 /* RemoteCommandHandlerStoreTests.swift */,
 			);
 			path = iosAppTests;
 			sourceTree = "<group>";
@@ -128,6 +134,7 @@
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
 				E184B96B79725950AACD5BE7 /* NowPlayingInfoStore.swift */,
 				C8FCC1992F18C88B00185678 /* PCMChunker.swift */,
+				E8RCH0002F1A000000000002 /* RemoteCommandHandlerStore.swift */,
 				6697875A889242950A65544F /* iosAppTests */,
 			);
 			sourceTree = "<group>";
@@ -319,6 +326,8 @@
 				C8CP00052F1A000000000005 /* CarPlayNavigationCoordinatorTests.swift in Sources */,
 				C29F123E61DAA17B671EC956 /* PCMChunker.swift in iosAppTests Sources */,
 				D8CP1002F1A000000000002 /* CarPlayNavigationCoordinator.swift in iosAppTests Sources */,
+				E8RCH0012F1A000000000003 /* RemoteCommandHandlerStore.swift in iosAppTests Sources */,
+				E8RCH0012F1A000000000004 /* RemoteCommandHandlerStoreTests.swift in Sources */,
 				6CF3E16270B477C8D3CDB192 /* NowPlayingInfoStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -333,6 +342,7 @@
 				D8CP1001F1A000000000001 /* CarPlayNavigationCoordinator.swift in Sources */,
 				C8CP00042F1A000000000004 /* CarPlayInterfaceControllerNavigationDriver.swift in Sources */,
 				C8FCC1952F17E001005E8312 /* NativeAudioController.swift in Sources */,
+				E8RCH0012F1A000000000001 /* RemoteCommandHandlerStore.swift in iosApp Sources */,
 				C29F123E61DAA17B671EC957 /* PCMChunker.swift in iosApp Sources */,
 				C8OA00022F1B000000000002 /* OAuthWebSession.swift in Sources */,
 				C8OA00022F1B000000000004 /* LocalNetworkProbe.swift in Sources */,

--- a/iosApp/iosAppTests/RemoteCommandHandlerStoreTests.swift
+++ b/iosApp/iosAppTests/RemoteCommandHandlerStoreTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+
+private final class LockedFlag {
+    private let lock = NSLock()
+    private var storage = false
+
+    func set(_ value: Bool) {
+        lock.lock()
+        storage = value
+        lock.unlock()
+    }
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
+private final class ReentrantOnDeinit {
+    private let beginReentry: DispatchSemaphore
+    private let completion: DispatchSemaphore
+    private let completedBeforeReturn: LockedFlag
+
+    init(
+        beginReentry: DispatchSemaphore,
+        completion: DispatchSemaphore,
+        completedBeforeReturn: LockedFlag
+    ) {
+        self.beginReentry = beginReentry
+        self.completion = completion
+        self.completedBeforeReturn = completedBeforeReturn
+    }
+
+    deinit {
+        beginReentry.signal()
+        completedBeforeReturn.set(
+            completion.wait(timeout: .now() + 5) == .success
+        )
+    }
+}
+
+private final class SnapshotValue {
+    let id: String
+
+    init(id: String) {
+        self.id = id
+    }
+}
+
+final class RemoteCommandHandlerStoreTests: XCTestCase {
+    func testReplacementAndInvocationUseCurrentSnapshot() {
+        let store = RemoteCommandHandlerStore<(() -> Void)?>(nil)
+        var calls: [String] = []
+
+        store.replace { calls.append("first") }
+        store.withSnapshot { $0?() }
+        store.replace { calls.append("second") }
+        store.withSnapshot { $0?() }
+
+        XCTAssertEqual(calls, ["first", "second"])
+    }
+
+    func testReplacementFromHandlerCanReenterStore() {
+        let store = RemoteCommandHandlerStore<(() -> Void)?>(nil)
+        var calls: [String] = []
+
+        store.replace {
+            calls.append("first")
+            store.replace { calls.append("second") }
+        }
+
+        store.withSnapshot { $0?() }
+        store.withSnapshot { $0?() }
+
+        XCTAssertEqual(calls, ["first", "second"])
+    }
+
+    func testReplacementDoesNotDestroyOldValueWhileLockIsHeld() {
+        let workerReady = DispatchSemaphore(value: 0)
+        let beginReentry = DispatchSemaphore(value: 0)
+        let completion = DispatchSemaphore(value: 0)
+        let workerFinished = expectation(description: "Reentry worker finished")
+        let completedBeforeReturn = LockedFlag()
+        let store = RemoteCommandHandlerStore<ReentrantOnDeinit?>(nil)
+        let queue = DispatchQueue(label: "RemoteCommandHandlerStoreTests.deinit-reentry")
+
+        queue.async {
+            workerReady.signal()
+            if beginReentry.wait(timeout: .now() + 15) == .success {
+                store.withSnapshot { _ in }
+                completion.signal()
+            }
+            workerFinished.fulfill()
+        }
+        guard workerReady.wait(timeout: .now() + 5) == .success else {
+            beginReentry.signal()
+            wait(for: [workerFinished], timeout: 10)
+            XCTFail("Reentry worker did not start")
+            return
+        }
+
+        store.replace(
+            ReentrantOnDeinit(
+                beginReentry: beginReentry,
+                completion: completion,
+                completedBeforeReturn: completedBeforeReturn
+            )
+        )
+        store.replace(nil)
+
+        XCTAssertTrue(completedBeforeReturn.value, "Old value was destroyed before the store unlocked")
+        wait(for: [workerFinished], timeout: 10)
+    }
+
+    func testReplacementDuringSnapshotLeavesInFlightSnapshotUntouched() {
+        let snapshotStarted = DispatchSemaphore(value: 0)
+        let releaseSnapshot = DispatchSemaphore(value: 0)
+        let snapshotFinished = DispatchSemaphore(value: 0)
+        let store = RemoteCommandHandlerStore(SnapshotValue(id: "first"))
+
+        DispatchQueue.global().async {
+            store.withSnapshot { snapshot in
+                XCTAssertEqual(snapshot.id, "first")
+                snapshotStarted.signal()
+                XCTAssertEqual(releaseSnapshot.wait(timeout: .now() + 1), .success)
+                XCTAssertEqual(snapshot.id, "first")
+            }
+            snapshotFinished.signal()
+        }
+
+        XCTAssertEqual(snapshotStarted.wait(timeout: .now() + 1), .success)
+        store.replace(SnapshotValue(id: "second"))
+        releaseSnapshot.signal()
+        XCTAssertEqual(snapshotFinished.wait(timeout: .now() + 1), .success)
+
+        var currentID: String?
+        store.withSnapshot { currentID = $0.id }
+        XCTAssertEqual(currentID, "second")
+    }
+
+    func testConcurrentReplacementAndSnapshotAccess() {
+        let callsLock = NSLock()
+        var callCount = 0
+        let store = RemoteCommandHandlerStore<(() -> Void)?>( {
+            callsLock.lock()
+            callCount += 1
+            callsLock.unlock()
+        })
+
+        DispatchQueue.concurrentPerform(iterations: 1_000) { index in
+            if index.isMultiple(of: 2) {
+                store.replace {
+                    callsLock.lock()
+                    callCount += 1
+                    callsLock.unlock()
+                }
+            } else {
+                store.withSnapshot { $0?() }
+            }
+        }
+
+        store.withSnapshot { $0?() }
+        XCTAssertEqual(callCount, 501)
+    }
+}


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

Synchronize remote-command handler replacement and reads across the Swift and Kotlin iOS layers. Swift callers retain a handler snapshot under lock, then invoke it after unlocking; replaced handlers are also released outside the lock to allow safe reentrancy during cleanup. Add regression tests for concurrent replacement, in-flight snapshots, and callback/deinit reentrancy.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

