### PR TITLE
Support dynamic text resizing in iOS

### DIFF
--- a/composeApp/src/androidMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.android.kt
+++ b/composeApp/src/androidMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.android.kt
@@ -1,0 +1,8 @@
+package io.music_assistant.client.ui.compose
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun ProvideDynamicTypeFontScale(content: @Composable () -> Unit) {
+    content()
+}

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/App.kt
@@ -83,21 +83,23 @@ fun App() {
         ThemeSetting.FollowSystem -> isSystemInDarkTheme()
     }
     SystemAppearance(isDarkTheme = darkTheme, followsSystem = followsSystem)
-    AppTheme(darkTheme = darkTheme) {
-        // Paint a themed background behind everything so the (light) platform window background
-        // never bleeds through the transparent system bars in edge-to-edge — otherwise any region
-        // Compose doesn't cover (e.g. the nav-bar strip beside the rail) shows as an off-theme white.
-        Box(
-            Modifier.fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .dismissKeyboardOnTap(),
-        ) {
-            ProvideClickActionPrefs {
-                TopLevelNavRoot()
+    ProvideDynamicTypeFontScale {
+        AppTheme(darkTheme = darkTheme) {
+            // Paint a themed background behind everything so the (light) platform window background
+            // never bleeds through the transparent system bars in edge-to-edge — otherwise any region
+            // Compose doesn't cover (e.g. the nav-bar strip beside the rail) shows as an off-theme white.
+            Box(
+                Modifier.fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .dismissKeyboardOnTap(),
+            ) {
+                ProvideClickActionPrefs {
+                    TopLevelNavRoot()
+                }
+                StatusBarScrim(darkTheme, Modifier.align(Alignment.TopCenter))
+                BackgroundRestrictionDialog()
+                SchemaVersionWarningDialog()
             }
-            StatusBarScrim(darkTheme, Modifier.align(Alignment.TopCenter))
-            BackgroundRestrictionDialog()
-            SchemaVersionWarningDialog()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.kt
@@ -1,0 +1,7 @@
+package io.music_assistant.client.ui.compose
+
+import androidx.compose.runtime.Composable
+
+/** Provides the platform's preferred text size to Compose; iOS updates it on Dynamic Type changes. */
+@Composable
+expect fun ProvideDynamicTypeFontScale(content: @Composable () -> Unit)

--- a/composeApp/src/iosMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.ios.kt
+++ b/composeApp/src/iosMain/kotlin/io/music_assistant/client/ui/compose/DynamicTypeFontScale.ios.kt
@@ -1,0 +1,76 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package io.music_assistant.client.ui.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplication
+import platform.UIKit.UIContentSizeCategoryAccessibilityExtraExtraExtraLarge
+import platform.UIKit.UIContentSizeCategoryAccessibilityExtraExtraLarge
+import platform.UIKit.UIContentSizeCategoryAccessibilityExtraLarge
+import platform.UIKit.UIContentSizeCategoryAccessibilityLarge
+import platform.UIKit.UIContentSizeCategoryAccessibilityMedium
+import platform.UIKit.UIContentSizeCategoryDidChangeNotification
+import platform.UIKit.UIContentSizeCategoryExtraExtraExtraLarge
+import platform.UIKit.UIContentSizeCategoryExtraExtraLarge
+import platform.UIKit.UIContentSizeCategoryExtraLarge
+import platform.UIKit.UIContentSizeCategoryExtraSmall
+import platform.UIKit.UIContentSizeCategoryLarge
+import platform.UIKit.UIContentSizeCategoryMedium
+import platform.UIKit.UIContentSizeCategorySmall
+
+@Composable
+actual fun ProvideDynamicTypeFontScale(content: @Composable () -> Unit) {
+    var fontScale by remember { mutableStateOf(currentFontScale()) }
+
+    DisposableEffect(Unit) {
+        val observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIContentSizeCategoryDidChangeNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+        ) { _ ->
+            fontScale = currentFontScale()
+        }
+        onDispose {
+            NSNotificationCenter.defaultCenter.removeObserver(observer)
+        }
+    }
+
+    val density = LocalDensity.current
+    CompositionLocalProvider(
+        LocalDensity provides Density(
+            density = density.density,
+            fontScale = fontScale,
+        ),
+        content = content,
+    )
+}
+
+private fun currentFontScale(): Float = uiContentSizeCategoryToFontScaleMap[
+    UIApplication.sharedApplication.preferredContentSizeCategory,
+] ?: 1f
+
+// Temporary workaround for Compose's missing live iOS font-scale propagation; remove when upstream fixes it.
+private val uiContentSizeCategoryToFontScaleMap = mapOf(
+    UIContentSizeCategoryExtraSmall to 0.8f,
+    UIContentSizeCategorySmall to 0.85f,
+    UIContentSizeCategoryMedium to 0.9f,
+    UIContentSizeCategoryLarge to 1f,
+    UIContentSizeCategoryExtraLarge to 1.1f,
+    UIContentSizeCategoryExtraExtraLarge to 1.2f,
+    UIContentSizeCategoryExtraExtraExtraLarge to 1.3f,
+    UIContentSizeCategoryAccessibilityMedium to 1.4f,
+    UIContentSizeCategoryAccessibilityLarge to 1.5f,
+    UIContentSizeCategoryAccessibilityExtraLarge to 1.6f,
+    UIContentSizeCategoryAccessibilityExtraExtraLarge to 1.7f,
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge to 1.8f,
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidx-lifecycle = "2.11.0"
 androidx-material = "1.14.0"
 androidx-test-junit = "1.3.0"
 
-compose-multiplatform = "1.11.1"
+compose-multiplatform = "1.12.0"
 junit = "4.13.2"
 kermit = "2.1.0"
 kotlin = "2.4.10"
@@ -99,7 +99,7 @@ coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.r
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 
 material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "materialIcons" }
-material = { module = "org.jetbrains.compose.material3:material3", version = "1.11.0-alpha07" }
+material = { module = "org.jetbrains.compose.material3:material3", version = "1.12.0-alpha03" }
 material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIcons" }
 icons-fontawesome = { module = "br.com.devsrsouza.compose.icons:font-awesome", version.ref = "fontIconsVersion" }
 icons-tabler = { module = "br.com.devsrsouza.compose.icons:tabler-icons", version.ref = "fontIconsVersion" }


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

While working on #1001 I noticed that we didn't respond to the default text size changing in iOS dynamically. The user would have to completely close and re-open the app. We now scale up and down "live" (it's iOS so you're switching back and forth between the Settings app and MA).

## Are there any additional changes not related to the issue above?

Also bump our compose-multiplatform version because 1.11.1 had a bug that prevented dynamic text resizing from working, which was fixed in 1.12.0.

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

