### PR TITLE
Limit CarPlay radio controls to play and pause

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
+++ b/composeApp/src/commonMain/kotlin/io/music_assistant/client/data/NowPlayingChannels.kt
@@ -30,6 +30,7 @@ data class NowPlayingTrack(
     val isLongFormContent: Boolean,
     // Pref-gated: remote next/previous will chapter-jump for this content.
     val hasChapterNavigation: Boolean = false,
+    val isRadio: Boolean = false,
 )
 
 /**
@@ -177,15 +178,17 @@ internal fun buildNowPlayingModes(playerData: PlayerData?): NowPlayingModes? {
         togglesEnabled = nowPlayingTogglesEnabled(
             isDynamicPlaylist = queueInfo.isDynamicPlaylist,
             isLongFormContent = track.isLongFormSpokenContent,
+            isRadio = track.mediaType == MediaType.RADIO,
         ),
     )
 }
 
-/** The same availability gates used by the in-app controls and Android media UI. */
+/** Availability gates for the system shuffle/repeat controls. */
 internal fun nowPlayingTogglesEnabled(
     isDynamicPlaylist: Boolean,
     isLongFormContent: Boolean,
-): Boolean = !isDynamicPlaylist && !isLongFormContent
+    isRadio: Boolean = false,
+): Boolean = !isDynamicPlaylist && !isLongFormContent && !isRadio
 
 private fun PlayableItem.toNowPlayingTrack(): NowPlayingTrack = NowPlayingTrack(
     mediaItemId = itemId,
@@ -195,4 +198,5 @@ private fun PlayableItem.toNowPlayingTrack(): NowPlayingTrack = NowPlayingTrack(
     artworkUrl = image(ImageType.THUMB)?.url,
     duration = duration,
     isLongFormContent = isLongFormSpokenContent,
+    isRadio = mediaType == MediaType.RADIO,
 )

--- a/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/music_assistant/client/data/NowPlayingChannelsTest.kt
@@ -145,6 +145,25 @@ class NowPlayingRadioStreamMetadataTest {
         )!!
 
     @Test
+    fun radioClassificationSurvivesStreamMetadataChanges() {
+        assertTrue(radioTrack(null).isRadio)
+        assertTrue(radioTrack(streamMedia()).isRadio)
+        assertTrue(radioTrack(streamMedia(title = "Another song")).isRadio)
+        assertFalse(radioTrack(streamMedia()).isLongFormContent)
+        for (item in listOf(testTrack(), testAudiobook(), testPodcastEpisode())) {
+            assertFalse(buildNowPlayingTrack(playerData(item, queueInfo(queueId = "queue-1")))!!.isRadio)
+        }
+    }
+
+    @Test
+    fun radioDisablesQueueModeControls() {
+        for (dynamic in listOf(false, true)) {
+            val data = playerData(testRadio(), queueInfo(queueId = "queue-1", isDynamicPlaylist = dynamic))
+            assertFalse(buildNowPlayingModes(data)!!.togglesEnabled)
+        }
+    }
+
+    @Test
     fun overlaysDynamicStreamMetadataKeepingStationIdentity() {
         val built = radioTrack(streamMedia(imageUrl = "https://example.invalid/song.jpg"))
         assertEquals("Song", built.title)

--- a/iosApp/NowPlayingCoordinator.swift
+++ b/iosApp/NowPlayingCoordinator.swift
@@ -108,6 +108,7 @@ final class NowPlayingCoordinator {
     // MARK: - Command profile / session state
 
     private var currentIsLongFormContent: Bool?
+    private var currentIsRadio: Bool?
     private var currentLongFormSeekBackSeconds: Int64?
     private var currentLongFormSeekForwardSeconds: Int64?
     private var currentAudioSessionMode: AVAudioSession.Mode?
@@ -149,7 +150,7 @@ final class NowPlayingCoordinator {
 
     /// Applies track metadata: hands the track key group to the store, runs
     /// the artwork load, and derives session mode + command profile from the
-    /// long-form flag. A nil track means "nothing to present" — the store
+    /// content flags. A nil track means "nothing to present" — the store
     /// empties and profile/session return to defaults, while remote-command
     /// targets stay installed.
     private func handleTrack(_ track: NowPlayingTrack?) {
@@ -162,7 +163,7 @@ final class NowPlayingCoordinator {
         currentTrackId = track.mediaItemId
 
         configureAudioSession(mode: track.isLongFormContent ? .spokenAudio : .default)
-        updateRemoteCommandMode(isLongFormContent: track.isLongFormContent)
+        updateRemoteCommandMode(isLongFormContent: track.isLongFormContent, isRadio: track.isRadio)
 
         // No artwork: present immediately. Rebuild even for a same-identity
         // track — this write carries the complete presentation state, and a
@@ -456,7 +457,7 @@ final class NowPlayingCoordinator {
         addTarget(commandCenter.changeShuffleModeCommand, cmd: "toggle_shuffle", enabled: false)
         addTarget(commandCenter.changeRepeatModeCommand, cmd: "toggle_repeat", enabled: false)
 
-        commandCenter.changePlaybackPositionCommand.isEnabled = true
+        // Enablement belongs to the transport profile above.
         commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
             // Floor to the same whole-second target KMP freezes at; otherwise the
@@ -486,18 +487,20 @@ final class NowPlayingCoordinator {
         }
     }
 
-    /// Swaps the transport-command profile: music uses prev/next, long-form
-    /// content uses skip ±N. Never touches the shuffle/repeat commands —
-    /// those belong to the modes handler.
-    private func updateRemoteCommandMode(isLongFormContent: Bool) {
-        guard currentIsLongFormContent != isLongFormContent else { return }
+    /// Swaps the transport-command profile: radio uses play/pause only,
+    /// music uses prev/next, and long-form content uses skip ±N.
+    /// Shuffle/repeat commands belong to the modes handler.
+    private func updateRemoteCommandMode(isLongFormContent: Bool, isRadio: Bool = false) {
+        guard currentIsLongFormContent != isLongFormContent || currentIsRadio != isRadio else { return }
         currentIsLongFormContent = isLongFormContent
+        currentIsRadio = isRadio
 
         let commandCenter = MPRemoteCommandCenter.shared()
-        commandCenter.previousTrackCommand.isEnabled = !isLongFormContent
-        commandCenter.nextTrackCommand.isEnabled = !isLongFormContent
-        commandCenter.skipBackwardCommand.isEnabled = isLongFormContent
-        commandCenter.skipForwardCommand.isEnabled = isLongFormContent
+        commandCenter.previousTrackCommand.isEnabled = !isRadio && !isLongFormContent
+        commandCenter.nextTrackCommand.isEnabled = !isRadio && !isLongFormContent
+        commandCenter.skipBackwardCommand.isEnabled = !isRadio && isLongFormContent
+        commandCenter.skipForwardCommand.isEnabled = !isRadio && isLongFormContent
+        commandCenter.changePlaybackPositionCommand.isEnabled = !isRadio
     }
 
     func setLongFormSeekIntervals(backSeconds: Int64, forwardSeconds: Int64) {

--- a/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
+++ b/iosApp/iosApp/CarPlay/CarPlaySceneDelegate.swift
@@ -47,7 +47,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     //   - Track channel: profile flips swap which retained instances are
     //     installed. Music gets shuffle/repeat; long-form content with
     //     navigable chapters gets chapter prev/next (the transport row keeps
-    //     the ±N skips); other long-form content gets nothing.
+    //     the ±N skips); radio and other long-form content get nothing.
     //   - Modes channel: shuffle/repeat enablement only.
     // Selected state is never written here: CarPlay renders it from
     // MPRemoteCommandCenter's currentShuffleType/currentRepeatType, whose sole
@@ -270,11 +270,13 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         nowPlayingButtonsEnabled = nil
 
         trackSubscription = KmpHelper.shared.observeNowPlayingTrack { [weak self] track in
-            // Bottom bar shows chapter prev/next only when the long-form
-            // content has navigable chapters, otherwise nothing. A nil track
-            // keeps the music profile; the modes channel's nil disables it.
+            // Radio has no auxiliary controls. Long-form shows chapter
+            // prev/next only with navigable chapters. A nil track keeps the
+            // music profile; the modes channel's nil disables it.
             let profile: NowPlayingButtonProfile
-            if track?.isLongFormContent != true {
+            if track?.isRadio == true {
+                profile = .empty
+            } else if track?.isLongFormContent != true {
                 profile = .music
             } else if track?.hasChapterNavigation == true {
                 profile = .chapters


### PR DESCRIPTION
## Is there anything about the code changes here that should be highlighted?

I was listening to an internet radio station in the car and noticed it had prev/next/shuffle/repeat all enabled as controls, none of which were actually useful. This detects 'radio mode' and disables everythign except play/pause.

## Are there any additional changes not related to the issue above?

## Before submitting this PR, make sure you have:
- [X] Given this PR a readable name that can be used in the app's changelog
- [X] Made sure checks pass by running `./gradlew detektAll testAndroidHostTest :androidApp:testDebug`

